### PR TITLE
switch ATV image to nvidia graphics

### DIFF
--- a/projects/ATV/options
+++ b/projects/ATV/options
@@ -228,7 +228,7 @@
 # Xorg Graphic drivers to use (all / i915,i965,r200,r300,r600,fglrx,nvidia,nouveau,vmware)
 # Space separated list is supported,
 # e.g. GRAPHIC_DRIVERS="i915 i965 r300 r600 radeon nvidia nouveau"
-  GRAPHIC_DRIVERS="nouveau"
+  GRAPHIC_DRIVERS="nvidia"
 
 # Use VDPAU video acceleration (needs nVidia driver and a supported card)
   VDPAU="no"


### PR DESCRIPTION
the long-standing HDMI audio bug is confirmed fixed in the 295.33 driver so no reason to stick with nouveau any longer..
