### PR TITLE
Update TBS drivers download URL and package version

### DIFF
--- a/packages/linux-drivers/linux-tbs-drivers/meta
+++ b/packages/linux-drivers/linux-tbs-drivers/meta
@@ -18,13 +18,13 @@
 #  http://www.gnu.org/copyleft/gpl.html
 ################################################################################
 
-PKG_NAME="tbs-linux-drivers"
+PKG_NAME="linux-tbs-drivers"
 PKG_VERSION="120405"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.tbsdtv.com/english/Download.html"
-PKG_URL="http://www.tbsdtv.com/download/document/common/${PKG_NAME}_v${PKG_VERSION}.zip"
+PKG_URL="http://www.tbsdtv.com/download/document/common/tbs-linux-drivers_v${PKG_VERSION}.zip"
 PKG_DEPENDS=""
 PKG_BUILD_DEPENDS="toolchain linux"
 PKG_PRIORITY="optional"


### PR DESCRIPTION
Driver zips seem to have been relocated. Hoping this newer package version will detect my TBS 6981 correctly.
