### PR TITLE
addon-vuplus: bump version to 0.1.15 because of major bug

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="310165e"
+PKG_VERSION="b0c16d5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
0.1.15
- fix: when using the channeldata-store option not all channel groups (bouquets) were loaded due to a nulled counter variable
