### PR TITLE
Mesa: mklib: use target ar / gcc / g++. tryfix #890

### DIFF
--- a/packages/graphics/Mesa/patches/Mesa-8.0.3-03_cross_compile.patch
+++ b/packages/graphics/Mesa/patches/Mesa-8.0.3-03_cross_compile.patch
@@ -1,0 +1,36 @@
+diff --git a/bin/mklib b/bin/mklib
+index 9bac29e..b8fac2c 100755
+--- a/bin/mklib
++++ b/bin/mklib
+@@ -49,8 +49,8 @@ expand_archives() {
+                     /*) ;;
+                     *)  FILE="$ORIG_DIR/$FILE" ;;
+                 esac
+-                MEMBERS=`ar t $FILE`
+-                ar x $FILE
++                MEMBERS=`$AR t $FILE`
++                $AR x $FILE
+                 for MEMBER in $MEMBERS ; do
+                     NEWFILES="$NEWFILES $DIR/$MEMBER"
+                 done
+@@ -87,7 +87,7 @@ make_ar_static_lib() {
+     rm -f ${LIBNAME}
+ 
+     # make static lib
+-    ar ${OPTS} ${LIBNAME} ${OBJECTS}
++    $AR ${OPTS} ${LIBNAME} ${OBJECTS}
+ 
+     # run ranlib
+     if [ ${RANLIB} = 1 ] ; then
+@@ -313,9 +313,9 @@ case $ARCH in
+ 	if [ "x$LINK" = "x" ] ; then
+ 	    # -linker was not specified so set default link command now
+             if [ $CPLUSPLUS = 1 ] ; then
+-                LINK=g++
++                LINK=$CXX
+             else
+-                LINK=gcc
++                LINK=$CC
+             fi
+ 	fi
+ 


### PR DESCRIPTION
looks good on my machine but I think this should be tested on i386 host / x86_64 target and vice-versa

> mklib: Making Linux shared library:  ../../lib/libdricore.so
> mklib: Making Linux static library:  libmesa.a
> mklib: Making Linux static library:  libmesagallium.a
> /root/OpenELEC.tv/build.OpenELEC_PVR-Intel.x86_64-devel/toolchain/bin/x86_64-openelec-linux-gnu-ar: creating libmesa.a
> /root/OpenELEC.tv/build.OpenELEC_PVR-Intel.x86_64-devel/toolchain/bin/x86_64-openelec-linux-gnu-ar: creating libmesagallium.a
