### PR TITLE
SDL: fix Axis 0 (left stick x) always returns 0

### DIFF
--- a/packages/multimedia/SDL/patches/SDL-1.2.15-11_joystick_misc_axes.patch
+++ b/packages/multimedia/SDL/patches/SDL-1.2.15-11_joystick_misc_axes.patch
@@ -1,0 +1,13 @@
+diff --git a/src/joystick/linux/SDL_sysjoystick.c b/src/joystick/linux/SDL_sysjoystick.c
+index ee43974..80e46e4 100644
+--- a/src/joystick/linux/SDL_sysjoystick.c
++++ b/src/joystick/linux/SDL_sysjoystick.c
+@@ -702,7 +702,7 @@ static SDL_bool EV_ConfigJoystick(SDL_Joystick *joystick, int fd)
+ 				++joystick->nbuttons;
+ 			}
+ 		}
+-		for ( i=0; i<ABS_MISC; ++i ) {
++		for ( i=0; i<ABS_MAX; ++i ) {
+ 			/* Skip hats */
+ 			if ( i == ABS_HAT0X ) {
+ 				i = ABS_HAT3Y;


### PR DESCRIPTION
if this works - should close #900
SDL-1.2.15-10_joystick_test_update.patch adapted from http://bugzilla.libsdl.org/attachment.cgi?id=840

@sraue please do not merge unless someone confirms that it is working.
