### PR TITLE
add mkpg script's for git repository

### DIFF
--- a/tools/mkpkg/mkpkg_tvheadend
+++ b/tools/mkpkg/mkpkg_tvheadend
@@ -1,0 +1,60 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2011 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+MKPKG_CURRENTPATH=$(pwd)
+MKPKG_TMP="$MKPKG_CURRENTPATH/mkpkg-temp"
+
+mkdir -p $MKPKG_TMP
+cd $MKPKG_TMP
+
+echo "deleteing old revisions..."
+  ls $MKPKG_TMP | \
+  while read I; do
+    if [ -f "${I}" ] ; then
+      case "${I}" in
+        tvheadend.tar.bz2)  rm "${I}";;
+      esac
+    elif [ -d "${I}" ] ; then
+      case "${I}" in
+        tvheadend) rm -Rf "${I}";;
+      esac
+    fi
+  done
+
+echo "getting sources if needed (or update only)"
+  if [ ! -d tvheadend ]; then
+    git clone git://github.com/andoma/tvheadend.git tvheadend
+  fi
+
+echo "updateing revision..."
+  cd tvheadend
+    git pull
+  cd $MKPKG_TMP
+
+echo "getting version..."
+  cd tvheadend
+    REV=$(git rev-parse --short HEAD)
+  cd $MKPKG_TMP
+  
+echo "packing sources..."
+  tar cvjf tvheadend-$REV.tar.bz2 tvheadend
+
+cd $MKPKG_CURRENTPATH

--- a/tools/mkpkg/mkpkg_xbmc-pvr-git
+++ b/tools/mkpkg/mkpkg_xbmc-pvr-git
@@ -1,0 +1,115 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2011 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 675 Mass Ave, Cambridge, MA 02139, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+if [ -z "$VERSION" ] ; then
+  echo "Please specify the git version: ppa | master"
+  echo "(ppa recommed)"
+  echo "Example usage: VERSION=ppa mkpkg_xbmc-pvr-git"
+  exit 1
+fi
+
+MKPKG_CURRENTPATH=$(pwd)
+MKPKG_TMP="$MKPKG_CURRENTPATH/mkpkg-temp"
+
+mkdir -p $MKPKG_TMP
+cd $MKPKG_TMP
+
+echo "deleteing old revisions..."
+  ls $MKPKG_TMP | \
+  while read I; do
+    if [ -f "${I}" ] ; then
+      case "${I}" in
+        xbmc*.tar.bz2)  rm "${I}";;
+      esac
+    elif [ -d "${I}" ] ; then
+      case "${I}" in
+        xbmc-pvr.master) rm -Rf "${I}";;
+        xbmc-pvr.ppa) rm -Rf "${I}";;
+      esac
+    fi
+  done
+
+echo "getting sources if needed (or update only)"
+  if [ ! -d xbmc-pvr ]; then
+    git clone git://github.com/opdenkamp/xbmc.git xbmc-pvr
+  fi
+
+echo "updateing revision... $VERSION"
+  cd xbmc-pvr
+    git pull
+  cd $MKPKG_TMP
+  
+echo "create repo xbmc-pvr -> xbmc-pvr.$VERSION"
+  cp -R xbmc-pvr xbmc-pvr.$VERSION
+  
+if [ $VERSION != "master" ] ; then
+  cd xbmc-pvr.$VERSION
+    git checkout pvr-$VERSION
+  cd $MKPKG_TMP
+fi
+
+echo "getting version..."
+  cd xbmc-pvr.$VERSION
+    REV=$(git rev-parse --short HEAD)
+  cd $MKPKG_TMP
+  
+echo "cleaning sources..."
+  find xbmc-pvr.$VERSION -name .git -exec rm -rf {} ";"
+
+  rm -rf xbmc-pvr.$VERSION/project
+
+  for i in "Changelog" "Fake\ Episode\ Maker" \
+           "PackageMaker" "Translator" "XprPack" \
+           "HardwareConfigure" "osx" "UpdateThumbs.py" "XBMCTex"; do
+    rm -rf xbmc-pvr.$VERSION/tools/$i
+  done
+
+  for i in dll a lib so bat; do
+    find xbmc-pvr.$VERSION -name *.$i -exec rm -rf {} ";"
+  done
+  
+  # remove bundled libraries (including zlib and OSX), saves space and forces using external versions
+  for i in cximage-6.0/zlib libid3tag/zlib zlib
+  do
+    rm -rf xbmc-pvr.$VERSION/xbmc/lib/$i
+  done
+
+  # bundled win32 binaries
+  rm -r xbmc-pvr.$VERSION/xbmc/visualizations/XBMCProjectM/win32
+
+  # remove various headers 
+  rm xbmc-pvr.$VERSION/xbmc/filesystem/zlib.h
+  
+echo "move xbmc-pvr.$VERSION to move xbmc-pvr.$VERSION-$REV"
+mv xbmc-pvr.$VERSION xbmc-pvr.$VERSION-$REV
+  
+echo "split xbmc-pvr.$VERSION-$REV theme and make xbmc-pvr-$VERSION-$REV.tar.gz"
+      
+  tar cvjf xbmc-pvr-$VERSION-theme-Confluence-$REV.tar.bz2 -C xbmc-pvr.$VERSION-$REV/addons/ ./skin.confluence
+  rm -rf xbmc-pvr-$VERSION-$REV/addons/skin.confluence
+
+echo "packing sources..."
+  tar cvjf xbmc-pvr-$VERSION-$REV.tar.bz2 xbmc-pvr.$VERSION-$REV
+
+echo "CLEANUP"
+  rm -Rf xbmc-pvr.$VERSION-$REV
+  
+cd $MKPKG_CURRENTPATH


### PR DESCRIPTION
add mkpg script's for git repository from opdenkamp (ppa & master / xbmc-pvr) and tvheadend

And i make a new folder for it (mkpkg-temp), because its easyer to update the git Revisons (we do not must load > 200 mb)

the ./tools/mkpkg/mkpkg_xbmc-pvr-git script does have two flags (ppa & master) to get the pvr-ppa branch from opdenkamp or the master.
usage example: VERSION=ppa ./tools/mkpkg/mkpkg_xbmc-pvr-git
or
usage example: VERSION=master ./tools/mkpkg/mkpkg_xbmc-pvr-git
