### PR TITLE
xbmc-addon-xvdr: updated version to 0.9.5

### DIFF
--- a/packages/mediacenter/xbmc-addon-xvdr/meta
+++ b/packages/mediacenter/xbmc-addon-xvdr/meta
@@ -19,12 +19,12 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-xvdr"
-PKG_VERSION="eb05616"
+PKG_VERSION="0.9.5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE=""
-PKG_URL="http://dl.dropbox.com/u/240579/xbmc-addon-xvdr/xbmc-addon-xvdr-$PKG_VERSION.tar.gz"
+PKG_URL="http://github.com/downloads/pipelka/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS="zlib"
 PKG_BUILD_DEPENDS="toolchain zlib"
 PKG_PRIORITY="optional"


### PR DESCRIPTION
this patch updates the current (a bit older) version to 0.9.5.
