### PR TITLE
Parsing of XML entities when generating the settings.conf file

### DIFF
--- a/packages/sysutils/busybox/init.d/06_systemconfig
+++ b/packages/sysutils/busybox/init.d/06_systemconfig
@@ -26,8 +26,10 @@
 OPENELEC_SETTINGS="$HOME/.xbmc/userdata/addon_data/os.openelec.settings/settings.xml"
 
 if [ -f "$OPENELEC_SETTINGS" ]; then
-  progress "creating system settings"
-
+    progress "creating system settings"
+    
     mkdir -p /var/config
-    cat "$OPENELEC_SETTINGS" | awk -F\" '{print $2"=\""$4"\""}' | sed '/^=/d' > /var/config/settings.conf
+    cat "$OPENELEC_SETTINGS" \
+        | awk -F'[\"|'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); print $2"=\""$4"\"";}' \
+        | sed '/^=/d' > /var/config/settings.conf
 fi


### PR DESCRIPTION
Basic XML entities such as "&quot;", "&apos;", "&amp;", "&lt;", and "&gt;" are not being parsed when the file /var/config/settings.conf is generated, and thus options such as NET_PASSPHRASE are being generated incorrectly.

Moreover, the systemconfig script only searches for properties encapsulated in double quotes. When XBMC generates the XML config files, values that contain double quotes are encapsulated in single quotes (even though the double quotes are being parsed into XML entities), and thus the script ends up missing them.

This patch takes care of both problems. I am not sure if there is a more elegant way of dealing with entities, so I'm open to suggestions.
