### PR TITLE
connmand: write to RTC in localtime

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -102,7 +102,7 @@ set_hwclock() {
       # sleep 30 seconds before hw clock is synced
       usleep 30000000
       progress "syncing hardware clock with system clock"
-      /sbin/hwclock --systohc --utc
+      /sbin/hwclock --systohc
     )&
   fi
 }


### PR DESCRIPTION
connman-scripts: 21_network should write to the RTC in localtime, not utc. All other components of OE handle the rtc as localtime, so updating the RTC with utc results in an offset of one or several hours after reboot which ntp needs to slew after network connection. Writing localtime (without the --utc parameter) fixes this.

Third attempt at this pull request, hope it is better done this time. Thanks to MindTooth - your walkthrough is great :-)

This is a resubmit of #1748 
