### PR TITLE
xbmc: add patch - linuxrenderer: delete texture targets on reconfigure

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-11.0.1-902.12-linuxrenderer_delete_texture_targets_on_reconfigure.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-11.0.1-902.12-linuxrenderer_delete_texture_targets_on_reconfigure.patch
@@ -1,0 +1,29 @@
+From 9687cc6b6f90fb40e39060eff9e4d8283254b770 Mon Sep 17 00:00:00 2001
+From: xbmc <fernetmenta@online.de>
+Date: Fri, 13 Jul 2012 18:57:37 +0200
+Subject: [PATCH] linuxrenderer: delete texture targets on reconfigure
+
+---
+ xbmc/cores/VideoRenderers/LinuxRendererGL.cpp |    6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+index 7c46cfd..85fc50c 100644
+--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
++++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+@@ -261,6 +261,12 @@ bool CLinuxRendererGL::ValidateRenderTarget()
+     else
+       CLog::Log(LOGNOTICE,"Using GL_TEXTURE_2D");
+ 
++    // function pointer for texture might change in
++    // call to LoadShaders
++    glFinish();
++    for (int i = 0 ; i < m_NumYV12Buffers ; i++)
++      (this->*m_textureDelete)(i);
++
+      // create the yuv textures
+     LoadShaders();
+ 
+-- 
+1.7.10
+

--- a/packages/mediacenter/xbmc/patches/xbmc-pvr-11.0.1-902.12-linuxrenderer_delete_texture_targets_on_reconfigure.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-pvr-11.0.1-902.12-linuxrenderer_delete_texture_targets_on_reconfigure.patch
@@ -1,0 +1,29 @@
+From 9687cc6b6f90fb40e39060eff9e4d8283254b770 Mon Sep 17 00:00:00 2001
+From: xbmc <fernetmenta@online.de>
+Date: Fri, 13 Jul 2012 18:57:37 +0200
+Subject: [PATCH] linuxrenderer: delete texture targets on reconfigure
+
+---
+ xbmc/cores/VideoRenderers/LinuxRendererGL.cpp |    6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+index 7c46cfd..85fc50c 100644
+--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
++++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.cpp
+@@ -261,6 +261,12 @@ bool CLinuxRendererGL::ValidateRenderTarget()
+     else
+       CLog::Log(LOGNOTICE,"Using GL_TEXTURE_2D");
+ 
++    // function pointer for texture might change in
++    // call to LoadShaders
++    glFinish();
++    for (int i = 0 ; i < m_NumYV12Buffers ; i++)
++      (this->*m_textureDelete)(i);
++
+      // create the yuv textures
+     LoadShaders();
+ 
+-- 
+1.7.10
+


### PR DESCRIPTION
This fixes problems with switching between channels on xbmc-pvr. As it is general XBMC fix I included it for both xbmc versions.

Here is also the issue which I created on fernetmenta xbmc repository:
https://github.com/FernetMenta/xbmc/issues/64
