### PR TITLE
vuplus-addon: bump version to 0.2.1

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/install
+++ b/packages/mediacenter/xbmc-addon-vuplus/install
@@ -26,3 +26,5 @@ mkdir -p $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -PRf $PKG_BUILD/addons/pvr.vuplus/resources $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -Pf $PKG_BUILD/addons/pvr.vuplus/addon.xml $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -Pf $PKG_BUILD/addons/pvr.vuplus/XBMC_vuplus.pvr $INSTALL/usr/share/xbmc/addons/pvr.vuplus
+  cp -Pf $PKG_BUILD/addons/pvr.vuplus/changelog $INSTALL/usr/share/xbmc/addons/pvr.vuplus
+  cp -Pf $PKG_BUILD/addons/pvr.vuplus/icon.png $INSTALL/usr/share/xbmc/addons/pvr.vuplus

--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="7b99259"
+PKG_VERSION="72b8840"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
From the changelog:
0.2.1:
- fix: encode the stream-url properly. Please remove your channeldata.xml file after updating
- change: add proper version string to the addon.xml generated by buildzip.bat (thanks to 'trans')

I have also changed the install-file so that the icon and the changelog will be copied over to the addon-directory.
