### PR TITLE
libmicrohttpd: Building 0.9.24 fails on missing .texi files

### DIFF
--- a/packages/web/libmicrohttpd/meta
+++ b/packages/web/libmicrohttpd/meta
@@ -33,4 +33,4 @@ PKG_SHORTDESC="libmicrohttpd: a small webserver C library"
 PKG_LONGDESC="GNU libmicrohttpd is a small C library that is supposed to make it easy to run an HTTP server as part of another application."
 PKG_IS_ADDON="no"
 
-PKG_AUTORECONF="yes"
+PKG_AUTORECONF="no"


### PR DESCRIPTION
Instead of a proper fix I am just tricking the build into completing.
After all, we don't care much about the documentation.

The actual error is:

```
$ ./scripts/build libmicrohttpd
...
rm -rf $backupdir; exit $rc
libmicrohttpd.texi:2132: @include `lgpl.texi': No such file or directory.
libmicrohttpd.texi:2136: @include `ecos.texi': No such file or directory.
libmicrohttpd.texi:2140: @include `fdl-1.3.texi': No such file or directory.
makeinfo: Removing output file `libmicrohttpd.info' due to errors; use --force to preserve.
make[1]: *** [libmicrohttpd.info] Error 1
```
