### PR TITLE
21_network: Change hwclock-call from --UTC to implicit

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -102,7 +102,7 @@ set_hwclock() {
       # sleep 30 seconds before hw clock is synced
       usleep 30000000
       progress "syncing hardware clock with system clock"
-      /sbin/hwclock --systohc --utc
+      /sbin/hwclock --systohc
     )&
   fi
 }


### PR DESCRIPTION
Using --UTC is not consistent with other uses of hwclock in the scripts, resulting in the RTC to shift one or more hours every reboot. Calling hwclock with --UTC would only be correct if there were a write-call with explicit --UTC, otherwise it's best to omit it.

Have a look at the 90clock-script in /user/lib/pm-utils/sleep.d: All read- and write-calls to hwclock are implicit without either --UTC or --localtime.
