### PR TITLE
connman: add -linklocal-routes.patch

### DIFF
--- a/packages/network/connman/patches/connman-1.9_20-linklocal-routes.patch
+++ b/packages/network/connman/patches/connman-1.9_20-linklocal-routes.patch
@@ -1,0 +1,45 @@
+diff --git a/src/connection.c b/src/connection.c
+index c7b1f62..3caeb47 100644
+--- a/src/connection.c
++++ b/src/connection.c
+@@ -413,6 +413,20 @@ static struct gateway_data *add_gateway(struct connman_service *service,
+ 	return data;
+ }
+ 
++static void linklocal_add_routes(int index)
++{
++	DBG("169.254.0.0/16 index %d", index);
++	connman_inet_add_network_route(index, "169.254.0.0",
++					NULL,
++					"255.255.0.0");
++}
++
++static void linklocal_del_routes(int index)
++{
++	DBG("del 169.254.0.0/16 index %d", index);
++	connman_inet_del_network_route(index, "169.254.0.0");
++}
++
+ static void set_default_gateway(struct gateway_data *data,
+ 				enum connman_ipconfig_type type)
+ {
+@@ -681,6 +695,9 @@ static void connection_newgateway(int index, const char *gateway)
+ 		if (data->ipv4_gateway != NULL)
+ 			set_default_gateway(data, CONNMAN_IPCONFIG_TYPE_IPV4);
+ 
++		if (data->ipv4_gateway != NULL)
++			linklocal_add_routes(index);
++
+ 		if (data->ipv6_gateway != NULL)
+ 			set_default_gateway(data, CONNMAN_IPCONFIG_TYPE_IPV6);
+ 	}
+@@ -725,6 +742,9 @@ static void connection_delgateway(int index, const char *gateway)
+ 	data = find_default_gateway();
+ 	if (data != NULL)
+ 		set_default_gateway(data, CONNMAN_IPCONFIG_TYPE_ALL);
++
++	if (data != NULL)
++		linklocal_del_routes(index);
+ }
+ 
+ static struct connman_rtnl connection_rtnl = {


### PR DESCRIPTION
the purpose of this patch is to (re)add a 169.254.0.0/16 static route every time a default gateway is set on an interface

I have tested it on my htpc and it works, but I can not test on a configuration with more than 1 active interface. I hope @vpeter4 and @mindnever could help here.

another important thing, I am not sure how this should be implemented because I am not much familiar with connman internals, so basicaly it is a workaround.

almost 100% sure that this patch will not do any unexpected damage, but pls don't merge yet until anyone confirms that it's fine on a setup with more than 1 network interfaces.

if merged, should fix #1619
