### PR TITLE
Update libcec to 1.7.1

### DIFF
--- a/packages/devel/libcec/meta
+++ b/packages/devel/libcec/meta
@@ -19,12 +19,12 @@
 ################################################################################
 
 PKG_NAME="libcec"
-PKG_VERSION="ab37938"
+PKG_VERSION="1.7.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libcec.pulse-eight.com/"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://packages.pulse-eight.net/pulse/sources/libcec/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS="systemd lockdev"
 PKG_BUILD_DEPENDS="toolchain systemd lockdev"
 PKG_PRIORITY="optional"


### PR DESCRIPTION
XBMC Frodo builds need at least libcec 1.6.0 for libcec support, but the version currently being used is still 1.5 or so. So XBMC Frodo builds are always (silently) getting build without libcec support which means the Pulse-Eight USB-CEC adapter doesn't work. This will update libcec to the latest 1.7.1 release.
