### PR TITLE
Added recordedtv and liveradio buttons to devinput map

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-463-add_remote_devinput-0.1.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-463-add_remote_devinput-0.1.patch
@@ -1,7 +1,7 @@
 diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lircmap.xml
 --- xbmc-10.1-Dharma/system/Lircmap.xml	2011-06-18 01:43:43.132101246 +0200
 +++ xbmc-10.1-Dharma.patch/system/Lircmap.xml	2011-06-18 01:44:53.777025290 +0200
-@@ -365,7 +365,6 @@
+@@ -409,7 +409,6 @@
  
  	<remote device="linux-input-layer">
  	<altname>cx23885_remote</altname>
@@ -9,7 +9,7 @@ diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lir
  		<left>KEY_LEFT</left>
  		<right>KEY_RIGHT</right>
  		<up>KEY_UP</up>
-@@ -452,4 +451,59 @@
+@@ -510,4 +509,61 @@
  		<mypictures>yellow</mypictures>
  		<myvideo>blue</myvideo>
  	</remote>
@@ -67,5 +67,7 @@ diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lir
 +		<green>KEY_GREEN</green>
 +		<yellow>KEY_YELLOW</yellow>
 +		<blue>KEY_BLUE</blue>
++		<recordedtv>KEY_PVR</recordedtv> 
++		<liveradio>KEY_RADIO</liveradio> 
 +	</remote>
  </lircmap>


### PR DESCRIPTION
Hi,

I have added 2 buttons to the devinput Lircmap.xml patch for xbmc 

I have also refreshed it a little... 

I have added a pull to xbmc to have all this keys added in the xbmc Lircmap.xml instead.
here: https://github.com/xbmc/xbmc/issues/1902
so we dont miss new keys in the future...

Patch:

```
diff --git a/packages/mediacenter/xbmc/patches/xbmc-f70eb43-463-add_remote_devinput-0.1.patch b/packages/mediac
index 85d635b..a15ab62 100644
--- a/packages/mediacenter/xbmc/patches/xbmc-f70eb43-463-add_remote_devinput-0.1.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-f70eb43-463-add_remote_devinput-0.1.patch
@@ -1,7 +1,7 @@
 diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lircmap.xml
 --- xbmc-10.1-Dharma/system/Lircmap.xml        2011-06-18 01:43:43.132101246 +0200
 +++ xbmc-10.1-Dharma.patch/system/Lircmap.xml  2011-06-18 01:44:53.777025290 +0200
-@@ -365,7 +365,6 @@
+@@ -409,7 +409,6 @@

        <remote device="linux-input-layer">
        <altname>cx23885_remote</altname>
@@ -9,7 +9,7 @@ diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lir
                <left>KEY_LEFT</left>
                <right>KEY_RIGHT</right>
                <up>KEY_UP</up>
-@@ -452,4 +451,59 @@
+@@ -510,4 +509,61 @@
                <mypictures>yellow</mypictures>
                <myvideo>blue</myvideo>
        </remote>
@@ -67,5 +67,7 @@ diff -Naur xbmc-10.1-Dharma/system/Lircmap.xml xbmc-10.1-Dharma.patch/system/Lir
 +              <green>KEY_GREEN</green>
 +              <yellow>KEY_YELLOW</yellow>
 +              <blue>KEY_BLUE</blue>
++              <recordedtv>KEY_PVR</recordedtv> 
++              <liveradio>KEY_RADIO</liveradio> 
 +      </remote>
  </lircmap>
```
