### PR TITLE
added missing strings

### DIFF
--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/French/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/French/strings.xml
@@ -36,5 +36,8 @@
 	<string id="5000">Samba</string>
 	<string id="5010">Démarrage</string>
 	<string id="5011">Lancer Samba au démarrage</string>
+	<string id="5012">Utiliser un mot de passe Samba</string>
+	<string id="5013">Utilisateur Samba</string>
+	<string id="5014">Mot de passe Samba</string>
 
 </strings>


### PR DESCRIPTION
Hi, just noticed some missing strings in the french translation of the settings addon.
