### PR TITLE
add bmc_sta to Generic image for Mac mini users, closes #490

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -170,7 +170,7 @@
 # asix-ax887xx:     Asix AX887xx USB LAN Driver
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="asix-ax887xx AF9035"
-  ADDITIONAL_DRIVERS="asix-ax887xx"
+  ADDITIONAL_DRIVERS="asix-ax887xx bcm_sta"
   if [ "$PVR" = yes ]; then
     ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS AF9035 A867 aver_h826d RTL2832 hdhomerun-driver vtuner-driver"
   fi


### PR DESCRIPTION
a number of Mac mini models require the same Broadcom driver as the AppleTV to get WLAN working but the driver is not currently included in the Generic image
