### PR TITLE
ffmpeg requires vdpau, or it silently fails

### DIFF
--- a/packages/multimedia/ffmpeg/meta
+++ b/packages/multimedia/ffmpeg/meta
@@ -39,3 +39,8 @@ if [ "$VAAPI" = yes ]; then
   PKG_BUILD_DEPENDS="$PKG_BUILD_DEPENDS libva"
   PKG_DEPENDS="$PKG_DEPENDS libva"
 fi
+
+if [ "$VDPAU" = yes ]; then
+  PKG_BUILD_DEPENDS="$PKG_BUILD_DEPENDS libvdpau"
+  PKG_DEPENDS="$PKG_DEPENDS libvdpau"
+fi


### PR DESCRIPTION
I got a failure when building xbmc, saying that "external ffmpeg does
not support vdpau". Going through the vdpau build logs, it seems that
vdpau was not installed prior to the ffmpeg bulid, and ffmpeg silently
installed without it.
