### PR TITLE
Fix install on blank 3TB drives

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -69,7 +69,7 @@ get_device_unmount() {
   # provides: DEVICES
 
     DEVICES=""
-    DEVICES=$(parted -m -l | grep ^/dev/sd | cut -f1 -d ":")
+    DEVICES=$(parted -s -m -l | grep ^/dev/sd | cut -f1 -d ":")
 
     for i in $(cat /proc/mounts | grep ^/dev/sd | cut -f1 -d " " | sed "s/[0-9]//"); do
       DEVICES=$(echo $DEVICES |sed -e "s|$i||")
@@ -82,7 +82,7 @@ get_partition() {
   # uses:     -
   # provides: PARTITIONS
 
-    PARTITIONS=$(parted -m $1 print |grep -v ^/dev |grep -v BYT | cut -f1 -d ":")
+    PARTITIONS=$(parted -s -m $1 print |grep -v ^/dev |grep -v BYT | cut -f1 -d ":")
 }
 
 create_device_list() {
@@ -104,8 +104,8 @@ create_device_list() {
     fi
 
     for i in $DEVICES; do
-      DEVICE_MODEL=$(parted $i -m print | grep ^$i | cut -f7 -d ":" | sed "s/;//")
-      DEVICE_SIZE=$(parted $i -m print | grep ^$i | cut -f2 -d ":")
+      DEVICE_MODEL=$(parted -s $i -m print | grep ^$i | cut -f7 -d ":" | sed "s/;//")
+      DEVICE_SIZE=$(parted -s $i -m print | grep ^$i | cut -f2 -d ":")
       DEVICE_NAME=$(echo $DEVICE_MODEL ${DEVICE_SIZE} | sed 's/ /_/g')
       DEVICE_LIST="$DEVICE_LIST $i $DEVICE_NAME"
     done
@@ -126,9 +126,9 @@ create_partition_list() {
     get_partition $1
 
     for partition in $PARTITIONS; do
-      PARTITION_NUMBER=$(parted -m $1 print |grep -v ^/dev |grep -v BYT | cut -f1 -d ":")
-      PARTITION_SIZE=$(parted -m $1 print |grep -v ^/dev |grep -v BYT | cut -f4 -d ":")
-      PARTITION_FORMAT=$(parted -m $1 print |grep -v ^/dev |grep -v BYT | cut -f5 -d ":")
+      PARTITION_NUMBER=$(parted -s -m $1 print |grep -v ^/dev |grep -v BYT | cut -f1 -d ":")
+      PARTITION_SIZE=$(parted -s -m $1 print |grep -v ^/dev |grep -v BYT | cut -f4 -d ":")
+      PARTITION_FORMAT=$(parted -s -m $1 print |grep -v ^/dev |grep -v BYT | cut -f5 -d ":")
       PARTITION_LIST=" $PARTITION_LIST \n Partition $1$PARTITION_NUMBER Size: $PARTITION_SIZE Format: $PARTITION_FORMAT"
     done
 }


### PR DESCRIPTION
For some reason something made parted enter its interactive mode. Always
calling it with -s makes more sense anyway, and fixes that remaining issue
with never used blank 3TB drives I was still seeing.
