### PR TITLE
updating to zlib 1.2.7

### DIFF
--- a/packages/compress/zlib/meta
+++ b/packages/compress/zlib/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="zlib"
-PKG_VERSION="1.2.6"
+PKG_VERSION="1.2.7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
I have updated the zlib version to 1.2.7 which was already supposed to be fixed in #579 #586 This is for the RaspberryPi build
