### PR TITLE
Add support for medialink bluetooth adapter

### DIFF
--- a/packages/linux/patches/linux-3.2.17-991-medialink-bluetooth.patch
+++ b/packages/linux/patches/linux-3.2.17-991-medialink-bluetooth.patch
@@ -1,6 +1,6 @@
 diff -Naur linux-3.2.16/drivers/bluetooth/btusb.c linux-3.2.16.patch/drivers/bluetooth/btusb.c
---- linux-3.2.16/drivers/bluetooth/btusb.c	2012-04-22 18:31:32.000000000 -0400
-+++ linux-3.2.16.patch/drivers/bluetooth/btusb.c	2012-04-29 15:19:24.120925633 -0400
+--- linux-3.2.17/drivers/bluetooth/btusb.c	2012-04-22 18:31:32.000000000 -0400
++++ linux-3.2.17.patch/drivers/bluetooth/btusb.c	2012-04-29 15:19:24.120925633 -0400
 @@ -102,6 +102,7 @@
  
  	/* Broadcom BCM20702A0 */


### PR DESCRIPTION
This patch has already been committed into the linux 3.3 branch but it doesn't look like they are pushing it into 3.2

This is a link to the specific adapter http://amzn.com/B004LNXO28
