### PR TITLE
Add username and password support in Samba shares

### DIFF
--- a/packages/mediacenter/xbmc-addon-settings/config/default_settings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/config/default_settings.xml
@@ -26,6 +26,8 @@
     <setting id="NET2_SECURITY" value="NONE" />
     <setting id="NET2_SSID" value="" />   
     <setting id="SAMBA_START" value="true" />
+    <setting id="SAMBA_USERNAME" value="openelec" />
+    <setting id="SAMBA_PASSWORD" value="openelec" />
     <setting id="UPDATE_AUTO" value="manual" />
     <setting id="X11_KEYMAP" value="us" />
     <setting id="X11_KEYMAP2" value="" />

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/Dutch/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/Dutch/strings.xml
@@ -36,6 +36,8 @@
 	<string id="5000">Samba</string>
 	<string id="5010">Configuratie</string>
 	<string id="5011">Start Samba bij het opstarten</string>
+	<string id="5012">Samba Username</string>
+	<string id="5013">Samba Password</string>
 
 </strings>
 

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/English/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/English/strings.xml
@@ -36,5 +36,7 @@
 	<string id="5000">Samba</string>
 	<string id="5010">Boot</string>
 	<string id="5011">Start Samba at boot</string>
+	<string id="5012">Samba Username</string>
+	<string id="5013">Samba Password</string>
 
 </strings>

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/French/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/French/strings.xml
@@ -36,5 +36,7 @@
 	<string id="5000">Samba</string>
 	<string id="5010">Démarrage</string>
 	<string id="5011">Lancer Samba au démarrage</string>
+	<string id="5012">Samba Username</string>
+	<string id="5013">Samba Password</string>
 
 </strings>

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/German/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/German/strings.xml
@@ -36,5 +36,7 @@
 <string id="5000">Samba</string>
 <string id="5010">Samba Server</string>
 <string id="5011">Starte Samba beim Booten</string>
+<string id="5012">Samba Username</string>
+<string id="5013">Samba Password</string>
 
 </strings>

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/Norwegian/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/Norwegian/strings.xml
@@ -36,5 +36,7 @@
 	<string id="5000">Samba</string>
 	<string id="5010">Oppstart</string>
 	<string id="5011">Start Samba under oppstart</string>
+	<string id="5012">Samba Username</string>
+	<string id="5013">Samba Password</string>
 
 </strings>

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/settings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/settings.xml
@@ -67,5 +67,7 @@
 		<setting label="5010" type="lsep"/>
 		<setting type="sep" />
 		<setting id="SAMBA_START" type="bool" label="5011" default="true" />
+		<setting id="SAMBA_USERNAME" type="text" label="5012" default="openelec" enable="eq(-1,true)"/>
+		<setting id="SAMBA_PASSWORD" type="text" option="hidden" label="5013" default="openelec"  enable="eq(-2,true)"/>
     </category>
 </settings>

--- a/packages/network/samba/build
+++ b/packages/network/samba/build
@@ -112,6 +112,7 @@ make bin/libsmbclient.so
 if [ "$SAMBA_SERVER" = yes ]; then
   make bin/smbd
   make bin/nmbd
+  make bin/smbpasswd
 fi
 
 mkdir -p $SYSROOT_PREFIX/usr/lib

--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -26,7 +26,8 @@
   server string = OpenELEC
   workgroup = WORKGROUP
   netbios name = %h
-  security = share
+  security = user
+  username map = /var/run/samba.map
   guest account = root
   socket options = TCP_NODELAY IPTOS_LOWDELAY SO_RCVBUF=65536 SO_SNDBUF=65536
   mangled names = no
@@ -46,12 +47,13 @@
 
 # Using the following configurations as a template allows you to add
 # writable shares of disks and paths under /storage
+# public = yes -> share is accessible by everyone!
 
 [Update]
   path = /storage/.update
   available = yes
   browsable = yes
-  public = yes
+#  public = yes
   writable = yes
   root preexec = mkdir -p /storage/.update
 
@@ -107,7 +109,7 @@
   path = /storage/.config
   available = yes
   browsable = yes
-  public = yes
+#  public = yes
   writable = yes
   root preexec = mkdir -p /storage/.config
 
@@ -115,7 +117,7 @@
   path = /storage/.xbmc/userdata
   available = yes
   browsable = yes
-  public = yes
+#  public = yes
   writable = yes
   root preexec = mkdir -p /storage/.xbmc/userdata
 
@@ -131,7 +133,7 @@
   path = /media
   available = yes
   browsable = yes
-  public = yes
+#  public = yes
   writable = yes
   root preexec = mkdir -p /media
 
@@ -139,7 +141,7 @@
   path = /storage/logfiles
   available = yes
   browsable = yes
-  public = yes
+#  public = yes
   writable = yes
   root preexec = mkdir -p /storage/logfiles
 

--- a/packages/network/samba/install
+++ b/packages/network/samba/install
@@ -29,6 +29,7 @@ if [ "$SAMBA_SERVER" = "yes" ]; then
   mkdir -p $INSTALL/usr/bin
     cp $PKG_BUILD/source3/bin/smbd $INSTALL/usr/bin
     cp $PKG_BUILD/source3/bin/nmbd $INSTALL/usr/bin
+    cp $PKG_BUILD/source3/bin/smbpasswd $INSTALL/usr/bin
 
   mkdir -p $INSTALL/etc/samba
     cp $PKG_DIR/config/smb.conf $INSTALL/etc/samba

--- a/packages/network/samba/scripts/52_samba
+++ b/packages/network/samba/scripts/52_samba
@@ -28,6 +28,11 @@
 
     if [ "$SAMBA_START" = "true" ]; then
 
+      echo -e "$SAMBA_PASSWORD\n$SAMBA_PASSWORD" | smbpasswd -s -a root >/dev/null 2>&1
+      #username map: first line makes sure plain root does not work all the time
+      #processing continues, so if user chooses root as username, second line overrides the first
+      echo -e "nobody = root\nroot = $SAMBA_USERNAME" > /var/run/samba.map
+  
     # sleep 2 sec to be ensure network is started
       usleep 2000000
 


### PR DESCRIPTION
Which shares are added password protection by default could still be discussed further (the forum thread is at http://www.openelec.tv/forum/20-development-discussion/19753-samba-username-and-password-support), but as it's quite easy for the user to add a custom smb.conf file, it's not a big issue.
