### PR TITLE
vdr-plugin-xmltv2vdr: fix building epgdata2xmltv

### DIFF
--- a/packages/3rdparty/multimedia/vdr-plugin-xmltv2vdr/build
+++ b/packages/3rdparty/multimedia/vdr-plugin-xmltv2vdr/build
@@ -27,4 +27,5 @@ cd $PKG_BUILD
   PWD=`pwd`
   make VDRDIR="$PWD/../$VDR_DIR" LIBDIR="." LOCALEDIR="./locale"
   cd dist/epgdata2xmltv
-  make
+  make -j1
+


### PR DESCRIPTION
This fixes #1519.
