### PR TITLE
xbmc: do not remount non optical devices on DeviceChanged event

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-11.0.1-984-do-not-remount-non-optical-devices-in-DeviceChanged-event.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-11.0.1-984-do-not-remount-non-optical-devices-in-DeviceChanged-event.patch
@@ -1,0 +1,13 @@
+diff --git a/xbmc/storage/linux/UDisksProvider.cpp b/xbmc/storage/linux/UDisksProvider.cpp
+index 6afc1a8..c940e69 100644
+--- a/xbmc/storage/linux/UDisksProvider.cpp
++++ b/xbmc/storage/linux/UDisksProvider.cpp
+@@ -356,7 +356,7 @@ void CUDisksProvider::DeviceChanged(const char *object, IStorageEventsCallback *
+   {
+     bool mounted = device->m_isMounted;
+     device->Update();
+-    if (g_advancedSettings.m_handleMounting)
++    if (g_advancedSettings.m_handleMounting && device->m_isOptical)
+       device->Mount();
+     if (!mounted && device->m_isMounted && callback)
+       callback->OnStorageAdded(device->m_Label, device->m_MountPath);

--- a/packages/mediacenter/xbmc/patches/xbmc-pvr-11.0.1-984-do-not-remount-non-optical-devices-in-DeviceChanged-event.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-pvr-11.0.1-984-do-not-remount-non-optical-devices-in-DeviceChanged-event.patch
@@ -1,0 +1,13 @@
+diff --git a/xbmc/storage/linux/UDisksProvider.cpp b/xbmc/storage/linux/UDisksProvider.cpp
+index 6afc1a8..c940e69 100644
+--- a/xbmc/storage/linux/UDisksProvider.cpp
++++ b/xbmc/storage/linux/UDisksProvider.cpp
+@@ -356,7 +356,7 @@ void CUDisksProvider::DeviceChanged(const char *object, IStorageEventsCallback *
+   {
+     bool mounted = device->m_isMounted;
+     device->Update();
+-    if (g_advancedSettings.m_handleMounting)
++    if (g_advancedSettings.m_handleMounting && device->m_isOptical)
+       device->Mount();
+     if (!mounted && device->m_isMounted && callback)
+       callback->OnStorageAdded(device->m_Label, device->m_MountPath);


### PR DESCRIPTION
a fix for [this bug](http://openelec.tv/forum/65-storage/14727-xs35gt-usb-harddisks-autoreconnects-after-qsafely-removeq#33382) (#618)

broken since c225823a. with this new patch applied I am able to "unmount safely" external disks. needs testing with optical drives
