### PR TITLE
Remove redundant typo correction

### DIFF
--- a/packages/linux-drivers/linux-tbs-drivers/unpack
+++ b/packages/linux-drivers/linux-tbs-drivers/unpack
@@ -32,5 +32,3 @@ unzip $SOURCES/$1/$ZIP_PKG -d $BUILD/${PKG_NAME}-${PKG_VERSION} >/dev/null 2>&1
 tar xjf $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers.tar.bz2 -C $BUILD/${PKG_NAME}-${PKG_VERSION}
 # fix permissions
 chmod -R u+rwX $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers/*
-# fix typo
-sed -i 's|tbs5880trl|tbs5880ctrl|g' $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers/v4l/tbs-x86_64.sh


### PR DESCRIPTION
Typo has been fixed in the new script version. I think this has been here for a while.

Sorry if I'm making the pull requests too minor!
