### PR TITLE
Update projects/RPi/xbmc/advancedsettings.xml

### DIFF
--- a/projects/RPi/xbmc/advancedsettings.xml
+++ b/projects/RPi/xbmc/advancedsettings.xml
@@ -7,10 +7,10 @@
   <showexitbutton>false</showexitbutton>
 
   <destroywindowcontrols>false</destroywindowcontrols>
-  <fanartheight>540</fanartheight>
-  <thumbsize>256</thumbsize>
+  <fanartres>540</fanartres>
+  <imageres>256</imageres>
   <bginfoloadermaxthreads>2</bginfoloadermaxthreads>
-  <useddsfanart>true</useddsfanart>
+  <useddsfanart>false</useddsfanart>
 
   <video>
     <defaultplayer>omxplayer</defaultplayer>


### PR DESCRIPTION
< fanartheight > 540 < / fanartheight >
< thumbsize > 256 < / thumbsize >

is deprecated, use

< fanartres > 540 < / fanartres >
< imageres > 256 < / imageres >

Change
< useddsfanart > true < / useddsfanart >

to

false

useddsfanart is not needed anymore and can hurt from the GPU memory side.

P.S.

Maybe time to raise thumbsize to 512 for a bit better resolution, I don't see an issue after a week of testing
