### PR TITLE
curl can’t retrieve ssl certificate file

### DIFF
--- a/packages/web/curl/build
+++ b/packages/web/curl/build
@@ -77,7 +77,7 @@ ac_cv_header_librtmp_rtmp_h=yes \
             --without-gnutls \
             --without-polarssl \
             --without-nss \
-            --with-ca-bundle="/etc/ssl/cacert.pem" \
+            --with-ca-bundle="/etc/pki/tls/cacert.pem" \
             --without-ca-path \
             --without-libssh2 \
             --with-librtmp="$SYSROOT_PREFIX/usr" \


### PR DESCRIPTION
When I try to download a file with curl from an https location, I get the following error :

>  curl: (77) error setting certificate verify locations:
>  CAfile: /etc/ssl/cacert.pem
>  CApath: none

A search of *.pem file with `find` give me the following location : `/etc/pki/tls/cacert.pem`
Then I tried again to download with curl and its `--cacert` option pointing to this location : it worked !

So, this pull request only update the certification path of curl.

(Tested on my own build : OpenELEC-Fusion.x86_64-devel-20120214141304-r9816)
