### PR TITLE
Hwclock fix

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -102,7 +102,7 @@ set_hwclock() {
       # sleep 30 seconds before hw clock is synced
       usleep 30000000
       progress "syncing hardware clock with system clock"
-      /sbin/hwclock --systohc --utc
+      /sbin/hwclock --systohc
     )&
   fi
 }


### PR DESCRIPTION
packages/network/connman/init.d/21_network: Changed the call to hwclock, removed the explicit "--utc" because other scripts handle hwclock with default timezone, which is localtime, not UTC.

This is a resubmit of #1708, this time I put my pull request into a separate branch so it remains frozen. Sorrry, I'm new to github.

Without the fix, the systemtime is changed every reboot. For germany i.e., the clock will move backwards one hour every reboot. hwclock is called several times in OE, and all calls handle the RTC as localtime, with the exception of 21_network.
