### PR TITLE
Easily deploy your new OpenELEC image

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -252,6 +252,15 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
         fi
       )
 
+    # automatic deployment 
+    if [ -z "$DEPLOY_TO_OPENELEC_APPLIANCE" ]; then
+      echo "You can define the DEPLOY_TO_OPENELEC_APPLIANCE variable to contain the IP/hostname of your OpenELEC machine for automatic deployment of the new image to it."
+    else
+      echo "Deploying the new image to $DEPLOY_TO_OPENELEC_APPLIANCE"
+      scp $RELEASE_DIR/target/* root@$DEPLOY_TO_OPENELEC_APPLIANCE:/storage/.update/
+      ssh root@$DEPLOY_TO_OPENELEC_APPLIANCE reboot &
+    fi
+
     # create target directory
       mkdir -p $TARGET_IMG
 


### PR DESCRIPTION
If the DEPLOY_TO_OPENELEC_APPLIANCE variable is defined in the
environment, (it should contain the IP/hostname of your OpenELEC
appliance), at the end of the building process the newly built image
would be uploaded automatically over SCP to it. The /flash filesystem
will be temporarily remounted in read-write mode to make this transfer
possible. It is recommended that you configure SSH key login to the
appliance.

If the variable is not defined a message would be shown, telling the
user about the existence of this possibility.
