### PR TITLE
Update vboxguest to 4.2.0 for building on 3.5.x kernels

### DIFF
--- a/packages/linux-drivers/vboxguest/meta
+++ b/packages/linux-drivers/vboxguest/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="vboxguest"
-PKG_VERSION="4.1.18"
+PKG_VERSION="4.2.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
updated package is on sources.openelec.tv
