### PR TITLE
Patch for wifi passwords with ampersands.

### DIFF
--- a/packages/sysutils/busybox/init.d/06_systemconfig
+++ b/packages/sysutils/busybox/init.d/06_systemconfig
@@ -30,6 +30,6 @@ if [ -f "$OPENELEC_SETTINGS" ]; then
     
     mkdir -p /var/config
     cat "$OPENELEC_SETTINGS" \
-        | awk -F'[\"|'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); print $2"=\""$4"\"";}' \
+        | awk -F'[\"|'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "\\&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); print $2"=\""$4"\"";}' \
         | sed '/^=/d' > /var/config/settings.conf
 fi


### PR DESCRIPTION
Fix usage of ampersands in wifi passphrases. They were being passed to connman as &amp;
