### PR TITLE
Fix for issue #8 in the issue tracker.

### DIFF
--- a/config/release/create_installstick
+++ b/config/release/create_installstick
@@ -56,14 +56,9 @@ echo "# Please read the instructions and use very carefully.. #"
 echo "#                                                       #"
 echo "#########################################################"
 
-# check MD5 sums
-  echo "checking MD5 sum..."
-  md5sum -c target/KERNEL.md5
-  MD5_ERROR="$?"
-  md5sum -c target/SYSTEM.md5
-  MD5_ERROR="$?"
-
-if [ "$MD5_ERROR" = "1" ]; then
+md5sumFailed()
+{
+  clear
   echo "#########################################################"
   echo "#                                                       #"
   echo "# OpenELEC.tv failed md5 check - Installation will quit #"
@@ -73,7 +68,19 @@ if [ "$MD5_ERROR" = "1" ]; then
   echo "#                                                       #"
   echo "#########################################################"
   exit 1
-fi
+}
+
+
+# check MD5 sums
+  echo "checking MD5 sum..."
+  md5sum -c target/KERNEL.md5
+  if [ "$?" = "1" ]; then
+	md5sumFailed
+  fi
+  md5sum -c target/SYSTEM.md5
+  if [ "$?" = "1" ]; then
+	md5sumFailed
+  fi
 
 # (TODO) umount anything
   umount "$PART"


### PR DESCRIPTION
The script ignored if the first md5sum check failed, both are now checked and the script will exit properly if
one of the check does not succeed.
