### PR TITLE
/dev/loop0 support requires additional flags on formatting and mounting

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/create_sdcard
+++ b/packages/tools/bcm2835-bootloader/files/create_sdcard
@@ -213,6 +213,7 @@ echo "#########################################################"
 
 # remount loopback device
   if [ "$DISK" = "/dev/loop0" ]; then
+    sync
     losetup -d $DISK
     losetup $DISK $IMGFILE -o 1048576 --sizelimit 131071488
     PART1=$DISK


### PR DESCRIPTION
also added a sync to ensure clean losetup -d
