### PR TITLE
libxslt: update to libxslt-1.1.27

### DIFF
--- a/packages/3rdparty/lib/libxslt/meta
+++ b/packages/3rdparty/lib/libxslt/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="libxslt"
-PKG_VERSION="1.1.26"
+PKG_VERSION="1.1.27"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"


### PR DESCRIPTION
Needed for VDR addon.
