### PR TITLE
new package: add package 'libdvbcsa'

### DIFF
--- a/packages/3rdparty/lib/libdvbcsa/build
+++ b/packages/3rdparty/lib/libdvbcsa/build
@@ -1,0 +1,13 @@
+#!/bin/sh
+
+. config/options $1
+
+cd $PKG_BUILD
+
+./configure --host=$TARGET_NAME \
+            --build=$HOST_NAME \
+            --prefix=/usr \
+            --disable-shared \
+            --enable-static
+
+$MAKEINSTALL

--- a/packages/3rdparty/lib/libdvbcsa/meta
+++ b/packages/3rdparty/lib/libdvbcsa/meta
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="libdvbcsa"
+PKG_VERSION="1.1.0"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="LGPL"
+PKG_SITE="http://www.videolan.org/developers/libdvbcsa.html"
+PKG_URL="http://download.videolan.org/pub/videolan/libdvbcsa/${PKG_VERSION}/libdvbcsa-${PKG_VERSION}.tar.gz"
+PKG_DEPENDS=""
+PKG_BUILD_DEPENDS="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="lib"
+PKG_SHORTDESC="DVB/CSA implementation"
+PKG_LONGDESC="libdvbcsa is a free implementation of the DVB Common Scrambling Algorithm - DVB/CSA - with encryption and decryption capabilities"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"


### PR DESCRIPTION
TESTING: add libdvbcsa to buildsystem so people can test tvheadend with dvbcsa support. for me it works well but I don't see a performance increase as some people claim. 
this also could be better for embedded (arm). 
