### PR TITLE
Reference the shorthash of the commit instead of logcount

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -35,9 +35,9 @@ export INSTALL=$BUILD/image/system
 BUILD_DATE=`date +%Y%m%d%H%M%S`
 
 if [ "$OPENELEC_VERSION" = devel -o "$OPENELEC_VERSION" = debug ]; then
-  GIT_BUILD=`git log --pretty=format:'' | wc -l`
+  GIT_BUILD=`git log -n1 --format=%h`
   GIT_HASH=`git log -n1 --format=%H`
-  OPENELEC_VERSION=$OPENELEC_VERSION-$BUILD_DATE-r$GIT_BUILD
+  OPENELEC_VERSION=$OPENELEC_VERSION-$BUILD_DATE-$GIT_BUILD
 fi
 
 TARGET_VERSION="$PROJECT.$TARGET_ARCH-$OPENELEC_VERSION"


### PR DESCRIPTION
It's kind of odd that the OpenELEC builds add a logcount number to the end of the build. This format serves no real purpose and gives little information on what revision the build was actually made on. Even the date is a better reference.

This patch updates the GIT_BUILD variable to contain a shorthash which can be used to identify the exact revision the build was done on. Since the variable isn't used anywhere else (at least in the OpenELEC repo) this should be a relatively safe change.
