### PR TITLE
Do not start avahi when zeroconf in xbmc is explicit disabled

### DIFF
--- a/packages/network/avahi/init.d/53_avahi
+++ b/packages/network/avahi/init.d/53_avahi
@@ -22,11 +22,13 @@
 #
 # runlevels: openelec, textmode
 
-(
-  wait_for_network
+if ! grep -q "<zeroconf>false</zeroconf>" $HOME/.xbmc/userdata/guisettings.xml 2>/dev/null; then
+  (
+    wait_for_network
 
-  progress "Starting Avahi Daemon"
+    progress "Starting Avahi Daemon"
 
-    mkdir -p /var/run/avahi-daemon
-    avahi-daemon -D
-)&
+      mkdir -p /var/run/avahi-daemon
+      avahi-daemon -D
+  )&
+fi


### PR DESCRIPTION
if guisettings.xml does not exist, it will run avahi (without an error) and the default setting to zeroconf when guisettings.xml is first created is <zeroconf>true</zeroconf>
