### PR TITLE
vdr & tvheadend: suspend/resume fixes

### DIFF
--- a/packages/addons/service/multimedia/hts-tvheadend/source/sleep.d/tvheadend.power
+++ b/packages/addons/service/multimedia/hts-tvheadend/source/sleep.d/tvheadend.power
@@ -26,11 +26,14 @@ ADDON_HOME="$HOME/.xbmc/userdata/addon_data/service.multimedia.hts-tvheadend"
 ADDON_SETTINGS="$ADDON_HOME/settings.xml"
 REMOVE_MODULES=`grep REMOVE_MODULES $ADDON_SETTINGS | awk '{print $3 }' | sed -e "s,value=,," -e "s,\",,g"`
 
+LOCKFILE="/var/lock/tvheadend.sleep"
+
 case "$1" in
   hibernate|suspend)
     if [ "$(pidof tvheadend)" ];then
       progress "Shutting down HTS TVHeadend for suspending..."
       tvheadend.stop
+      touch $LOCKFILE
       for module in $REMOVE_MODULES ; do
         rmmod -w $module
       done
@@ -42,7 +45,10 @@ case "$1" in
       modprobe $module
     done
     progress "Restarting HTS TVHeadend for wakeup..."
-    xbmc-send --host=127.0.0.1 -a "XBMC.RunScript(service.multimedia.hts-tvheadend)" &
+    if [ -f "$LOCKFILE" ] ; then
+      rm -rf "$LOCKFILE"
+      tvheadend.start
+    fi
     ;;
   *) exit $NA
     ;;

--- a/packages/addons/service/multimedia/vdr-addon/source/sleep.d/modules.power
+++ b/packages/addons/service/multimedia/vdr-addon/source/sleep.d/modules.power
@@ -27,10 +27,14 @@ ADDON_CONFIG_DIR="$ADDON_HOME/config"
 ADDON_SETTINGS="$ADDON_HOME/settings.xml"
 REMOVE_MODULES=`grep REMOVE_MODULES $ADDON_SETTINGS | awk '{print $3}' | sed -e "s,value=,," -e "s,\",,g"`
 
+LOCKFILE="/var/lock/vdr.sleep"
+
 if [ ! "$REMOVE_MODULES" == "" ] ; then
   case "$1" in
     hibernate|suspend)
+      progress "Shutting down vdr for suspending..."
       vdr.stop
+      touch $LOCKFILE
       for module in $REMOVE_MODULES ; do
         rmmod -w $module
       done
@@ -39,7 +43,11 @@ if [ ! "$REMOVE_MODULES" == "" ] ; then
       for module in $REMOVE_MODULES ; do
         modprobe $module
       done
-      xbmc-send --host=127.0.0.1 -a "XBMC.RunScript(service.multimedia.vdr-addon)" &
+      progress "Restarting vdr for wakeup..."
+      if [ -f "$LOCKFILE" ] ; then
+        rm -rf "$LOCKFILE"
+        vdr.start
+      fi
       ;;
     *) exit $NA
       ;;


### PR DESCRIPTION
seems like (in latest xbmc releases) xbmc-send doesn't always work. so instead of counnting on xbmc to decide whether to run vdr/tvheadend or not, we do it manualy

on suspend: if (vdr|tvheadend) is runing - stop it and save a "lockfile"
on resume: check if lockfile exists (this means (vdr|tvheadend) was runing before suspend) - so start it.
