### PR TITLE
Bump vuplus addon version to 0.2.6.

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="6c16993"
+PKG_VERSION="6e31a01"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Some changes - mainly to get better debug output and to make sure the users have a proper data in their channeldata file

0.2.6:
- cosmetic: remove unnecessary '/' in recording-stream url
- cosmetic: inprove log output
- change: get the proper device info from the reveiver box instead of just setting dummy values
- change: change the buildzip.bat to include version string in the name of the zip-file
- change: introduce a version string for the channeldata xml file so that we can invalidate old channeldata files if necessary
