### PR TITLE
Adds three checks for tools needed by the installer

### DIFF
--- a/config/release/create_installstick
+++ b/config/release/create_installstick
@@ -56,6 +56,58 @@ echo "# Please read the instructions and use very carefully.. #"
 echo "#                                                       #"
 echo "#########################################################"
 
+# check for some required tools
+
+  # this is needed to create a bootloader
+  which syslinux > /dev/null
+  if [ "$?" = "1" ]; then
+	clear
+    echo "#########################################################"
+    echo "#                                                       #"
+    echo "# OpenELEC.tv missing tool - Installation will quit     #"
+    echo "#                                                       #"
+    echo "#      We can't find the required tool \"syslinux\"     #"
+    echo "#      on your system.                                  #"
+    echo "#      Please install it via your package manager.      #"
+    echo "#                                                       #"
+    echo "#########################################################"
+    exit 1
+  fi
+
+  # this is needed by syslinux
+  which mcopy > /dev/null
+    if [ "$?" = "1" ]; then
+	clear
+    echo "#########################################################"
+    echo "#                                                       #"
+    echo "# OpenELEC.tv missing tool - Installation will quit     #"
+    echo "#                                                       #"
+    echo "#      We can't find the required tool \"mcopy\"        #"
+    echo "#      on your system.                                  #"
+    echo "#      Please install it via your package manager.      #"
+    echo "#      NOTE: Some distributions call this package       #"
+    echo "#      \"mtools\".                                      #"
+    echo "#                                                       #"
+    echo "#########################################################"
+    exit 1
+  fi
+
+  # this is needed to partion the stick
+  which parted > /dev/null
+  if [ "$?" = "1" ]; then
+	clear
+    echo "#########################################################"
+    echo "#                                                       #"
+    echo "# OpenELEC.tv missing tool - Installation will quit     #"
+    echo "#                                                       #"
+    echo "#      We can't find the required tool \"parted\"       #"
+    echo "#      on your system.                                  #"
+    echo "#      Please install it via your package manager.      #"
+    echo "#                                                       #"
+    echo "#########################################################"
+    exit 1
+  fi
+
 # check MD5 sums
   echo "checking MD5 sum..."
   md5sum -c target/KERNEL.md5


### PR DESCRIPTION
syslinux, parted, and mcopy (which is needed by syslinux but has it's own package in debian)
This will fix this issue:
http://openelec.tv/forum/20-development-discussion/4643-0993-under-linux-creates-an-unbootable-usb-stick
