### PR TITLE
linux: add support for TeVii S471 DVB-S2 PCIe card

### DIFF
--- a/packages/linux/patches/linux-3.2.16-211-add_TeVii_s471_support.patch
+++ b/packages/linux/patches/linux-3.2.16-211-add_TeVii_s471_support.patch
@@ -1,0 +1,90 @@
+cx23885: add TeVii s471 card.
+
+From: Igor M. Liplianin <liplianin@me.by>
+
+New TeVii s471 card is like s470 model,
+but there is different LNB power control.
+
+Signed-off-by: Igor M. Liplianin <liplianin@me.by>
+
+diff --git a/drivers/media/dvb/frontends/ds3000.c b/drivers/media/dvb/frontends/ds3000.c
+index 90bf573..6f4901a 100644
+--- a/drivers/media/dvb/frontends/ds3000.c
++++ b/drivers/media/dvb/frontends/ds3000.c
+@@ -1129,7 +1129,10 @@ static int ds3000_set_frontend(struct dvb_frontend *fe,
+ 			ds3000_writereg(state,
+ 				ds3000_dvbs2_init_tab[i],
+ 				ds3000_dvbs2_init_tab[i + 1]);
+-		ds3000_writereg(state, 0xfe, 0x98);
++		if (c->symbol_rate >= 30000000)
++			ds3000_writereg(state, 0xfe, 0x54);
++		else
++			ds3000_writereg(state, 0xfe, 0x98);
+ 		break;
+ 	default:
+ 		return 1;
+diff --git a/drivers/media/video/cx23885/cx23885-cards.c b/drivers/media/video/cx23885/cx23885-cards.c
+index ab8be9a..76e83e4 100644
+--- a/drivers/media/video/cx23885/cx23885-cards.c
++++ b/drivers/media/video/cx23885/cx23885-cards.c
+@@ -452,6 +452,10 @@ struct cx23885_board cx23885_boards[] = {
+ 		.portc		= CX23885_MPEG_DVB,
+ 	},		
+ 
++	[CX23885_BOARD_TEVII_S471] = {
++		.name		= "TeVii S471",
++		.portb		= CX23885_MPEG_DVB,
++	},
+ };
+ const unsigned int cx23885_bcount = ARRAY_SIZE(cx23885_boards);
+ 
+@@ -663,6 +667,10 @@ struct cx23885_subid cx23885_subids[] = {
+ 		.subvendor = 0x4254,
+ 		.subdevice = 0x0952,
+ 		.card      = CX23885_BOARD_DVBSKY_S952,
++	}, {
++		.subvendor = 0xd471,
++		.subdevice = 0x9022,
++		.card      = CX23885_BOARD_TEVII_S471,
+ 	},
+ };
+ const unsigned int cx23885_idcount = ARRAY_SIZE(cx23885_subids);
+@@ -1485,6 +1493,7 @@ void cx23885_card_setup(struct cx23885_dev *dev)
+ 	case CX23885_BOARD_BST_PS8512:
+ 	case CX23885_BOARD_DVBSKY_S950:
+ 	case CX23885_BOARD_TEVII_S470:
++	case CX23885_BOARD_TEVII_S471:
+ 	case CX23885_BOARD_DVBWORLD_2005:
+ 		ts1->gen_ctrl_val  = 0x5; /* Parallel */
+ 		ts1->ts_clk_en_val = 0x1; /* Enable TS_CLK */
+diff --git a/drivers/media/video/cx23885/cx23885-dvb.c b/drivers/media/video/cx23885/cx23885-dvb.c
+index af9c459..9f68250 100644
+--- a/drivers/media/video/cx23885/cx23885-dvb.c
++++ b/drivers/media/video/cx23885/cx23885-dvb.c
+@@ -1174,6 +1174,14 @@ static int dvb_register(struct cx23885_tsport *port)
+ 			break;
+ 		}
+ 		break;
++	case CX23885_BOARD_TEVII_S471:
++		i2c_bus = &dev->i2c_bus[1];
++
++		fe0->dvb.frontend = dvb_attach(ds3000_attach,
++					&tevii_ds3000_config,
++					&i2c_bus->i2c_adap);
++		break;
++
+ 	default:
+ 		printk(KERN_INFO "%s: The frontend of your DVB/ATSC card "
+ 			" isn't supported yet\n",
+diff --git a/drivers/media/video/cx23885/cx23885.h b/drivers/media/video/cx23885/cx23885.h
+index 6f058f1..19cebdf 100644
+--- a/drivers/media/video/cx23885/cx23885.h
++++ b/drivers/media/video/cx23885/cx23885.h
+@@ -90,6 +90,7 @@
+ #define CX23885_BOARD_BST_PS8512               (CX23885_BOARD_MPX885+1)
+ #define CX23885_BOARD_DVBSKY_S952              (CX23885_BOARD_BST_PS8512+1)
+ #define CX23885_BOARD_DVBSKY_S950              (CX23885_BOARD_DVBSKY_S952+1)
++#define CX23885_BOARD_TEVII_S471               (CX23885_BOARD_DVBSKY_S950+1)
+ 
+ #define GPIO_0 0x00000001
+ #define GPIO_1 0x00000002


### PR DESCRIPTION
this is an attempt to fix #514

compiles fine. not tested (I don't have the hardware)
