### PR TITLE
Createlog modifications

### DIFF
--- a/packages/sysutils/busybox/scripts/createlog
+++ b/packages/sysutils/busybox/scripts/createlog
@@ -86,6 +86,7 @@ mkdir -p $BASEDIR/$LOGDIR
 # Filesystem.log
   LOGFILE="08_Filesystem.log"
   getlog_cmd cat /proc/mounts
+  getlog_cmd df -h
 
 # DMI.log
 #  LOGFILE="08_dmi.log"


### PR DESCRIPTION
Add OE version information to the header of every log file generated
Disable generation of 00_OS.log 
Adds 08_Filesystem.log to output of createlog. contains list of mounts
relates to #329
