### PR TITLE
Fix playback of DVB subtitles from tvheadend recordings

### DIFF
--- a/packages/multimedia/ffmpeg/patches/ffmpeg-0.10.4-0031-add-S_DVBSUB-to-list-of-codecs-in-mkv-containers.patch
+++ b/packages/multimedia/ffmpeg/patches/ffmpeg-0.10.4-0031-add-S_DVBSUB-to-list-of-codecs-in-mkv-containers.patch
@@ -1,0 +1,10 @@
+--- a/libavformat/matroska.c	2012-07-07 03:11:59.514972002 -0700
++++ b/libavformat/matroska.c	2012-07-07 03:12:49.054969249 -0700
+@@ -59,6 +59,7 @@
+     {"S_ASS"            , CODEC_ID_SSA},
+     {"S_SSA"            , CODEC_ID_SSA},
+     {"S_VOBSUB"         , CODEC_ID_DVD_SUBTITLE},
++    {"S_DVBSUB"         , CODEC_ID_DVB_SUBTITLE},
+     {"S_HDMV/PGS"       , CODEC_ID_HDMV_PGS_SUBTITLE},
+ 
+     {"V_DIRAC"          , CODEC_ID_DIRAC},


### PR DESCRIPTION
This makes it possible to use the DVB subtitle tracks written by e.g. tvheadend
(essentially, this is the one-line patch referred to in http://lists.matroska.org/pipermail/matroska-devel/2011-February/003983.html)

Note: Until ffmpeg, tvheadend et.al. get around to implementing S_DVBSUB in MKV according to the agreed method (see http://lists.matroska.org/pipermail/matroska-devel/2011-February/003978.html), this oneliner will allow tvheadend users to view the DVB subtitles in their mkv-recordings.
