### PR TITLE
libgpg-error-1.10: wrong gettext version

### DIFF
--- a/packages/security/libgpg-error/build
+++ b/packages/security/libgpg-error/build
@@ -23,6 +23,7 @@
 . config/options $1
 
 cd $PKG_BUILD
+sed -i 's/AM_GNU_GETTEXT_VERSION(\[0.17\])/AM_GNU_GETTEXT_VERSION([0.18])/' configure.ac
 autopoint -f
 ./configure --host=$TARGET_NAME \
             --build=$HOST_NAME \


### PR DESCRIPTION
Making all in po
make[2]: Entering directory `/home/viljo/git/OpenELEC.tv/build.OpenELEC-Virtual.i386-devel/libgpg-error-1.10/po'
*** error: gettext infrastructure mismatch: using a Makefile.in.in from gettext version 0.17 but the autoconf macros are from gettext version 0.18
make[2]: *** [check-macro-version] Error 1
make[2]: Leaving directory`/home/viljo/git/OpenELEC.tv/build.OpenELEC-Virtual.i386-devel/libgpg-error-1.10/po'
make[1]: **\* [all-recursive] Error 1
make[1]: Leaving directory `/home/viljo/git/OpenELEC.tv/build.OpenELEC-Virtual.i386-devel/libgpg-error-1.10'
make: **\* [all] Error 2

Again on a fairly clean "PROJECT=Virtual ARCH=i386 make" as of current master.

Fixed by adding a sed to build file, it was quicker than creating a patch file. Haven't tested... "if it compiles, it works :-)"
