### PR TITLE
Properly count the number of commits

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -35,8 +35,8 @@ export INSTALL=$BUILD/image/system
 BUILD_DATE=`date +%Y%m%d%H%M%S`
 
 if [ "$OPENELEC_VERSION" = devel -o "$OPENELEC_VERSION" = debug ]; then
-  GIT_BUILD=`git log --pretty=format:'' | wc -l`
-  GIT_HASH=`git log -n1 --format=%H`
+  GIT_BUILD=`git rev-list HEAD | wc -l`
+  GIT_HASH=`git rev-parse HEAD`
   OPENELEC_VERSION=$OPENELEC_VERSION-$BUILD_DATE-r$GIT_BUILD
 fi
 


### PR DESCRIPTION
The "git log --pretty=format:" command eats up the line feed for the
last commit, and thus "wc -l" counts one commit less than there are.
This is easy to demonstrate with:

$ git log '2.95.3^..2.95.3' --oneline
e84de34 config/version: set version to 2.95.3 (OpenELEC-3.0 Beta 3)

$ git log '2.95.3^..2.95.3' --pretty=format: | wc -l
0

Even though this is a minor discrepancy, "git rev-list" and "git
rev-parse" are simpler and more accurate tools for this task (their
output format is not going to change).
