### PR TITLE
busybox-initramfs: Skip and warn instead of error on module load failure

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -319,7 +319,7 @@ NBD_DEVS="0"
     for module in $(cat /etc/modules); do
       progress "Loading kernel module $module"
       /bin/busybox insmod "$MODULE_DIR/$module.ko" || \
-        error "load_modules" "Failed to load kernel module $module"
+        progress "... Failed to load kernel module $module, skipping"
     done
   }
 


### PR DESCRIPTION
When a kernel module fails to load, produce a warning instead of an error and
skip that module instead of halting the system.

Currently uses progress() for the warning, we may need a better alternative.

Signed-off-by: Alain Kalker a.c.kalker@gmail.com
