### PR TITLE
Fixes #947

### DIFF
--- a/packages/network/samba/patches/samba-3.6.8-400-reset_ntlmv2.patch
+++ b/packages/network/samba/patches/samba-3.6.8-400-reset_ntlmv2.patch
@@ -1,0 +1,11 @@
+--- samba-3.6.8/source3/param/loadparm.c	2012-09-14 02:12:09.000000000 -0600
++++ samba-3.6.8-b/source3/param/loadparm.c	2012-11-25 15:53:07.543125017 -0700
+@@ -5336,7 +5336,7 @@
+ 	Globals.bClientPlaintextAuth = False;	/* Do NOT use a plaintext password even if is requested by the server */
+ 	Globals.bLanmanAuth = False;	/* Do NOT use the LanMan hash, even if it is supplied */
+ 	Globals.bNTLMAuth = True;	/* Do use NTLMv1 if it is supplied by the client (otherwise NTLMv2) */
+-	Globals.bClientNTLMv2Auth = True; /* Client should always use use NTLMv2, as we can't tell that the server supports it, but most modern servers do */
++	Globals.bClientNTLMv2Auth = False; /* Client should always use use NTLMv2, as we can't tell that the server supports it, but most modern servers do */
+ 	/* Note, that we will also use NTLM2 session security (which is different), if it is available */
+ 
+ 	Globals.map_to_guest = 0;	/* By Default, "Never" */


### PR DESCRIPTION
When upgrading to samba 3.6.x they changed the default for NTLMv2 auth
from false to true. This causes xbmc to fail to connec to OpenSolaris
based distros like Nexenta or IllumOS which use the native in kernel
CIFS server. This patch resets the default back to false.

https://github.com/OpenELEC/OpenELEC.tv/issues/947
