### PR TITLE
tvheadend: remove w-scan binary from addon. This fixes #226

### DIFF
--- a/packages/addons/service/multimedia/hts-tvheadend/addon
+++ b/packages/addons/service/multimedia/hts-tvheadend/addon
@@ -28,4 +28,3 @@ mkdir -p $ADDON_BUILD/$PKG_ADDON_ID
 
 mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/bin
   cp -P $PKG_BUILD/build.Linux/tvheadend $ADDON_BUILD/$PKG_ADDON_ID/bin
-  cp -P $BUILD/w_scan-[0-9]*/w_scan $ADDON_BUILD/$PKG_ADDON_ID/bin


### PR DESCRIPTION
Remove w-scan binary from addon. This was included in tvheadend 2.0.5 update. Fixes #226
