### PR TITLE
xbmv-pvr: add pvr setwakeup script

### DIFF
--- a/packages/mediacenter/xbmc-pvr/install
+++ b/packages/mediacenter/xbmc-pvr/install
@@ -28,6 +28,7 @@ mkdir -p $INSTALL/usr/bin
   cp $PKG_DIR/scripts/cputemp $INSTALL/usr/bin
   cp $PKG_DIR/scripts/gputemp $INSTALL/usr/bin
   cp $PKG_DIR/scripts/wait_on_xbmc_exit $INSTALL/usr/bin
+  cp $PKG_DIR/scripts/setwakeup $INSTALL/usr/bin
   cp $PKG_BUILD/tools/EventClients/Clients/XBMC\ Send/xbmc-send.py $INSTALL/usr/bin/xbmc-send
 
 mkdir -p $INSTALL/usr/lib/xbmc

--- a/packages/mediacenter/xbmc-pvr/scripts/setwakeup
+++ b/packages/mediacenter/xbmc-pvr/scripts/setwakeup
@@ -1,0 +1,6 @@
+#!/bin/bash
+
+DEV=/sys/class/rtc/rtc0/wakealarm
+echo 0 > $DEV
+echo $1 > $DEV
+cat /proc/driver/rtc > /storage/nextboot


### PR DESCRIPTION
To use this script the user has to enable xbmc-pvr energy saving options in livetv setup
