### PR TITLE
open-vm-tools: configure --without-procps

### DIFF
--- a/packages/sysutils/open-vm-tools/build
+++ b/packages/sysutils/open-vm-tools/build
@@ -35,6 +35,7 @@ cd $PKG_BUILD
             --without-dnet \
             --without-x \
             --without-icu \
+            --without-procps \
             --with-linuxdir=$(kernel_path)
 
 make CFLAGS+="-DG_DISABLE_DEPRECATED"


### PR DESCRIPTION
checking for getstat in -lproc... no
checking for getstat in -lproc-3.2.8... no
checking for getstat in -lproc-3.2.7... no
configure: error: libproc not found. Please configure without procps (using --without-procps) or install procps - http://procps.sourceforge.net

This is on a fairly clean "PROJECT=Virtual ARCH=i386 make" as of current master. Probably open-vm-tools is okay even without procps. Haven't tested it though.
