### PR TITLE
initramfs init: add user-defined mount options for NFS mounts

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -160,9 +160,12 @@ NBD_DEVS="0"
 
   mount_nfs() {
   # Mount NFS export
-    NFS_OPTIONS="nolock,retrans=10"
+    NFS_EXPORT="${1%%,*}"
+    NFS_OPTIONS="${1#*,}"
 
-    mount_common "$1" "$2" "$3,$NFS_OPTIONS" "nfs"
+    [ "$NFS_OPTIONS" = "$1" ] && NFS_OPTIONS=
+
+    mount_common "$NFS_EXPORT" "$2" "$3,nolock,retrans=10,$NFS_OPTIONS" "nfs"
   }
 
   mount_part() {


### PR DESCRIPTION
This adds the possibility to add mount options for NFS mounts.

Feature request and patch submitted by: Björn Ketelaars bjorn.ketelaars@hydroxide.nl

Possible uses: e.g. add options like proto=udp for NFS-over-UDP mounts.
