### PR TITLE
lirc: support for custom lircd file in /storage/.config/

### DIFF
--- a/packages/sysutils/remote/eventlircd/patches/eventlircd-42-002-custom_config.patch
+++ b/packages/sysutils/remote/eventlircd/patches/eventlircd-42-002-custom_config.patch
@@ -1,0 +1,17 @@
+diff --git a/udev/lircd_helper.in b/udev/lircd_helper.in
+index f580cc6..6befeed 100644
+--- a/udev/lircd_helper.in
++++ b/udev/lircd_helper.in
+@@ -41,7 +41,11 @@ case "${ACTION}" in
+             daemon="${daemon} --uinput"
+             daemon="${daemon} --output=@localstatedir@/run/lirc/lircd-${devname_instance}"
+             daemon="${daemon} --pidfile=@localstatedir@/run/lirc/lircd-${devname_instance}.pid"
+-            daemon="${daemon} ${lircd_conf}"
++            if test -e "/storage/.config/lircd.conf" ; then
++                daemon="${daemon} /storage/.config/lircd.conf"
++            else
++                daemon="${daemon} ${lircd_conf}"
++            fi
+             ${daemon}
+             for devlink in ${DEVLINKS} ; do
+                 devlink_instance=`echo ${devlink} | /bin/sed -e 's/\/\+/~/g' -e 's/^~dev~//'`


### PR DESCRIPTION
closes #513

later we can add some working lircd configs (like we do now for asound for example)
