### PR TITLE
Giada N20 - Missing remote keys

### DIFF
--- a/packages/sysutils/remote/eventlircd/evmap/03_0709_9137.evmap
+++ b/packages/sysutils/remote/eventlircd/evmap/03_0709_9137.evmap
@@ -39,7 +39,7 @@
  KEY_COMPOSE      = KEY_INFO        # Info/EPG
  KEY_G            = KEY_EPG         # Guide
 
- shift+KEY_3      = KEY_NUMERIC_POUND  #Star
- shift+KEY_8      = KEY_NUMERIC_STAR   #Hash
+ shift+KEY_3      = KEY_NUMERIC_POUND  # Hash (#)
+ shift+KEY_8      = KEY_NUMERIC_STAR   # Star (*)
 
  KEY_POWER        = KEY_POWER       # Power


### PR DESCRIPTION
Not able to set OS as RW to check this works.
This is a direct mapping of the evtest results for the Star & Hash keys which are currently mapped for the Giada N20.
