### PR TITLE
initramfs init: enhancement / redesign proposal

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -168,9 +168,9 @@ NBD_DEVS="0"
   mount_part() {
   # Mount a local or network filesystem
   # $1:[TYPE=]target, $2:mountpoint, $3:mount options, [$4:fs type]
-    MOUNT_TARGET="${1#*=}"
-
     progress "mount filesystem $1 ..."
+
+    MOUNT_TARGET="${1#*=}"
     case $1 in
       LABEL=*|UUID=*|/*)
         MOUNT_CMD="mount_common"
@@ -222,6 +222,7 @@ NBD_DEVS="0"
 
   load_modules() {
     progress "Loading kernel modules"
+
     [ ! -f "/etc/modules" ] && return
     for module in $(cat /etc/modules); do
       progress "Loading kernel module $module"
@@ -232,6 +233,7 @@ NBD_DEVS="0"
 
   check_disks() {
     progress "Checking disks"
+
     if [ -x /sbin/fsck_hfs ]; then
     # deal with hfs partitions
       hfsdiskprep
@@ -240,30 +242,34 @@ NBD_DEVS="0"
 
   mount_disks() {
     progress "Mounting disks"
+
     mount_part "$boot" "/flash" "ro,noatime"
-    mount_part "$disk" "/storage" "rw,noatime"
 
-    [ -z "$OVERLAY" ] && return
-    OVERLAY_DIR=`cat /sys/class/net/eth0/address | /bin/busybox tr -d :`
-    if [ ! -d /storage/$OVERLAY_DIR ]; then
-      mkdir /storage/$OVERLAY_DIR
-    fi
-    /bin/busybox umount /storage
+    if [ -n "$disk" ]; then
+      if [ -n "$OVERLAY" ]; then
+        OVERLAY_DIR=`cat /sys/class/net/eth0/address | /bin/busybox tr -d :`
 
-    # split $disk into $target,$options so we can append $OVERLAY_DIR
-      options="${disk#*,}"
-      target="${disk%%,*}"
-      if [ "$options" = "$disk" ]; then
-        disk="$target/$OVERLAY_DIR"
-      else
-        disk="$target/$OVERLAY_DIR,$options"
+        mount_part "$disk" "/storage" "rw,noatime"
+        mkdir -p /storage/$OVERLAY_DIR
+        /bin/busybox umount /storage
+
+      # split $disk into $target,$options so we can append $OVERLAY_DIR
+        options="${disk#*,}"
+        target="${disk%%,*}"
+        if [ "$options" = "$disk" ]; then
+          disk="$target/$OVERLAY_DIR"
+        else
+          disk="$target/$OVERLAY_DIR,$options"
+        fi
       fi
 
-    mount_part "$disk" "/storage" "rw,noatime"
+      mount_part "$disk" "/storage" "rw,noatime"
+    fi
   }
 
   check_update() {
     progress "Checking for updates"
+
     if [ -f "/flash/MACH_KERNEL" ]; then
       IMAGE_KERNEL="MACH_KERNEL"
     fi
@@ -288,7 +294,10 @@ NBD_DEVS="0"
     # /flash is actual root filesystem
       /bin/busybox mount --move /flash /sysroot
     fi
-    /bin/busybox mount --move /storage /sysroot/storage
+
+    if [ -n "$disk" ]; then
+      /bin/busybox mount --move /storage /sysroot/storage
+    fi
 
     [ -f "/sysroot/sbin/init" ] || error "final_check" "Could not find system."
   }


### PR DESCRIPTION
In order to better support multiple mount types and future extensibility, I would like to propose the following enhancements: Documentation below could be added to the Wiki.
### Kernel commandline parameters:
#### Mandatory support:
- debugging # Start debug shell on error
- bootchart # Gather boot statistics
- ssh # Enable ssh server
- progress # Show boot progress
- fastboot # Speed up boot
- boot=TYPE=path # Specify mount type and path to mount as System. path can point to either a partition containing SYSTEM image, or to a raw block device containing Squashfs (for use with NBD or embedded devices like Raspberry Pi etc.)
- disk=TYPE=path: specify mount type and path to mount as Storage
  TYPE=path can be one of:
  - LABEL=label # mount partition by label, supported by busybox mount
  - UUID=uuid # mount partition by UUID, supported by busybox mount
  - NBD=server:port # mount NBD device
  - NFS=server:port:/path # mount NFS export
  - ISCSI="option1=val,option2=otherval,..." # mount iSCSI target. May require rethinking on how to pass those options, there could be quite a lot of them...
#### Optional support (for backwards compatibility, only if feasible):
- netboot # implies: boot=NBD=$NBD_ROOT_SERVER:$NBD_ROOT_PORT disk=NFS=$NFS_OVERLAY overlay
- nbdroot=server:port # (requires: netboot) implies: boot=NBD=server:port
- nfsoverlay=server:port:/path # implies: disk=NFS=server:port:/path overlay
#### Optional support, proposed
- break=step,step,... # (requires: debugging), start debug shell at a particular step. May require 'grep' applet in busybox.
- overlay # Use an overlay to support multiple OpenELEC clients with a single boot configfile. Might only work for NFS mounts because it needs subdir mount support.

To support all those combinations of mount types, I think it is best to mostly redo the init, keeping parts which can be reused.
### init script functionality
#### Basic infrastructure
- Global variables: keep most of them, add when necessary
- Kernel commandline parsing: strip to bare minimum
- fastboot handling, progress(): keep
- error(): run `/bin/busybox halt` on error, not stopping here could do more damage
- mount_part(): rewrite to handle different mount types. need to find out if / when / how to retry mount for different mount types
- update(): keep, check to make sure both /storage/.update && /flash contain an image, to prevent accidental clobbering of unrelated fs
- hfsdiskprep(): is this really needed? if so, keep it
- mount_*(): rework to match boot steps, see below
- filesystem moves / switch_root: keep
#### Other changes
- Make error messages more meaningful, "INIT_3" doesn't mean much when a description is always shown anyway.
#### Boot steps
- mount special filesystems
- setup console
- parse kernel commandline
- mount_flash(): Mount system image partition or raw block device
- mount_storage(): Mount storage partition
- check_update(): Check for and perform system update. Disable update downloads when /flash cannot be written to (ro export)
- mount_sysroot(): if /flash contains system image file, loop mount that on /sysroot, otherwise the image contents were already mounted straight from a block device onto /flash, so move /flash to /sysroot
- move /flash and /storage to their final places
- switch root and continue with final init
