### PR TITLE
AE: wait max 10 seconds to find at least _one_ audio device

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-464-fix-no-devices-found.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-464-fix-no-devices-found.patch
@@ -1,0 +1,276 @@
+From ac29de2eff8fe144fdbe0330dc38036cf546a372 Mon Sep 17 00:00:00 2001
+From: fritsch <peter.fruehberger@gmail.com>
+Date: Thu, 31 Jan 2013 21:27:56 +0100
+Subject: [PATCH 1/2] AE: make forced enumeration possible - this can be used
+ to delay startup when now devices are present
+
+---
+ xbmc/cores/AudioEngine/AESinkFactory.cpp           |   10 +++++-----
+ xbmc/cores/AudioEngine/AESinkFactory.h             |    2 +-
+ xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp   |   11 +++++++++++
+ xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp        |    4 ++--
+ xbmc/cores/AudioEngine/Sinks/AESinkALSA.h          |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp  |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h    |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h   |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp         |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkOSS.h           |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp      |    2 +-
+ xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h        |    4 ++--
+ 13 files changed, 29 insertions(+), 18 deletions(-)
+
+diff --git a/xbmc/cores/AudioEngine/AESinkFactory.cpp b/xbmc/cores/AudioEngine/AESinkFactory.cpp
+index b066ecd..9917f11 100644
+--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp
++++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp
+@@ -129,15 +129,15 @@ IAESink *CAESinkFactory::Create(std::string &device, AEAudioFormat &desiredForma
+   return NULL;
+ }
+ 
+-#define ENUMERATE_SINK(SINK) { \
++#define ENUMERATE_SINK(SINK, force) { \
+   AESinkInfo info; \
+   info.m_sinkName = #SINK; \
+-  CAESink ##SINK::EnumerateDevicesEx(info.m_deviceInfoList); \
++  CAESink ##SINK::EnumerateDevicesEx(info.m_deviceInfoList, force); \
+   if(!info.m_deviceInfoList.empty()) \
+     list.push_back(info); \
+ }
+ 
+-void CAESinkFactory::EnumerateEx(AESinkInfoList &list)
++void CAESinkFactory::EnumerateEx(AESinkInfoList &list, bool force)
+ {
+ #if defined(TARGET_WINDOWS)
+   ENUMERATE_SINK(DirectSound);
+@@ -147,10 +147,10 @@ void CAESinkFactory::EnumerateEx(AESinkInfoList &list)
+     ENUMERATE_SINK(AUDIOTRACK);
+ #elif defined(TARGET_LINUX) || defined(TARGET_FREEBSD)
+   #if defined(HAS_ALSA)
+-    ENUMERATE_SINK(ALSA);
++    ENUMERATE_SINK(ALSA, force);
+   #endif
+ 
+-    ENUMERATE_SINK(OSS);
++    ENUMERATE_SINK(OSS, force);
+ #endif
+ 
+ }
+diff --git a/xbmc/cores/AudioEngine/AESinkFactory.h b/xbmc/cores/AudioEngine/AESinkFactory.h
+index 99c53f9..6f8a4e5 100644
+--- a/xbmc/cores/AudioEngine/AESinkFactory.h
++++ b/xbmc/cores/AudioEngine/AESinkFactory.h
+@@ -40,6 +40,6 @@ class CAESinkFactory
+ public:
+   static void     ParseDevice(std::string &device, std::string &driver);
+   static IAESink *Create(std::string &device, AEAudioFormat &desiredFormat, bool rawPassthrough);
+-  static void     EnumerateEx(AESinkInfoList &list);
++  static void     EnumerateEx(AESinkInfoList &list, bool force = false);
+ };
+ 
+diff --git a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+index 410e20c..8a19ac4 100644
+--- a/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
++++ b/xbmc/cores/AudioEngine/Engines/SoftAE/SoftAE.cpp
+@@ -39,6 +39,7 @@
+ #include "Interfaces/AESink.h"
+ #include "Utils/AEUtil.h"
+ #include "Encoders/AEEncoderFFmpeg.h"
++#include <unistd.h>
+ 
+ using namespace std;
+ 
+@@ -74,7 +75,17 @@
+   m_outputStageFn      (NULL        ),
+   m_streamStageFn      (NULL        )
+ {
++  unsigned int c_retry = 5;
+   CAESinkFactory::EnumerateEx(m_sinkInfoList);
++  while(m_sinkInfoList.size() == 0 && c_retry > 0)
++  {
++    CLog::Log(LOGNOTICE, "No Devices found - retry: %d", c_retry);
++    usleep(2000000);
++    c_retry--;
++    // retry the enumeration
++    CAESinkFactory::EnumerateEx(m_sinkInfoList, true);
++  }
++  CLog::Log(LOGNOTICE, "Found %lu Lists of Devices", m_sinkInfoList.size());
+   for (AESinkInfoList::iterator itt = m_sinkInfoList.begin(); itt != m_sinkInfoList.end(); ++itt)
+   {
+     CLog::Log(LOGNOTICE, "Enumerated %s devices:", itt->m_sinkName.c_str());
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index 91218a4..b0d6bb1 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -676,11 +676,11 @@ bool CAESinkALSA::OpenPCMDevice(const std::string &name, const std::string &para
+   return false;
+ }
+ 
+-void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list)
++void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+ {
+   /* ensure that ALSA has been initialized */
+   snd_lib_error_set_handler(sndLibErrorHandler);
+-  if(!snd_config)
++  if(!snd_config || force)
+     snd_config_update();
+ 
+   snd_config_t *config;
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+index db1ba80..c1b1c76 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.h
+@@ -50,7 +50,7 @@ class CAESinkALSA : public IAESink
+   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio);
+   virtual void         Drain           ();
+ 
+-  static void EnumerateDevicesEx(AEDeviceInfoList &list);
++  static void EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
+ private:
+   CAEChannelInfo GetChannelLayout(AEAudioFormat format);
+   void           GetAESParams(const AEAudioFormat format, std::string& params);
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+index e8a7876..8f23b41 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.cpp
+@@ -236,7 +236,7 @@ void  CAESinkAUDIOTRACK::SetVolume(float volume)
+   m_volume_changed = true;
+ }
+ 
+-void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list)
++void CAESinkAUDIOTRACK::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+ {
+   m_info.m_channels.Reset();
+   m_info.m_dataFormats.clear();
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+index 46b3551..bbb7856 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkAUDIOTRACK.h
+@@ -43,7 +43,7 @@ class CAESinkAUDIOTRACK : public CThread, public IAESink
+   virtual void         Drain           ();
+   virtual bool         HasVolume       ();
+   virtual void         SetVolume       (float volume);
+-  static void          EnumerateDevicesEx(AEDeviceInfoList &list);
++  static void          EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
+ 
+ private:
+   virtual void Process();
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+index 4d3d41e..c9680e7 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.cpp
+@@ -464,7 +464,7 @@ double CAESinkDirectSound::GetCacheTotal()
+   return (double)m_dwBufferLen / (double)m_AvgBytesPerSec;
+ }
+ 
+-void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
++void CAESinkDirectSound::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool force)
+ {
+   CAEDeviceInfo        deviceInfo;
+ 
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+index 9f54090..2e6209b 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkDirectSound.h
+@@ -43,7 +43,7 @@ class CAESinkDirectSound : public IAESink
+   virtual double       GetCacheTime       ();
+   virtual double       GetCacheTotal      ();
+   virtual unsigned int AddPackets         (uint8_t *data, unsigned int frames, bool hasAudio);
+-  static  void         EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList);
++  static  void         EnumerateDevicesEx (AEDeviceInfoList &deviceInfoList, bool force = false);
+ private:
+   void          AEChannelsFromSpeakerMask(DWORD speakers);
+   DWORD         SpeakerMaskFromAEChannels(const CAEChannelInfo &channels);
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+index 06b9a7f..970e236 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.cpp
+@@ -427,7 +427,7 @@ void CAESinkOSS::Drain()
+   // ???
+ }
+ 
+-void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list)
++void CAESinkOSS::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+ {
+   int mixerfd;
+   const char * mixerdev = "/dev/mixer";
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+index aa8a9f8..7e2db8b 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkOSS.h
+@@ -43,7 +43,7 @@ class CAESinkOSS : public IAESink
+   virtual double       GetCacheTotal   () { return 0.0; } /* FIXME */
+   virtual unsigned int AddPackets      (uint8_t *data, unsigned int frames, bool hasAudio);
+   virtual void         Drain           ();
+-  static  void         EnumerateDevicesEx(AEDeviceInfoList &list);
++  static  void         EnumerateDevicesEx(AEDeviceInfoList &list, bool force = false);
+ private:
+   int m_fd;
+   std::string      m_device;
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+index 8475d60..f238d75 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.cpp
+@@ -559,7 +559,7 @@ bool CAESinkWASAPI::SoftResume()
+   return false;
+ }
+ 
+-void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList)
++void CAESinkWASAPI::EnumerateDevicesEx(AEDeviceInfoList &deviceInfoList, bool force)
+ {
+   IMMDeviceEnumerator* pEnumerator = NULL;
+   IMMDeviceCollection* pEnumDevices = NULL;
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+index a0c567a..7111ea9 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkWASAPI.h
+@@ -45,7 +45,7 @@ class CAESinkWASAPI : public IAESink
+     virtual unsigned int AddPackets                  (uint8_t *data, unsigned int frames, bool hasAudio);
+     virtual bool         SoftSuspend                 ();
+     virtual bool         SoftResume                  ();
+-    static  void         EnumerateDevicesEx          (AEDeviceInfoList &deviceInfoList);
++    static  void         EnumerateDevicesEx          (AEDeviceInfoList &deviceInfoList, bool force = false);
+ private:
+     bool         InitializeExclusive(AEAudioFormat &format);
+     void         AEChannelsFromSpeakerMask(DWORD speakers);
+@@ -78,4 +78,4 @@ class CAESinkWASAPI : public IAESink
+     unsigned int        m_uiBufferLen;    /* wasapi endpoint buffer size, in frames */
+     double              m_avgTimeWaiting; /* time between next buffer of data from SoftAE and driver call for data */
+     double              m_sinkLatency;    /* time in seconds of total duration of the two WASAPI buffers */
+-};
+\ No newline at end of file
++};
+-- 
+1.7.10
+
+
+From b236f0a78079f522f8f9743098820e6301e27625 Mon Sep 17 00:00:00 2001
+From: fritsch <peter.fruehberger@gmail.com>
+Date: Fri, 1 Feb 2013 13:05:24 +0100
+Subject: [PATCH 2/2] AE: recreate alsa source tree to find new devices
+
+---
+ xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp |    6 ++++++
+ 1 file changed, 6 insertions(+)
+
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index b0d6bb1..61848a1 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -681,7 +681,13 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+   /* ensure that ALSA has been initialized */
+   snd_lib_error_set_handler(sndLibErrorHandler);
+   if(!snd_config || force)
++  {
++    if(force)
++      snd_config_update_free_global();
++
+     snd_config_update();
++  }
++
+ 
+   snd_config_t *config;
+   snd_config_copy(&config, snd_config);
+-- 
+1.7.10
+


### PR DESCRIPTION
We cannot wait for devices the user probably not has - but we can wait that there is at least one output device present.
