### PR TITLE
initramfs init: add support for NFS boot and NFS storage mount when not netbooting

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -60,6 +60,9 @@ NBD_DEVS="0"
       fastboot)
         FASTBOOT=yes
         ;;
+      overlay)
+        OVERLAY=yes
+        ;;
       break=*)
         BREAK="${arg#*=}"
         ;;
@@ -220,6 +223,14 @@ NBD_DEVS="0"
     progress "Mounting disks"
     mount_part "$boot" "/flash" "ro,noatime"
     mount_part "$disk" "/storage" "rw,noatime"
+
+    [ -z "$OVERLAY" ] && return
+    OVERLAY_DIR=`cat /sys/class/net/eth0/address | /bin/busybox tr -d :`
+    if [ ! -d /storage/$OVERLAY_DIR ]; then
+      mkdir /storage/$OVERLAY_DIR
+    fi
+    /bin/busybox umount /storage
+    mount_part "$disk/$OVERLAY_DIR" "/storage" "rw,noatime"
   }
 
   check_update() {


### PR DESCRIPTION
Added kernel commandline parameter: nfsboot: boot from NFS
Added kernel commandline parameter: nfsdisk: mount /storage from NFS even when not netbooting

To do this I had to split several functions to enable re-use for different boot methods. I've made the changes to be compatible compatible with existing use, and it should be easy to add other boot options (iSCSI, gPXE) in the future.

Tested with:
boot from disk: boot=LABEL=System disk=LABEL=Storage debugging progress  ssh
- boot from NFS: ip=dhcp nfsboot nfsroot=<server>:<path> nfsoverlay=<server>:<path> debugging progress  ssh
- boot from disk, with storage on NFS: ip=dhcp boot=LABEL=System nfsdisk nfsoverlay=<server>:<path> debugging progress  ssh

Any comments are welcome.

-Alain
