### PR TITLE
Hi10p: Change Hi10p patch to be enabled by default

### DIFF
--- a/packages/mediacenter/xbmc/config/advancedsettings.xml
+++ b/packages/mediacenter/xbmc/config/advancedsettings.xml
@@ -13,7 +13,6 @@
         <delay>175</delay>
       </refresh>
     </latency>
-    <allowhi10pmultithreading>true</allowhi10pmultithreading>
   </video>
   <samba>
     <clienttimeout>30</clienttimeout>

--- a/packages/mediacenter/xbmc/patches/xbmc-f70eb43-601-add_multithread_support_for_hi10p-0.1.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-f70eb43-601-add_multithread_support_for_hi10p-0.1.patch
@@ -1,20 +1,21 @@
-From 29d0061ac7887ed8681847915d5d5bcd3af3fa9b Mon Sep 17 00:00:00 2001
+From ca0ddf0673dea966af5bf0bc562f9ff69a551cd9 Mon Sep 17 00:00:00 2001
 From: fritsch <peter.fruehberger@gmail.com>
 Date: Sat, 12 Jan 2013 13:03:50 +0100
-Subject: [PATCH] dvdplayer: Allow multithread decoding for hi10p content
+Subject: [PATCH] dvdplayer: Allow multithread decoding for hi10p content by
+ default
 
 This allows decoding of some hi10p material on e.g. AMD Fusion with
-both cores at the max. This introduces a new advancedsetting to get hi10p
-decoded multithreaded.
+both cores at the max. This introduces a new advancedsetting named
+disablehi10pmultithreading to disable hi10p decoded multithreaded.
 ---
- .../dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp |   17 +++++++++++++++--
- .../dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h   |    1 +
- xbmc/settings/AdvancedSettings.cpp                    |    2 ++
- xbmc/settings/AdvancedSettings.h                      |    1 +
- 4 files changed, 19 insertions(+), 2 deletions(-)
+ .../DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp          |   18 ++++++++++++++++--
+ .../dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.h  |    1 +
+ xbmc/settings/AdvancedSettings.cpp                   |    2 ++
+ xbmc/settings/AdvancedSettings.h                     |    1 +
+ 4 files changed, 20 insertions(+), 2 deletions(-)
 
 diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
-index 8f81637..8164457 100644
+index 8f81637..77ac6b1 100644
 --- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 +++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
 @@ -138,6 +138,7 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
@@ -36,7 +37,7 @@ index 8f81637..8164457 100644
        break;
      }
    }
-@@ -247,8 +251,17 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
+@@ -247,8 +251,18 @@ bool CDVDVideoCodecFFmpeg::Open(CDVDStreamInfo &hints, CDVDCodecOptions &options
    m_pCodecContext->codec_tag = hints.codec_tag;
    /* Only allow slice threading, since frame threading is more
     * sensitive to changes in frame sizes, and it causes crashes
@@ -44,12 +45,13 @@ index 8f81637..8164457 100644
 -  m_pCodecContext->thread_type = FF_THREAD_SLICE;
 +   * during HW accell - so we unset it in this case.
 +   *
-+   * When user forces it and codec is hi10p - we enable it again.
++   * When we detect Hi10p and user did not disable hi10pmultithreading
++   * via advancedsettings.xml we keep the ffmpeg default thread type.
 +   * */
-+  if(m_isHi10p && g_advancedSettings.m_videoAllowHi10pMultithreading)
++  if(m_isHi10p && !g_advancedSettings.m_videoDisableHi10pMultithreading)
 +  {
-+    m_pCodecContext->thread_type = FF_THREAD_FRAME;
-+    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Enabled Hi10p Multithreading");
++    CLog::Log(LOGDEBUG,"CDVDVideoCodecFFmpeg::Open() Keep default threading for Hi10p: %d",
++                        m_pCodecContext->thread_type);
 +  }
 +  else
 +    m_pCodecContext->thread_type = FF_THREAD_SLICE;
@@ -69,14 +71,14 @@ index 61d0305..827b2d9 100644
    int m_iLastKeyframe;
    double m_dts;
 diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
-index 16800b7..50d6462 100644
+index 16800b7..1e0f3e0 100644
 --- a/xbmc/settings/AdvancedSettings.cpp
 +++ b/xbmc/settings/AdvancedSettings.cpp
 @@ -112,6 +112,7 @@ void CAdvancedSettings::Initialize()
    m_DXVANoDeintProcForProgressive = false;
    m_videoFpsDetect = 1;
    m_videoDefaultLatency = 0.0;
-+  m_videoAllowHi10pMultithreading = false;
++  m_videoDisableHi10pMultithreading = false;
  
    m_musicUseTimeSeeking = true;
    m_musicTimeSeekForward = 10;
@@ -84,19 +86,19 @@ index 16800b7..50d6462 100644
      XMLUtils::GetBoolean(pElement,"enablehighqualityhwscalers", m_videoEnableHighQualityHwScalers);
      XMLUtils::GetFloat(pElement,"autoscalemaxfps",m_videoAutoScaleMaxFps, 0.0f, 1000.0f);
      XMLUtils::GetBoolean(pElement,"allowmpeg4vdpau",m_videoAllowMpeg4VDPAU);
-+    XMLUtils::GetBoolean(pElement,"allowhi10pmultithreading",m_videoAllowHi10pMultithreading);
++    XMLUtils::GetBoolean(pElement,"disablehi10pmultithreading",m_videoDisableHi10pMultithreading);
      XMLUtils::GetBoolean(pElement,"allowmpeg4vaapi",m_videoAllowMpeg4VAAPI);    
      XMLUtils::GetBoolean(pElement, "disablebackgrounddeinterlace", m_videoDisableBackgroundDeinterlace);
      XMLUtils::GetInt(pElement, "useocclusionquery", m_videoCaptureUseOcclusionQuery, -1, 1);
 diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
-index 27887d4..37723f7 100644
+index 27887d4..fc05e41 100644
 --- a/xbmc/settings/AdvancedSettings.h
 +++ b/xbmc/settings/AdvancedSettings.h
 @@ -164,6 +164,7 @@ class CAdvancedSettings
      bool m_DXVAForceProcessorRenderer;
      bool m_DXVANoDeintProcForProgressive;
      int  m_videoFpsDetect;
-+    bool m_videoAllowHi10pMultithreading;
++    bool m_videoDisableHi10pMultithreading;
  
      CStdString m_videoDefaultPlayer;
      CStdString m_videoDefaultDVDPlayer;


### PR DESCRIPTION
It can be disabled via advancedsettings.xml by specifying
<video>
<disablehi10pmultithreading>true</disablehi10pmultithreading>
</video>
