### PR TITLE
fix for dvb cards with more than one tuner

### DIFF
--- a/packages/multimedia/hts-tvheadend/udev.d/76-tvheadend.rules
+++ b/packages/multimedia/hts-tvheadend/udev.d/76-tvheadend.rules
@@ -24,7 +24,7 @@ SUBSYSTEM!="dvb", GOTO="end"
 ENV{DVB_DEVICE_TYPE}!="frontend", GOTO="end"
 
 # Start TVHeadend if dvb frontend is starting
-ACTION=="add", RUN+="/usr/bin/tvheadend -C -s -f -u root -g root"
+ACTION=="add", RUN+="/etc/pm/sleep.d/50_tvheadend resume"
 ACTION=="remove", RUN+="/usr/bin/killall tvheadend"
 
 LABEL="end"


### PR DESCRIPTION
call "/etc/pm/sleep.d/50_tvheadend resume" instead "/usr/bin/tvheadend -C -s -f -u root -g root" (directly), because on a twin tuner card tvheadend is starting multiple times.
