### PR TITLE
Allow the ccache directory to be changed via an environment variable

### DIFF
--- a/config/path
+++ b/config/path
@@ -106,7 +106,9 @@ HOST_PKG_CONFIG_PATH=""
 HOST_PKG_CONFIG_LIBDIR="$ROOT/$TOOLCHAIN/lib/pkgconfig:$ROOT/$TOOLCHAIN/share/pkgconfig"
 HOST_PKG_CONFIG_SYSROOT_DIR=""
 
-export CCACHE_DIR=$HOME/.ccache-openelec
+if [ -z "$CCACHE_DIR" ]; then
+    export CCACHE_DIR=$HOME/.ccache-openelec
+fi
 export MAKEFLAGS=-j$CONCURRENCY_MAKE_LEVEL
 export PKG_CONFIG=$ROOT/$TOOLCHAIN/bin/pkg-config
 


### PR DESCRIPTION
Allow the default ccache directory to be changed via an environment variable, for example:

> PROJECT=RPi ARCH=arm CCACHE_DIR=.ccache-openelec make

This is useful if $HOME is restricted in size (due to disk-space / company policy). See also #644.
