### PR TITLE
add 'upower' to ATV project

### DIFF
--- a/projects/ATV/options
+++ b/projects/ATV/options
@@ -205,7 +205,7 @@
   UDISKS="yes"
 
 # build and install powermanagement support (upower) (yes / no)
-  UPOWER="no"
+  UPOWER="yes"
 
 # build and install exFAT fuse support (yes / no)
   EXFAT="yes"


### PR DESCRIPTION
add upower to the ATV image so XBMC can detect the power options the ATV does not have; removes unusable suspend/hibernation options from various GUI menus
