### PR TITLE
Bump version to 0.2.8

### DIFF
--- a/packages/mediacenter/xbmc-addon-vuplus/meta
+++ b/packages/mediacenter/xbmc-addon-vuplus/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xbmc-addon-vuplus"
-PKG_VERSION="50571e7"
+PKG_VERSION="6e31a01"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
0.2.8:
- add: option to only fetch one TV bouquet which can be specified via the addon settings

0.2.7:
- fix: fix incorrect escape character for & (use '&amp;' instead of '&quot;'). Thx to 'hani' for pointing this out.

0.2.6:
- cosmetic: remove unnecessary '/' in recording-stream url
- cosmetic: inprove log output
- change: get the proper device info from the reveiver box instead of just setting dummy values
- change: change the buildzip.bat to include version string in the name of the zip-file
- change: introduce a version string for the channeldata xml file so that we can invalidate old channeldata files if necessary
