### PR TITLE
vuplus-addon: bump version to 0.2.2

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/install
+++ b/packages/mediacenter/xbmc-addon-vuplus/install
@@ -26,5 +26,5 @@ mkdir -p $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -PRf $PKG_BUILD/addons/pvr.vuplus/resources $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -Pf $PKG_BUILD/addons/pvr.vuplus/addon.xml $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -Pf $PKG_BUILD/addons/pvr.vuplus/XBMC_vuplus.pvr $INSTALL/usr/share/xbmc/addons/pvr.vuplus
-  cp -Pf $PKG_BUILD/addons/pvr.vuplus/changelog $INSTALL/usr/share/xbmc/addons/pvr.vuplus
+  cp -Pf $PKG_BUILD/addons/pvr.vuplus/changelog.txt $INSTALL/usr/share/xbmc/addons/pvr.vuplus
   cp -Pf $PKG_BUILD/addons/pvr.vuplus/icon.png $INSTALL/usr/share/xbmc/addons/pvr.vuplus

--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="72b8840"
+PKG_VERSION="7151aa1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
0.2.2:
- fix: escape xml entities in the stream-url before saving to channeldata.xml
- fix: fetch the version string from configure.in not the ChangeLog (thanks to 'trans')
- fix: rename changelog in addon-directory to changelog.txt
