### PR TITLE
file: fix segfault

### DIFF
--- a/packages/devel/file/patches/file-5.12-fix-segfault-in-magic_close.patch
+++ b/packages/devel/file/patches/file-5.12-fix-segfault-in-magic_close.patch
@@ -1,0 +1,17 @@
+diff --git a/src/apprentice.c b/src/apprentice.c
+index 961e83d..b7d500c 100644
+--- a/src/apprentice.c
++++ b/src/apprentice.c
+@@ -348,11 +348,9 @@ apprentice_1(struct magic_set *ms, const char *fn, int action)
+ protected void
+ file_ms_free(struct magic_set *ms)
+ {
+-	size_t i;
+ 	if (ms == NULL)
+ 		return;
+-	for (i = 0; i < MAGIC_SETS; i++)
+-		mlist_free(ms->mlist[i]);
++	mlist_free(ms->mlist[0]);
+ 	free(ms->o.pbuf);
+ 	free(ms->o.buf);
+ 	free(ms->c.li);


### PR DESCRIPTION
a quick and dirty fix for a segfault in file-5.12 (doesn't happen in 5.11)
this is probably wrong but works for me

```
#0  0x00007ffff78a8794 in free () from /lib/libc.so.6
#1  0x00007ffff7bcb47c in ?? () from /usr/lib/libmagic.so.1
#2  0x00007ffff7bcb4ad in ?? () from /usr/lib/libmagic.so.1
#3  0x00007ffff7bd2901 in magic_close () from /usr/lib/libmagic.so.1
#4  0x00000000004018a8 in ?? ()
#5  0x00007ffff784c1c6 in __libc_start_main () from /lib/libc.so.6
#6  0x000000000040191d in ?? ()
```

```
munmap(0x7fbe5c01e000, 2359296)         = 0
--- SIGSEGV {si_signo=SIGSEGV, si_code=SEGV_MAPERR, si_addr=0x7fbe5c248498} ---
+++ killed by SIGSEGV +++
Segmentation fault
```
