### PR TITLE
transmission: update to transmission-2.74

### DIFF
--- a/packages/addons/service/downloadmanager/transmission/changelog.txt
+++ b/packages/addons/service/downloadmanager/transmission/changelog.txt
@@ -1,3 +1,6 @@
+3.0.2
+- update to transmission-2.74
+
 3.0.1
 - bump addon version
 - update to transmission-2.73

--- a/packages/addons/service/downloadmanager/transmission/meta
+++ b/packages/addons/service/downloadmanager/transmission/meta
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="transmission"
-PKG_VERSION="2.73"
-PKG_REV="1"
+PKG_VERSION="2.74"
+PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.transmissionbt.com/"


### PR DESCRIPTION
Transmission 2.75 just for Mac. There is no 2.75 source code. We need 2.74.
