### PR TITLE
Update xf86-video-intel to 2.20.0 from 2.19.0

### DIFF
--- a/packages/x11/driver/xf86-video-intel/meta
+++ b/packages/x11/driver/xf86-video-intel/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="2.19.0"
+PKG_VERSION="2.20.0"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
This new version fixes a host of SNA-related bugs.  The full release announcement can be seen here: http://lists.x.org/archives/xorg-announce/2012-July/002004.html

Additionally, this release contains a fix for an issue that would disable HDMI output on resume from S3 suspend when connected to a receiver. See https://bugs.freedesktop.org/show_bug.cgi?id=50078 for more information.
