### PR TITLE
Corrections for create of /var/config/settings.conf

### DIFF
--- a/packages/sysutils/busybox/init.d/06_systemconfig
+++ b/packages/sysutils/busybox/init.d/06_systemconfig
@@ -30,6 +30,6 @@ if [ -f "$OPENELEC_SETTINGS" ]; then
     
     mkdir -p /var/config
     cat "$OPENELEC_SETTINGS" \
-        | awk -F'[\"|'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "\\&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); print $2"=\""$4"\"";}' \
+        | awk -F'["'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "\\&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); gsub(/\$/, "\\\$", $4); print $2"=\""$4"\"";}' \
         | sed '/^=/d' > /var/config/settings.conf
 fi


### PR DESCRIPTION
- Busybox awk does not interpret the -F option as regular expression. With this patch the field seperators are '" and not \"|'
- Added gsub for $ so that it becomes \$. This is because the generated config file assignes string with "" to variables. Insite "" the $ sign is used to reference variables.

This problem was discovered with a wlan passphrase that included a \ and & sign. Here is a example string that can be used to reproduce both problems:

```
<setting id="TEST_KEY" value="$-you_can_see_me\you_can_not_see_me" />
```

Here is what we get before merge:

```
echo '<setting id="TEST_KEY" value="$-you_can_see_me\you_can_not_see_me" />' | awk -F'[\"|'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "\\&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); print $2"=\""$4"\"";}'
TEST_KEY="$-you_can_see_me"
```

Here is what we get after merge:

```
echo '<setting id="TEST_KEY" value="$-you_can_see_me\you_can_not_see_me" />' | awk -F'["'\'']' '{gsub(/\&quot\;/, "\\\"", $4); gsub(/\&apos\;/, "\047", $4); gsub(/\&amp\;/, "\\&", $4); gsub(/\&lt\;/, "<", $4); gsub(/\&gt\;/, ">", $4); gsub(/\$/, "\\\$", $4); print $2"=\""$4"\"";}'
TEST_KEY="\$-you_can_see_me\you_can_not_see_me"
```
