### PR TITLE
add mkpg script's for git repository from opdenkamp (ppa & master / xbmc-pvr) and tvheadend 

### DIFF
--- a/.gitignore
+++ b/.gitignore
@@ -13,5 +13,8 @@ target/
 tools/mkpkg/*
 !tools/mkpkg/mkpkg_*
 
+# mkpkg temp
+mkpkg-temp
+
 # private working directory
 .work/

--- a/tools/mkpkg/mkpkg_tvheadend
+++ b/tools/mkpkg/mkpkg_tvheadend
@@ -24,20 +24,10 @@ MKPKG_TMP="$MKPKG_CURRENTPATH/mkpkg-temp"
 
 mkdir -p $MKPKG_TMP
 cd $MKPKG_TMP
+mkdir -p dest
 
 echo "deleteing old revisions..."
-  ls $MKPKG_TMP | \
-  while read I; do
-    if [ -f "${I}" ] ; then
-      case "${I}" in
-        tvheadend.tar.bz2)  rm "${I}";;
-      esac
-    elif [ -d "${I}" ] ; then
-      case "${I}" in
-        tvheadend) rm -Rf "${I}";;
-      esac
-    fi
-  done
+  rm -Rf dest/tvheadend*
 
 echo "getting sources if needed (or update only)"
   if [ ! -d tvheadend ]; then
@@ -53,8 +43,14 @@ echo "getting version..."
   cd tvheadend
     REV=$(git rev-parse --short HEAD)
   cd $MKPKG_TMP
+
+echo "create repo for packaging tvheadend -> tvheadend-$REV"
+  cp -R tvheadend tvheadend-$REV
   
 echo "packing sources..."
-  tar cvjf tvheadend-$REV.tar.bz2 tvheadend
+  tar cvjf dest/tvheadend-$REV.tar.bz2 --exclude ".git" --exclude ".gitignore" tvheadend-$REV
+
+echo "CLEANUP"
+  rm -Rf tvheadend-$REV
 
 cd $MKPKG_CURRENTPATH

--- a/tools/mkpkg/mkpkg_xbmc-pvr-git
+++ b/tools/mkpkg/mkpkg_xbmc-pvr-git
@@ -31,21 +31,10 @@ MKPKG_TMP="$MKPKG_CURRENTPATH/mkpkg-temp"
 
 mkdir -p $MKPKG_TMP
 cd $MKPKG_TMP
+mkdir -p dest
 
 echo "deleteing old revisions..."
-  ls $MKPKG_TMP | \
-  while read I; do
-    if [ -f "${I}" ] ; then
-      case "${I}" in
-        xbmc*.tar.bz2)  rm "${I}";;
-      esac
-    elif [ -d "${I}" ] ; then
-      case "${I}" in
-        xbmc-pvr.master) rm -Rf "${I}";;
-        xbmc-pvr.ppa) rm -Rf "${I}";;
-      esac
-    fi
-  done
+  rm -Rf dest/xbmc*$VERSION*
 
 echo "getting sources if needed (or update only)"
   if [ ! -d xbmc-pvr ]; then
@@ -98,18 +87,17 @@ echo "cleaning sources..."
   # remove various headers 
   rm xbmc-pvr.$VERSION/xbmc/filesystem/zlib.h
   
-echo "move xbmc-pvr.$VERSION to move xbmc-pvr.$VERSION-$REV"
-mv xbmc-pvr.$VERSION xbmc-pvr.$VERSION-$REV
   
 echo "split xbmc-pvr.$VERSION-$REV theme and make xbmc-pvr-$VERSION-$REV.tar.gz"
-      
-  tar cvjf xbmc-pvr-$VERSION-theme-Confluence-$REV.tar.bz2 -C xbmc-pvr.$VERSION-$REV/addons/ ./skin.confluence
-  rm -rf xbmc-pvr-$VERSION-$REV/addons/skin.confluence
+  mv xbmc-pvr.$VERSION/addons/skin.confluence xbmc-pvr-$VERSION-theme-Confluence-$REV
+  tar cvjf dest/xbmc-pvr-$VERSION-theme-Confluence-$REV.tar.bz2 xbmc-pvr-$VERSION-theme-Confluence-$REV
+  rm -rf xbmc-pvr-$VERSION-theme-Confluence-$REV
 
 echo "packing sources..."
-  tar cvjf xbmc-pvr-$VERSION-$REV.tar.bz2 xbmc-pvr.$VERSION-$REV
+  mv xbmc-pvr.$VERSION xbmc-pvr-$VERSION-$REV
+  tar cvjf dest/xbmc-pvr-$VERSION-$REV.tar.bz2 xbmc-pvr-$VERSION-$REV
 
 echo "CLEANUP"
-  rm -Rf xbmc-pvr.$VERSION-$REV
-  
+  rm -Rf xbmc-pvr-$VERSION-$REV
+
 cd $MKPKG_CURRENTPATH


### PR DESCRIPTION
make packages script's for getting tvheadend and pvr-ppa branch & master from opdenkamp.
script does create an folder "mkpkg-temp" (which is in .gitignore) for git temp stuff, because so ne do not need to download the sources over 200 MB (from XBMC) again and can pull the latest revisions.

Find the result packages in mkpkg-temp/dest.
Will work on the other mkpkg script's, because all can use the mkpkg-temp.

Cheers :)
