### PR TITLE
Upgrade to fglrx 12.10

### DIFF
--- a/packages/x11/driver/xf86-video-fglrx/build
+++ b/packages/x11/driver/xf86-video-fglrx/build
@@ -34,7 +34,7 @@ fi
 
 INSTALL_DIR=".install/usr/lib/fglrx/"
 
-cd $PKG_BUILD/lib/modules/fglrx/build_mod
+cd $PKG_BUILD/common/lib/modules/fglrx/build_mod
   ln -sf $ROOT/$PKG_BUILD/arch/$FGLRX_ARCH/lib/modules/fglrx/build_mod/libfglrx_ip.a .
 
   cd 2.6.x
@@ -45,9 +45,9 @@ cd $ROOT/$PKG_BUILD
 
 # config files
   mkdir -p $INSTALL_DIR/etc/ati
-    cp etc/ati/amdpcsdb.default $INSTALL_DIR/etc/ati
-    cp etc/ati/control $INSTALL_DIR/etc/ati
-    cp etc/ati/signature $INSTALL_DIR/etc/ati
+    cp common/etc/ati/amdpcsdb.default $INSTALL_DIR/etc/ati
+    cp common/etc/ati/control $INSTALL_DIR/etc/ati
+    cp common/etc/ati/signature $INSTALL_DIR/etc/ati
     ln -sf /storage/.config/fglrx.conf $INSTALL_DIR/etc/ati/amdpcsdb
 
 (

--- a/packages/x11/driver/xf86-video-fglrx/install
+++ b/packages/x11/driver/xf86-video-fglrx/install
@@ -26,7 +26,7 @@ VER=`ls $BUILD/linux*/modules/lib/modules`
 
 # ATI kernel driver
 mkdir -p $INSTALL/lib/modules/$VER/ati
-  cp $PKG_BUILD/lib/modules/fglrx/build_mod/2.6.x/fglrx.ko $INSTALL/lib/modules/$VER/ati
+  cp $PKG_BUILD/common/lib/modules/fglrx/build_mod/2.6.x/fglrx.ko $INSTALL/lib/modules/$VER/ati
 
 mkdir -p $INSTALL/etc/X11
   cp $PKG_DIR/config/*.conf $INSTALL/etc/X11

--- a/packages/x11/driver/xf86-video-fglrx/meta
+++ b/packages/x11/driver/xf86-video-fglrx/meta
@@ -19,14 +19,12 @@
 ################################################################################
 
 PKG_NAME="xf86-video-fglrx"
-PKG_VERSION="12.9-ubuntu"
+PKG_VERSION="12.10"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64"
 PKG_LICENSE="nonfree"
 PKG_SITE="http://www.ati.com/"
-# PKG_URL="http://www2.ati.com/drivers/linux/amd-driver-installer-`echo $PKG_VERSION | sed 's/\./-/'`-x86.x86_64.run"
-# use ubuntus package from http://archive.ubuntu.com/ubuntu/pool/restricted/f/fglrx-installer/fglrx-installer_9.000.orig.tar.gz
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://www2.ati.com/drivers/linux/amd-driver-installer-`echo $PKG_VERSION | sed 's/\./-/'`-x86.x86_64.run"
 PKG_DEPENDS="linux libX11 libXinerama libXcomposite"
 PKG_BUILD_DEPENDS="toolchain util-macros libX11 libXinerama libXcomposite linux"
 PKG_PRIORITY="optional"


### PR DESCRIPTION
Get back to the "stable" branch.  Hopefully we can upgrade to 12.12 later in December. 12.10 worked for at least 3 people that had sever problems with 12.9Quantal. Let's test it during beta and gather regressions.
