### PR TITLE
fixes linux unpack logic so the atv image builds with nouveau correctly

### DIFF
--- a/packages/linux/unpack
+++ b/packages/linux/unpack
@@ -52,10 +52,10 @@ sed -i -e "s|^CONFIG_INITRAMFS_SOURCE=.*$|CONFIG_INITRAMFS_SOURCE=\"$ROOT/$BUILD
     sed -i -e "s|^CONFIG_DEBUG_FS=.*$|# CONFIG_DEBUG_FS is not set|" $LINUX/.config
   fi
 
-# wipe out nouveau if GRAPHICS_DRIVERS contains nvidia
-  echo $GRAPHIC_DRIVERS | grep "nvidia" &>/dev/null && \
-  sed -i '/NOUVEAU/ d' $LINUX/.config && \
-  echo "# CONFIG_DRM_NOUVEAU is not set" >> $LINUX/.config
+# prevent nouveau from building unless it is the active graphics driver
+  if [ "$GRAPHIC_DRIVERS" != "nouveau" ]; then
+    sed -i -e "s|^CONFIG_DRM_NOUVEAU=.*$|# CONFIG_DRM_NOUVEAU is not set|" $LINUX/.config
+  fi
 
 # copy some extra firmware to linux tree
   cp -R $PKG_DIR/firmware/* $LINUX/firmware


### PR DESCRIPTION
To be honest I cannot follow what the current logic is in the unpack file.. but it does not work :)

If we test for "nvidia" we need to allow for Generic which supports a variety of video drivers (including nvidia) instead of a single driver, so some regex is required. It is easier to test for nouveau which is only used in the ATV image. So, if GRAPHICS_DRIVERS is not "nouveau" ..we unset CONFIG_DRM_NOUVEAU in the kernel config.
