### PR TITLE
libvdpau: fix for blue faces in flash video with opera addon

### DIFF
--- a/packages/multimedia/libvdpau/patches/libvdpau-0.5-opera_flash_blue.patch
+++ b/packages/multimedia/libvdpau/patches/libvdpau-0.5-opera_flash_blue.patch
@@ -1,0 +1,12 @@
+diff -uNr libvdpau-0.5-orig/src/vdpau_wrapper.c libvdpau-0.5/src/vdpau_wrapper.c
+--- libvdpau-0.5-orig/src/vdpau_wrapper.c	2012-09-04 19:26:33.000000000 +0200
++++ libvdpau-0.5/src/vdpau_wrapper.c	2012-10-14 17:05:52.000000000 +0200
+@@ -320,7 +320,7 @@
+     }
+     buffer[ret] = '\0';
+ 
+-    if (strstr(buffer, "libflashplayer") != NULL) {
++    if (strstr(buffer, "libflashplayer") != NULL || strstr(buffer, "operapluginwrapper") != NULL) {
+         _running_under_flash = 1;
+     }
+ }


### PR DESCRIPTION
Searching for additional string operapluginwrapper in /proc/self/cmdline instead for only libflashplayer.
