### PR TITLE
add edid.bin content and comments to xorg-nvidia.conf

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/config/xorg-nvidia.conf
+++ b/packages/x11/driver/xf86-video-nvidia/config/xorg-nvidia.conf
@@ -8,7 +8,13 @@ Section "Device"
     Option         "FlatPanelProperties" "Scaling = Native"
     Option         "ModeValidation" "NoVesaModes, NoXServerModes"
     Option         "HWCursor" "false"
+    # To put Xorg in debug mode change "false" to "true" in the line below:
     Option         "ModeDebug" "false"
+    # To use a local edid.bin file uncomment the 4 lines below (change DFP-0 to match your card)
+#    Option         "ConnectedMonitor" "DFP-0"
+#    Option         "CustomEDID" "DFP-0:/storage/.config/edid.bin"
+#    Option         "IgnoreEDID" "false"
+#    Option         "UseEDID" "true"
 EndSection
 
 Section "Screen"


### PR DESCRIPTION
adding markup to make things easier for users who need to use a local edid.bin file.. these changes have no impact on normal use unless you copy the file to .config and start uncommenting things
