### PR TITLE
xbmc-addon-vuplus: version update

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="e20c7a0"
-PKG_REV="1"
+PKG_VERSION="4164f0b"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="https://github.com/jdembski/xbmc-addon-vuplus"


### PR DESCRIPTION
fix: URLEncode the service reference - should fix missing EPG data for some channels
add support for storing channel data into a file
