### PR TITLE
create_virtualimage: use the first unused loop device

### DIFF
--- a/packages/tools/syslinux/files/create_virtualimage
+++ b/packages/tools/syslinux/files/create_virtualimage
@@ -43,7 +43,7 @@ fi
 
 DISK="$1/OpenELEC.img"
 VMDK="$1/OpenELEC.vmdk"
-LOOP="/dev/loop0"
+LOOP=$(losetup -f)
 
 clear
 echo "#########################################################"


### PR DESCRIPTION
closes #717
