### PR TITLE
Cleanup patch

### DIFF
--- a/packages/linux/patches/linux-3.2.31-059.02-media-rc-Make-probe-cleanup-goto-labels-more-verbose.patch
+++ b/packages/linux/patches/linux-3.2.31-059.02-media-rc-Make-probe-cleanup-goto-labels-more-verbose.patch
@@ -208,8 +208,6 @@ index ab30c64..8284d28 100644
  	rc_free_device(rdev);
  	kfree(fintek);
  
-diff --git a/drivers/media/rc/gpio-ir-recv.c b/drivers/media/rc/gpio-ir-recv.c
-index 04cb272..0c03b7d 100644
 diff --git a/drivers/media/rc/ite-cir.c b/drivers/media/rc/ite-cir.c
 index 36fe5a3..77cb21f 100644
 --- a/drivers/media/rc/ite-cir.c


### PR DESCRIPTION
Newer patch versions support so called "git format".  This patch
contains bogus header for non existant file, patch fails to apply.

Signed-off-by: Alexey I. Froloff raorn@raorn.name
