### PR TITLE
connman: add hardware clock synchronization to network init

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -189,6 +189,16 @@ fi
     [ -f "$DEBUG_CONNMAN_PROFILE" ] && cp $DEBUG_CONNMAN_PROFILE $CONNMAN_PROFILE
     [ -f "$DEBUG_CONNMAN_PROFILE" ] && mv $DEBUG_CONNMAN_PROFILE ${DEBUG_CONNMAN_PROFILE}_saved
 
+  # set hwclock
+  if [ -f /proc/driver/rtc ]; then
+    (
+    # sleep 30 seconds before hw clock is synced
+    usleep 30000000
+    progress "syncing hardware clock with system clock"
+    /sbin/hwclock --systohc
+    )&
+  fi
+  
   # starting Connection manager
     progress "starting Connection manager"
 


### PR DESCRIPTION
This is necessary for RTC wakeup alarms.
