### PR TITLE
eglibc: add libdir to configparms

### DIFF
--- a/packages/toolchain/devel/eglibc/build
+++ b/packages/toolchain/devel/eglibc/build
@@ -119,6 +119,7 @@ EOF
 
 cat >configparms <<EOF
 slibdir=/lib
+libdir=/usr/lib
 EOF
 
 ../configure --host=$TARGET_NAME \


### PR DESCRIPTION
Sometimes eglibc is installed into wrong folder (lib64 instead of lib). I couldn't figure out why but setting folder in configparms helps.

linker error:
.../ld: cannot find crti.o: No such file or directory
.../ld: cannot find -lc
.../ld: cannot find crtn.o: No such file or directory

forum reference: http://openelec.tv/forum/64-installation/48318-error--libgccsso-error-1#48318
