### PR TITLE
vdr-addon: enable unloading/loading dvb modules on suspend/resume

### DIFF
--- a/packages/addons/service/multimedia/vdr-addon/addon
+++ b/packages/addons/service/multimedia/vdr-addon/addon
@@ -33,6 +33,7 @@ mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config
   cp $BUILD/vdr-[0-9]*/sources.conf $ADDON_BUILD/$PKG_ADDON_ID/config
   cp $BUILD/vdr-[0-9]*/svdrphosts.conf $ADDON_BUILD/$PKG_ADDON_ID/config
   echo '0.0.0.0/0' >> $ADDON_BUILD/$PKG_ADDON_ID/config/svdrphosts.conf
+  cp -PR $PKG_DIR/config/vdr-sleep.conf $ADDON_BUILD/$PKG_ADDON_ID/config
 
 mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/plugin
   cp -PR $BUILD/vdr-plugin-xvdr-*/libvdr*.so.* $ADDON_BUILD/$PKG_ADDON_ID/plugin

--- a/packages/addons/service/multimedia/vdr-addon/changelog.txt
+++ b/packages/addons/service/multimedia/vdr-addon/changelog.txt
@@ -1,3 +1,6 @@
+2.0.6
+- enable unloading/loading dvb modules on suspend/resume
+
 2.0.5
 - update to vdr-1.7.24
 - sc now works without the need to disable dynamite plugin

--- a/packages/addons/service/multimedia/vdr-addon/config/vdr-sleep.conf
+++ b/packages/addons/service/multimedia/vdr-addon/config/vdr-sleep.conf
@@ -1,0 +1,6 @@
+# space-separated list of modules to remove on suspend
+# and load on resume
+# example:
+# REMOVE_MODULES="cx23885 mantis"
+
+REMOVE_MODULES=""

--- a/packages/addons/service/multimedia/vdr-addon/meta
+++ b/packages/addons/service/multimedia/vdr-addon/meta
@@ -21,7 +21,7 @@
 
 PKG_NAME="vdr-addon"
 PKG_VERSION="2.0"
-PKG_REV="5"
+PKG_REV="6"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"

--- a/packages/addons/service/multimedia/vdr-addon/source/sleep.d/modules.power
+++ b/packages/addons/service/multimedia/vdr-addon/source/sleep.d/modules.power
@@ -1,0 +1,32 @@
+#!/bin/sh
+
+. /etc/profile
+
+ADDON_HOME="$HOME/.xbmc/userdata/addon_data/service.multimedia.vdr-addon"
+ADDON_CONFIG_DIR="$ADDON_HOME/config"
+
+if [ -f "$ADDON_CONFIG_DIR/vdr-sleep.conf" ]; then
+  . "$ADDON_CONFIG_DIR/vdr-sleep.conf"
+
+  if [ ! "$REMOVE_MODULES" == "" ] ; then
+    case "$1" in
+      hibernate|suspend)
+        killall -9 vdr.bin
+        # xbmc-send -a "Notification(suspend,unloading modules...)"
+        for module in $REMOVE_MODULES ; do
+          rmmod -w $module
+        done
+        ;;
+      thaw|resume)
+        # xbmc-send -a "Notification(resume,loading modules...)"
+        for module in $REMOVE_MODULES ; do
+          modprobe $module
+        done
+        # xbmc-send -a "Notification(resume,starting vdr service...)"
+        vdr.service
+        ;;
+      *) exit $NA
+        ;;
+    esac
+  fi
+fi


### PR DESCRIPTION
optional but nice to have on hand. 

nothing will change at all until a user edits 
/storage/.xbmc/userdata/addon_data/service.multimedia.vdr-addon/config/vdr-sleep.conf
