### PR TITLE
vdr: adjust for fontconfig 2.9.0

### DIFF
--- a/packages/3rdparty/multimedia/vdr/patches/vdr-1.7.27-10_fontconfig_fontsort.patch
+++ b/packages/3rdparty/multimedia/vdr/patches/vdr-1.7.27-10_fontconfig_fontsort.patch
@@ -1,0 +1,14 @@
+diff --git a/font.c b/font.c
+index 706a017..72c5ec3 100644
+--- a/font.c
++++ b/font.c
+@@ -482,7 +482,8 @@ cString cFont::GetFontFileName(const char *FontName)
+      FcPatternAddBool(pat, FC_SCALABLE, FcTrue);
+      FcConfigSubstitute(NULL, pat, FcMatchPattern);
+      FcDefaultSubstitute(pat);
+-     FcFontSet *fontset = FcFontSort(NULL, pat, FcFalse, NULL, NULL);
++     FcResult fresult;
++     FcFontSet *fontset = FcFontSort(NULL, pat, FcFalse, NULL, &fresult);
+      if (fontset) {
+         for (int i = 0; i < fontset->nfont; i++) {
+             FcBool scalable;


### PR DESCRIPTION
see http://cgit.freedesktop.org/fontconfig/commit/?id=a18ca17b6211f62fbd1d893811b94b8c83db4cc0

in fontconfig FcFontSort() behaviour has changed.

this fixes #408
