### PR TITLE
prelink: correct install location

### DIFF
--- a/packages/toolchain/devel/prelink-cross/build
+++ b/packages/toolchain/devel/prelink-cross/build
@@ -29,4 +29,4 @@ cd $PKG_BUILD
             --build=$HOST_NAME \
             --prefix=$ROOT/$TOOLCHAIN
 make
-$MAKEINSTALL
+make install


### PR DESCRIPTION
binaries must be installed in $ROOT/$TOOLCHAIN not $SYSROT_PREFIX
