### PR TITLE
fixed: don't match /source/ subdirectories in the PKG_DIR check

### DIFF
--- a/config/path
+++ b/config/path
@@ -55,7 +55,7 @@ SED="sed -i"
   PKG_IS_ADDON="no"
 
   if [ -n "$1" ]; then
-    PKG_DIR=`find $PACKAGES -type d -name $1 2>/dev/null`
+    PKG_DIR=`find $PACKAGES -type d -name $1 ! -wholename \*\/source\/\* 2>/dev/null`
     if [ "${PKG_DIR}" != "$(echo $PKG_DIR | tr -d '\n')" ]; then
       echo "Error - multiple package folders:"
       echo "$PKG_DIR"


### PR DESCRIPTION
I have a /xbmc subdirectory in one of my custom packages (python add-on), which this script didn't like.
changed so it won't match subdirectories of /source/
