### PR TITLE
SABnzbd-Suite: correction of empty password for CouchPotato V2

### DIFF
--- a/packages/addons/service/downloadmanager/SABnzbd-Suite/source/bin/SABnzbd-Suite.py
+++ b/packages/addons/service/downloadmanager/SABnzbd-Suite/source/bin/SABnzbd-Suite.py
@@ -374,8 +374,12 @@ except Exception,e:
 
 # CouchPotatoServer start
 try:
-    #convert password to md5
-    md5pwd =  hashlib.md5(pwd).hexdigest()
+    # empty password hack
+    if pwd == '':
+        md5pwd = ''
+    else:
+        #convert password to md5
+        md5pwd =  hashlib.md5(str(pwd)).hexdigest()
 
     # write CouchPotatoServer settings
     # --------------------------


### PR DESCRIPTION
If CouchPotato V2 password is empty md5sum always configure "d41d8cd98f00b204e9800998ecf8427e" for password area and because of this blocking for without password api calls.
