### PR TITLE
add logic to start connman in debug mode

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -270,7 +270,11 @@ set_interface() {
     set_interface
     set_hwclock
 
-    /usr/sbin/connmand -n > /dev/null 2>&1
+    if [ -f $HOME/.config/debug.connman ]; then
+      /usr/sbin/connmand -nd > /dev/null 2>&1
+    else
+      /usr/sbin/connmand -n > /dev/null 2>&1
+    fi
     usleep 250000
   done
 )&


### PR DESCRIPTION
allow a simple and persistent way to start connman in debug mode to assist with networking diagnostics
