### PR TITLE
linux: support for kernel drivers which interfere with each other

### DIFF
--- a/packages/linux-extra/media_build/build
+++ b/packages/linux-extra/media_build/build
@@ -1,0 +1,52 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+# dont build parallel
+  MAKEFLAGS=-j1
+
+cd $PKG_BUILD
+
+if [ ! -f v4l/scripts/make_makefile.pl_orig ]; then
+  cp v4l/scripts/make_makefile.pl v4l/scripts/make_makefile.pl_orig
+  sed -i "s|/sbin/depmod|$ROOT/$TOOLCHAIN/bin/depmod|g" v4l/scripts/make_makefile.pl
+  sed -i "s|strip --strip-debug|$STRIP --strip-debug|g" v4l/scripts/make_makefile.pl
+  sed -i 's|\\\\nRemoving obsolete files from \\$(KDIR26)|Removing obsolete files from \\$(DESTDIR)\\$(KDIR26)|g' v4l/scripts/make_makefile.pl
+fi
+
+LDFLAGS="" make DIR=$(kernel_path) prepare
+
+# select which modules (xterm error)
+# LDFLAGS="" make DIR=$(kernel_path) menuconfig
+
+LDFLAGS="" make DIR=$(kernel_path)
+
+# remove object files to save space
+find ./ -name *.o -exec rm {} \;
+find ./ -name *.o.cmd -exec rm {} \;
+find ./ -name *.ko.cmd -exec rm {} \;
+
+# strip kernel modules
+for i in v4l/*.ko; do
+  $STRIP --strip-debug $i
+done

--- a/packages/linux-extra/media_build/install
+++ b/packages/linux-extra/media_build/install
@@ -1,0 +1,112 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+# dont build parallel
+  MAKEFLAGS=-j1
+
+install_modules() {
+  TMPDIR=$ROOT/$INSTALL/lib/modules/$KVER/modules.tmp
+
+  make -C $ROOT/$BUILD/${PKG_NAME}-${PKG_VERSION} install DESTDIR=$TMPDIR >/dev/null
+  rm -f $TMPDIR/lib/modules/$KVER/* || true
+
+  mkdir -p $INSTALL/lib/modules/$KVER/updates
+  cp -a $TMPDIR/lib/modules/$KVER/* $INSTALL/lib/modules/$KVER/updates
+
+  mkdir -p $INSTALL/lib/firmware/
+  cp -a $TMPDIR/lib/firmware/* $INSTALL/lib/firmware/
+  [ -f $PKG_DIR/firmware/*.fw ] && cp $PKG_DIR/firmware/*.fw $INSTALL/lib/firmware/
+
+  rm -fr $TMPDIR
+
+  # run depmod
+  $TOOLCHAIN/bin/depmod -b $INSTALL $KVER > /dev/null
+}
+
+# modules installed under this name
+KNAME_NEW=$PKG_NAME
+# compare with
+KNAME_CMP=sys
+
+#------------------------------------------------------
+KVER=$(ls $BUILD/linux-*/modules/lib/modules)
+KDIR=$INSTALL/lib/modules/${KVER}
+KDIRSYS=$INSTALL/lib/modules/${KVER}-sys
+KDIR_NEW=$INSTALL/lib/modules/${KVER}-$KNAME_NEW
+KDIR_CMP=$INSTALL/lib/modules/${KVER}-$KNAME_CMP
+
+if [ ! -d $KDIRSYS ]; then
+  # sys folder doesn't exist
+  cp -aP $KDIR $KDIRSYS
+else
+  rm -fr $KDIR
+  cp -aP $KDIRSYS $KDIR
+fi
+
+# actual install
+install_modules
+
+find $KDIR/* -type f -name *.ko | while read f1; do
+  f2=$(echo "$f1" | sed "s|$KDIR/||")
+
+  if [ -f $KDIR/$f2 -a -f $KDIR_CMP/$f2 ]; then
+    md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+    md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+    if [ "$md5_new" = "$md5_cmp" ]; then
+      # use symbolic link from compared kernel
+      ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+    fi
+  elif [ -f $KDIR/$f2 -a -L $KDIR_CMP/$f2 ]; then
+    # symbolic link for compare
+    KNAME_CMP_SAVE=$KNAME_CMP
+    TMP_PATH=$(readlink $KDIR_CMP/$f2)
+
+    KDIR_CMP=$(echo $TMP_PATH | sed "s|/$f2||")
+    KNAME_CMP=$(echo $KDIR_CMP | sed "s|/lib/modules/$KVER-||")
+    KDIR_CMP=${INSTALL}$KDIR_CMP
+
+    md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+    md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+    if [ "$md5_new" = "$md5_cmp" ]; then
+      # use symbolic link from compare kernel
+      ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+    fi
+
+    KNAME_CMP=$KNAME_CMP_SAVE
+    KDIR_CMP=$INSTALL/lib/modules/${KVER}-$KNAME_CMP
+  fi
+done
+
+# rename to new folder
+rm -fr $KDIR_NEW
+mv $KDIR $KDIR_NEW
+
+# create symbolic link
+ln -s /var/run/modules/$KVER $KDIR
+
+(
+  cd $INSTALL/lib/modules
+  echo "/storage/.config/" >drivers-extra.txt
+  ls -d ${KVER}-* | grep -v "\-sys$" | sed "s|${KVER}-\(.*\)|  enable-drivers-\1.txt|g" >>drivers-extra.txt
+)

--- a/packages/linux-extra/media_build/meta
+++ b/packages/linux-extra/media_build/meta
@@ -1,0 +1,42 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="media_build"
+PKG_VERSION="185"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE=""
+PKG_URL="http://dl.dropbox.com/u/8224157/public/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS=""
+PKG_BUILD_DEPENDS="toolchain linux"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Linux tuner drivers"
+PKG_LONGDESC="Linux tuner drivers"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+# http://www.vdr-portal.de/board18-vdr-hardware/board102-dvb-karten/113367-aktuelle-treiber-für-octopus-ddbridge-cines2-ngene-ddbridge-duoflex-s2-duoflex-ct-cinect-sowie-tt-s2-6400-teil-2/
+# hg clone http://linuxtv.org/hg/~endriss/media_build_experimental
+# cd media_build_experimental
+# make download
+# make untar
+# find . -type d -name ".hg" -exec rm -fr {} \;

--- a/packages/linux-extra/s2-liplianin/build
+++ b/packages/linux-extra/s2-liplianin/build
@@ -1,0 +1,53 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+# dont build parallel
+  MAKEFLAGS=-j1
+
+cd $PKG_BUILD
+
+if [ ! -f v4l/scripts/make_makefile.pl_orig ]; then
+  cp v4l/scripts/make_makefile.pl v4l/scripts/make_makefile.pl_orig
+  sed -i "s|/sbin/depmod|$ROOT/$TOOLCHAIN/bin/depmod|g" v4l/scripts/make_makefile.pl
+  sed -i "s|strip --strip-debug|$STRIP --strip-debug|g" v4l/scripts/make_makefile.pl
+  sed -i 's|\\\\nRemoving obsolete files from \\$(KDIR26)|Removing obsolete files from \\$(DESTDIR)\\$(KDIR26)|g' v4l/scripts/make_makefile.pl
+fi
+
+LDFLAGS="" make DIR=$(kernel_path) prepare
+sed -i -e "s|^CONFIG_IR_LIRC_CODEC=.*$|# CONFIG_IR_LIRC_CODEC is not set|" v4l/.config
+
+# select which modules (xterm error)
+# LDFLAGS="" make DIR=$(kernel_path) menuconfig
+
+LDFLAGS="" make DIR=$(kernel_path)
+
+# remove object files to save space
+find ./ -name *.o -exec rm {} \;
+find ./ -name *.o.cmd -exec rm {} \;
+find ./ -name *.ko.cmd -exec rm {} \;
+
+# strip kernel modules
+for i in v4l/*.ko; do
+  $STRIP --strip-debug $i
+done

--- a/packages/linux-extra/s2-liplianin/install
+++ b/packages/linux-extra/s2-liplianin/install
@@ -1,0 +1,115 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+# dont build parallel
+  MAKEFLAGS=-j1
+
+install_modules() {
+  TMPDIR=$ROOT/$INSTALL/lib/modules/$KVER/modules.tmp
+
+  make -C $ROOT/$BUILD/${PKG_NAME}-${PKG_VERSION} install DESTDIR=$TMPDIR >/dev/null
+  rm -f $TMPDIR/lib/modules/$KVER/* 2>/dev/null || true
+
+  mkdir -p $INSTALL/lib/modules/$KVER/updates
+  cp -a $TMPDIR/lib/modules/$KVER/* $INSTALL/lib/modules/$KVER/updates
+
+  mkdir -p $INSTALL/lib/firmware/
+  cp -a $TMPDIR/lib/firmware/* $INSTALL/lib/firmware/
+  cp $BUILD/${PKG_NAME}-${PKG_VERSION}/v4l/firmware/*.fw $INSTALL/lib/firmware/
+  [ -f $PKG_DIR/firmware/*.fw ] && cp $PKG_DIR/firmware/*.fw $INSTALL/lib/firmware/
+
+  rm -fr $TMPDIR
+
+  # run depmod
+  $TOOLCHAIN/bin/depmod -b $INSTALL $KVER > /dev/null
+}
+
+# modules installed under this name
+KNAME_NEW=$PKG_NAME
+# compare with
+KNAME_CMP=sys
+
+#------------------------------------------------------
+KVER=$(ls $BUILD/linux-*/modules/lib/modules)
+KDIR=$INSTALL/lib/modules/${KVER}
+KDIRSYS=$INSTALL/lib/modules/${KVER}-sys
+KDIR_NEW=$INSTALL/lib/modules/${KVER}-$KNAME_NEW
+KDIR_CMP=$INSTALL/lib/modules/${KVER}-$KNAME_CMP
+
+if [ ! -d $KDIRSYS ]; then
+  # sys folder doesn't exist
+  cp -aP $KDIR $KDIRSYS
+else
+  rm -fr $KDIR
+  cp -aP $KDIRSYS $KDIR
+fi
+
+# actual install
+install_modules
+
+find $KDIR/* -type f -name *.ko | while read f1; do
+  f2=$(echo "$f1" | sed "s|$KDIR/||")
+
+  if [ -f $KDIR/$f2 -a -f $KDIR_CMP/$f2 ]; then
+    md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+    md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+    if [ "$md5_new" = "$md5_cmp" ]; then
+      # use symbolic link from compared kernel
+      ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+    fi
+  elif [ -f $KDIR/$f2 -a -L $KDIR_CMP/$f2 ]; then
+    # symbolic link for compare
+    KNAME_CMP_SAVE=$KNAME_CMP
+    TMP_PATH=$(readlink $KDIR_CMP/$f2)
+
+    KDIR_CMP=$(echo $TMP_PATH | sed "s|/$f2||")
+    KNAME_CMP=$(echo $KDIR_CMP | sed "s|/lib/modules/$KVER-||")
+    KDIR_CMP=${INSTALL}$KDIR_CMP
+
+    md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+    md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+    if [ "$md5_new" = "$md5_cmp" ]; then
+      # use symbolic link from compare kernel
+      ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+    fi
+
+    KNAME_CMP=$KNAME_CMP_SAVE
+    KDIR_CMP=$INSTALL/lib/modules/${KVER}-$KNAME_CMP
+  fi
+done
+
+# rename to new folder
+rm -fr $KDIR_NEW
+mv $KDIR $KDIR_NEW
+
+# create symbolic link
+ln -s /var/run/modules/$KVER $KDIR
+
+#echo "/storage/.config/" >$INSTALL/lib/modules/drivers-extra.txt
+#ls -d $INSTALL/lib/modules/${KVER}-* | grep -v "\-sys$" | sed "s|$INSTALL/lib/modules/${KVER}-\(.*\)|  enable-drivers-\1.txt|g" >>$INSTALL/lib/modules/drivers-extra.txt
+(
+  cd $INSTALL/lib/modules
+  echo "/storage/.config/" >drivers-extra.txt
+  ls -d ${KVER}-* | grep -v "\-sys$" | sed "s|${KVER}-\(.*\)|  enable-drivers-\1.txt|g" >>drivers-extra.txt
+)

--- a/packages/linux-extra/s2-liplianin/meta
+++ b/packages/linux-extra/s2-liplianin/meta
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="s2-liplianin"
+PKG_VERSION="v37"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://vurd.name/2012/11/07/?????????-skystar-2-express-hd-?-debian-6-0-6/"
+PKG_URL="http://dl.dropbox.com/u/8224157/public/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+PKG_DEPENDS=""
+PKG_BUILD_DEPENDS="toolchain linux"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Linux tuner drivers"
+PKG_LONGDESC="Linux tuner drivers"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"

--- a/packages/linux-extra/s2-liplianin/patches/s2-liplianin-v37-kernel-3.7.patch
+++ b/packages/linux-extra/s2-liplianin/patches/s2-liplianin-v37-kernel-3.7.patch
@@ -1,0 +1,108 @@
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/meye.c s2-liplianin-v37/linux/drivers/media/video/meye.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/meye.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/meye.c	2013-02-03 13:07:39.000000000 +0100
+@@ -1647,7 +1647,7 @@
+ 
+ 	vma->vm_ops = &meye_vm_ops;
+ 	vma->vm_flags &= ~VM_IO;	/* not I/O memory */
+-	vma->vm_flags |= VM_RESERVED;	/* avoid to swap out this VMA */
++	vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);	/* avoid to swap out this VMA */
+ 	vma->vm_private_data = (void *) (offset / gbufsize);
+ 	meye_vm_open(vma);
+ 
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/omap/omap_vout.c s2-liplianin-v37/linux/drivers/media/video/omap/omap_vout.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/omap/omap_vout.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/omap/omap_vout.c	2013-02-03 13:07:39.000000000 +0100
+@@ -910,7 +910,7 @@
+ 
+ 	q->bufs[i]->baddr = vma->vm_start;
+ 
+-	vma->vm_flags |= VM_RESERVED;
++	vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_page_prot = pgprot_writecombine(vma->vm_page_prot);
+ 	vma->vm_ops = &omap_vout_vm_ops;
+ 	vma->vm_private_data = (void *) vout;
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/sn9c102/sn9c102_core.c s2-liplianin-v37/linux/drivers/media/video/sn9c102/sn9c102_core.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/sn9c102/sn9c102_core.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/sn9c102/sn9c102_core.c	2013-02-03 13:07:39.000000000 +0100
+@@ -2129,7 +2129,7 @@
+ 	}
+ 
+ 	vma->vm_flags |= VM_IO;
+-	vma->vm_flags |= VM_RESERVED;
++	vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
+ 
+ 	pos = cam->frame[i].bufmem;
+ 	while (size > 0) { /* size is page-aligned */
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/usbvision/usbvision-video.c s2-liplianin-v37/linux/drivers/media/video/usbvision/usbvision-video.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/usbvision/usbvision-video.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/usbvision/usbvision-video.c	2013-02-03 13:07:39.000000000 +0100
+@@ -1091,7 +1091,7 @@
+ 
+ 	/* VM_IO is eventually going to replace PageReserved altogether */
+ 	vma->vm_flags |= VM_IO;
+-	vma->vm_flags |= VM_RESERVED;	/* avoid to swap out this VMA */
++	vma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);	/* avoid to swap out this VMA */
+ 
+ 	pos = usbvision->frame[i].data;
+ 	while (size > 0) {
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/videobuf2-memops.c s2-liplianin-v37/linux/drivers/media/video/videobuf2-memops.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/videobuf2-memops.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/videobuf2-memops.c	2013-02-03 13:07:39.000000000 +0100
+@@ -162,7 +162,7 @@
+ 		return ret;
+ 	}
+ 
+-	vma->vm_flags		|= VM_DONTEXPAND | VM_RESERVED;
++	vma->vm_flags		|= VM_DONTEXPAND | (VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_private_data	= priv;
+ 	vma->vm_ops		= vm_ops;
+ 
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/videobuf-dma-sg.c s2-liplianin-v37/linux/drivers/media/video/videobuf-dma-sg.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/videobuf-dma-sg.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/videobuf-dma-sg.c	2013-02-03 13:07:39.000000000 +0100
+@@ -582,7 +582,7 @@
+ 	map->count    = 1;
+ 	map->q        = q;
+ 	vma->vm_ops   = &videobuf_vm_ops;
+-	vma->vm_flags |= VM_DONTEXPAND | VM_RESERVED;
++	vma->vm_flags |= VM_DONTEXPAND | (VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_flags &= ~VM_IO; /* using shared anonymous pages */
+ 	vma->vm_private_data = map;
+ 	dprintk(1, "mmap %p: q=%p %08lx-%08lx pgoff %08lx bufs %d-%d\n",
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/videobuf-vmalloc.c s2-liplianin-v37/linux/drivers/media/video/videobuf-vmalloc.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/videobuf-vmalloc.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/videobuf-vmalloc.c	2013-02-03 13:07:39.000000000 +0100
+@@ -270,7 +270,7 @@
+ 	}
+ 
+ 	vma->vm_ops          = &videobuf_vm_ops;
+-	vma->vm_flags       |= VM_DONTEXPAND | VM_RESERVED;
++	vma->vm_flags       |= VM_DONTEXPAND | (VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_private_data = map;
+ 
+ 	dprintk(1, "mmap %p: q=%p %08lx-%08lx (%lx) pgoff %08lx buf %d\n",
+diff -uNr s2-liplianin-v37-orig/linux/drivers/media/video/vino.c s2-liplianin-v37/linux/drivers/media/video/vino.c
+--- s2-liplianin-v37-orig/linux/drivers/media/video/vino.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/media/video/vino.c	2013-02-03 13:07:39.000000000 +0100
+@@ -3950,7 +3950,7 @@
+ 
+ 	fb->map_count = 1;
+ 
+-	vma->vm_flags |= VM_DONTEXPAND | VM_RESERVED;
++	vma->vm_flags |= VM_DONTEXPAND | (VM_DONTEXPAND | VM_DONTDUMP);
+ 	vma->vm_flags &= ~VM_IO;
+ 	vma->vm_private_data = fb;
+ 	vma->vm_file = file;
+diff -uNr s2-liplianin-v37-orig/linux/drivers/staging/media/easycap/easycap_main.c s2-liplianin-v37/linux/drivers/staging/media/easycap/easycap_main.c
+--- s2-liplianin-v37-orig/linux/drivers/staging/media/easycap/easycap_main.c	2013-01-31 10:24:58.000000000 +0100
++++ s2-liplianin-v37/linux/drivers/staging/media/easycap/easycap_main.c	2013-02-03 13:07:39.000000000 +0100
+@@ -2453,7 +2453,7 @@
+ 	JOT(8, "\n");
+ 
+ 	pvma->vm_ops = &easycap_vm_ops;
+-	pvma->vm_flags |= VM_RESERVED;
++	pvma->vm_flags |= (VM_DONTEXPAND | VM_DONTDUMP);
+ 	if (file)
+ 		pvma->vm_private_data = file->private_data;
+ 	easycap_vma_open(pvma);

--- a/packages/linux-extra/tbs/build
+++ b/packages/linux-extra/tbs/build
@@ -1,0 +1,86 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+TBS_SET_DVBC=yes
+
+# dont build parallel
+  MAKEFLAGS=-j1
+
+cd $PKG_BUILD/linux-tbs-drivers
+
+sed -i "s|/sbin/depmod|$ROOT/$TOOLCHAIN/bin/depmod|g" v4l/scripts/make_makefile.pl
+sed -i "s|strip --strip-debug|$STRIP --strip-debug|g" v4l/scripts/make_makefile.pl
+sed -i 's|\\\\nRemoving obsolete files from \\$(KDIR26)|Removing obsolete files from \\$(DESTDIR)\\$(KDIR26)|g' v4l/scripts/make_makefile.pl
+echo "#!/usr/bin/perl" >v4l/scripts/rmmod.pl
+
+for type in dvbc dvbs; do
+  if [ "$type" = "dvbc" -a "$TBS_SET_DVBC" != "yes" ]; then
+    continue
+  fi
+
+  if [ "$type" = "dvbc" ]; then
+    echo "build for DVB-C"
+  else
+    echo "build for DVB-S"
+  fi
+
+  LDFLAGS="" make DIR=$(kernel_path) clean
+
+  echo ""
+  [ "$TARGET_ARCH" = "i386" ]   && ./v4l/tbs-x86_r3.sh
+  [ "$TARGET_ARCH" = "x86_64" ] && ./v4l/tbs-x86_64.sh
+
+  if [ "$type" = "dvbc" ]; then
+    [ "$TARGET_ARCH" = "i386" ]   && ./v4l/tbs-dvbc-x86_r3.sh
+    [ "$TARGET_ARCH" = "x86_64" ] && ./v4l/tbs-dvbc-x86_64.sh
+  fi
+
+  LDFLAGS="" make DIR=$(kernel_path) prepare
+
+  # linux 3.9 temp build fix (thanks seo)
+  find . -iname *.[ch] | xargs sed -i -e "s|__devinit||"
+  find . -iname *.[ch] | xargs sed -i -e "s|__devexit||"
+  find . -iname *.[ch] | xargs sed -i -e "s|__devexit_p||"
+
+	# CONFIG_IR_LIRC_CODEC CONFIG_VIDEO_PVRUSB2
+  for cfg in CONFIG_VIDEO_SH_MOBILE_CEU CONFIG_VIDEO_SH_MOBILE_CSI2; do
+    sed -i -e "s|^$cfg=.*$|# $cfg is not set|" v4l/.config 
+  done
+
+  LDFLAGS="" make DIR=$(kernel_path)
+
+  # remove object files to save space
+  find ./ -name *.o -exec rm {} \;
+  find ./ -name *.o.cmd -exec rm {} \;
+  find ./ -name *.ko.cmd -exec rm {} \;
+
+  # strip kernel modules
+  for mod in v4l/*.ko; do
+    $STRIP --strip-debug $mod
+  done
+
+  if [ "$type" = "dvbc" ]; then
+    cp -a v4l v4l_dvbc
+  fi
+done

--- a/packages/linux-extra/tbs/install
+++ b/packages/linux-extra/tbs/install
@@ -1,0 +1,142 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+# dont build parallel
+	MAKEFLAGS=-j1
+
+install_modules() {
+  V4L=$1
+  [ -z "$V4L" ] && V4L=v4l
+
+  TMPDIR=$ROOT/$INSTALL/lib/modules/$KVER/modules.tmp
+  rm -fr "$TMPDIR"
+
+  make -C $ROOT/$PKG_BUILD/linux-tbs-drivers/$V4L install DESTDIR=$TMPDIR >/dev/null
+
+  rm -f $TMPDIR/lib/modules/$KVER/* 2>/dev/null || true
+
+  mkdir -p $INSTALL/lib/modules/$KVER/updates
+  cp -a $TMPDIR/lib/modules/$KVER/* $INSTALL/lib/modules/$KVER/updates
+
+  mkdir -p $INSTALL/lib/firmware/
+  cp -a $TMPDIR/lib/firmware/* $INSTALL/lib/firmware/
+  cp $PKG_BUILD/*.fw $INSTALL/lib/firmware/
+  [ -f $PKG_DIR/firmware/*.fw ] && cp $PKG_DIR/firmware/*.fw $INSTALL/lib/firmware/ 
+
+  rm -fr "$TMPDIR"
+
+  # run depmod
+  $TOOLCHAIN/bin/depmod -b $INSTALL $KVER > /dev/null
+}
+
+for type in dvbs dvbc; do
+  if [ "$type" = "dvbc" -a ! -d $PKG_BUILD/linux-tbs-drivers/v4l_dvbc ]; then
+    continue
+  fi
+
+  if [ "$type" = "dvbc" ]; then
+    echo "  installing DVB-C"
+  else
+    echo "  installing DVB-S"
+  fi
+
+  if [ "$type" = "dvbc" ]; then
+    # modules installed under this name
+    KNAME_NEW=$PKG_NAME-dvbc
+    # compare with
+    # KNAME_CMP=sys
+    # compare with tbs drivers not sys - only some minor changes between tbs and tbs-dvbc
+    KNAME_CMP=tbs
+  else
+    # modules installed under this name
+    KNAME_NEW=$PKG_NAME
+    # compare with
+    KNAME_CMP=sys
+  fi
+
+  KVER=$(ls $BUILD/linux-*/modules/lib/modules)
+  KDIR=$INSTALL/lib/modules/$KVER
+  KDIRSYS=$INSTALL/lib/modules/$KVER-sys
+  KDIR_NEW=$INSTALL/lib/modules/$KVER-$KNAME_NEW
+  KDIR_CMP=$INSTALL/lib/modules/$KVER-$KNAME_CMP
+
+  if [ ! -d $KDIRSYS ]; then
+    # sys folder doesn't exist
+    cp -aP $KDIR $KDIRSYS
+  else
+    rm -fr $KDIR
+    cp -aP $KDIRSYS $KDIR
+  fi
+
+  # actual install
+  if [ "$type" = "dvbc" ]; then
+    install_modules v4l_dvbc
+  else
+    install_modules v4l
+  fi
+
+  find $KDIR/* -type f -name *.ko | while read f1; do
+    f2=$(echo "$f1" | sed "s|$KDIR/||")
+
+    if [ -f $KDIR/$f2 -a -f $KDIR_CMP/$f2 ]; then
+      md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+      md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+      if [ "$md5_new" = "$md5_cmp" ]; then
+        # use symbolic link from compared kernel
+        ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+      fi
+    elif [ -f $KDIR/$f2 -a -L $KDIR_CMP/$f2 ]; then
+      # symbolic link for compare
+      KNAME_CMP_SAVE=$KNAME_CMP
+      TMP_PATH=$(readlink $KDIR_CMP/$f2)
+
+      KDIR_CMP=$(echo $TMP_PATH | sed "s|/$f2||")
+      KNAME_CMP=$(echo $KDIR_CMP | sed "s|/lib/modules/$KVER-||")
+      KDIR_CMP=${INSTALL}$KDIR_CMP
+
+      md5_new=$(md5sum $KDIR/$f2 | cut -d ' ' -f1)
+      md5_cmp=$(md5sum $KDIR_CMP/$f2 | cut -d ' ' -f1)
+      if [ "$md5_new" = "$md5_cmp" ]; then
+        # use symbolic link from compare kernel
+        ln -f -s "/lib/modules/$KVER-$KNAME_CMP/$f2" "$KDIR/$f2"
+      fi
+
+      KNAME_CMP=$KNAME_CMP_SAVE
+      KDIR_CMP=$INSTALL/lib/modules/$KVER-$KNAME_CMP
+    fi
+  done
+
+  # rename to new folder
+  rm -fr $KDIR_NEW
+  mv $KDIR $KDIR_NEW
+
+  # create symbolic link
+  ln -s /var/run/modules/$KVER $KDIR
+done
+
+(
+  cd $INSTALL/lib/modules
+  echo "/storage/.config/" >drivers-extra.txt
+  ls -d ${KVER}-* | grep -v "\-sys$" | sed "s|${KVER}-\(.*\)|  enable-drivers-\1.txt|g" >>drivers-extra.txt
+)

--- a/packages/linux-extra/tbs/meta
+++ b/packages/linux-extra/tbs/meta
@@ -1,0 +1,35 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="tbs"
+PKG_VERSION="130429"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.tbsdtv.com/english/Download.html"
+PKG_URL="http://www.tbsdtv.com/download/document/common/tbs-linux-drivers_v${PKG_VERSION}.zip"
+PKG_DEPENDS=""
+PKG_BUILD_DEPENDS="toolchain linux"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Linux TBS tuner drivers"
+PKG_LONGDESC="Linux TBS tuner drivers"
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"

--- a/packages/linux-extra/tbs/unpack
+++ b/packages/linux-extra/tbs/unpack
@@ -1,0 +1,42 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+ZIP_PKG="`echo $PKG_URL | sed 's%.*/\(.*\)$%\1%'`"
+
+mkdir -p $BUILD/${PKG_NAME}-${PKG_VERSION}
+
+# unzip main archive
+unzip $SOURCES/$1/$ZIP_PKG -d $BUILD/${PKG_NAME}-${PKG_VERSION} >/dev/null 2>&1
+# extract .tar.bz2 archive
+tar xjf $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers.tar.bz2 -C $BUILD/${PKG_NAME}-${PKG_VERSION}
+rm -f $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers.tar.bz2
+# fix permissions
+chmod -R u+rwX $BUILD/${PKG_NAME}-${PKG_VERSION}/linux-tbs-drivers/*
+
+echo "### Applying upstream patches ###"
+for i in $PKG_DIR/patches.upstream/*.patch; do
+  if [ -f "$i" ]; then
+    cat $i | patch -d `echo $BUILD/$PKG_NAME-$PKG_VERSION | cut -f1 -d\ ` -p1
+  fi
+done

--- a/packages/sysutils/busybox/init.d/02_set-modules
+++ b/packages/sysutils/busybox/init.d/02_set-modules
@@ -1,0 +1,49 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+#
+# make symbolic link for kernel modules
+#
+# runlevels: openelec, installer, textmode
+
+  KVER=$(uname -r)
+  KNAME=sys
+
+  for kn in /lib/modules/$KVER-*; do
+    kn="${kn%%/}"           # strip last / if exist
+    KNAME=${kn##*/$KVER-}   # strip kernel version in front
+    CONFIG_FILE=/storage/.config/enable-drivers-${KNAME}.txt
+
+    if [ -f $CONFIG_FILE ]; then
+      # use first driver
+      break
+    else
+      KNAME=sys
+    fi
+  done
+
+  # check for symbolic link
+  if [ -h "/lib/modules/$KVER" ]; then
+    progress "enabling kernel drivers $KNAME..."
+    mkdir -p /var/run/modules/
+    ln -s /lib/modules/${KVER}-$KNAME /var/run/modules/$KVER
+  else
+    progress "only stock kernel drivers available..."
+  fi

--- a/projects/ARCTIC_MC/options
+++ b/projects/ARCTIC_MC/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Fusion/options
+++ b/projects/Fusion/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Generic_OSS/options
+++ b/projects/Generic_OSS/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/ION/options
+++ b/projects/ION/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Intel/options
+++ b/projects/Intel/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Ultra/options
+++ b/projects/Ultra/options
@@ -162,6 +162,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+  
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/projects/Virtual/options
+++ b/projects/Virtual/options
@@ -157,6 +157,10 @@
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
   ADDITIONAL_DRIVERS="RTL8192CU RTL8188EU vboxguest dvbhdhomerun"
 
+# extra drivers to install:
+# Space separated list is supported
+  EXTRA_DRIVERS="tbs media_build"
+
 # build with network support (yes / no)
   NETWORK="yes"
 

--- a/scripts/image
+++ b/scripts/image
@@ -165,6 +165,11 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
     $STRIP --strip-debug $MOD
   done
 
+# build linux kernel drivers which interfere with each other
+  for p in $EXTRA_DRIVERS; do
+    $SCRIPTS/install $p
+  done
+
 # make target dir
   mkdir -p $TARGET_IMG
     rm -rf $TARGET_IMG/$IMAGE_NAME.kernel

--- a/tools/mkpkg/mkpkg_media_build_experimental
+++ b/tools/mkpkg/mkpkg_media_build_experimental
@@ -1,0 +1,56 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2013 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME=media_build
+HG_URL=http://linuxtv.org/hg/~endriss/
+HG_NAME=media_build_experimental
+HG_REV=latest
+
+echo "getting sources..."
+  if [ ! -d $PKG_NAME.hg ]; then
+    hg clone ${HG_URL}${HG_NAME} $PKG_NAME.hg
+  fi
+
+  cd $PKG_NAME.hg
+    make download
+    make untar
+    if [ $HG_REV = latest ]; then
+      hg update
+      HG_REV=$(hg identify -n)
+    else
+      hg update $HG_REV
+    fi
+    # remove .hg folders
+    find . -type d -name ".hg" -exec rm -fr {} \;
+    cd ..
+
+echo "copying sources..."
+  rm -rf $PKG_NAME-$HG_REV
+  cp -R $PKG_NAME.hg $PKG_NAME-$HG_REV
+
+echo "cleaning sources..."
+  rm -rf $PKG_NAME-$HG_REV/.hg
+
+echo "packing sources..."
+  tar cvJf $PKG_NAME-$HG_REV.tar.xz $PKG_NAME-$HG_REV
+
+echo "remove temporary sourcedir..."
+#  rm -rf $PKG_NAME-$HG_REV


### PR DESCRIPTION
(like TBS, TBS DVB-C, s2-liplianin, media_build, ...)

I created a very simple way to include TBS and similar kernel drivers within openelec in a way that they don't interfere with system ones (from linux kernel itself). So they doesn't brake anything.

What I did was build normal kernel which is installed in /lib/modules/3.7.5.
Then I copied this folder to 3.7.5-sys which means system kernel modules.
Then I build TBS driver and install modules over /lib/modules/3.7.5.
In next step I removed all SAME kernel module files which are already in 3.7.5-sys folder and make symbolic links to them (to make image smaller).
At the end I rename 3.7.5 to 3.7.5-tbs and create symbolic link /lib/modules/3.7.5 => /var/run/modules/3.7.5.
In one new init file just after mounting filesystem I check for a file in /storage/.config.

If file enable-drivers-tbs.txt exist symbolic link is created /var/run/modules/3.7.5 => /lib/modules/3.7.5-tbs.
If this file is not present symbolic link is created /var/run/modules/3.7.5 => /lib/modules/3.7.5-sys and nothing from tbs can be used because it's not present.
The whole magic happens in install script for a driver (tbs, s2-liplianin).

The final image size difference is only 3 MB extra for TBS modules. It can also include two different TBS modules (one for default DVB-T/S/S2 and one for DVB-C).

root ~ # ls -l /lib/modules/
lrwxrwxrwx 1 root root   22 Feb  3 12:00 3.7.5 -> /var/run/modules/3.7.5
drwxrwxr-x 8 root root 4096 Feb  3 12:00 3.7.5-s2liplianin/
drwxrwxr-x 8 root root 4096 Feb  3 12:00 3.7.5-sys/
drwxrwxr-x 8 root root 4096 Feb  3 12:00 3.7.5-tbs/
drwxrwxr-x 8 root root 4096 Feb  3 12:00 3.7.5-tbs-dvbc/

root ~ # ls -l /var/run/modules/
lrwxrwxrwx    1 root     root          22 Feb  3 12:00 3.7.5 -> /lib/modules/3.7.5-tbs/

root ~ # du -hx --max-depth=0 3.7.5-s2liplianin/
15M     3.7.5-s2liplianin/
root ~ # du -hx --max-depth=0 3.7.5-sys/
25M     3.7.5-sys/
root ~ # du -hx --max-depth=0 3.7.5-tbs
15M     3.7.5-tbs
root ~ # du -hx --max-depth=0 3.7.5-tbs-dvbc/
15M     3.7.5-tbs-dvbc/

9 MB larger SYSTEM file with 3 extra kernel drivers (TBS, TBS for DVB-C, s2-liplianin).

I think having TBS (and others) drivers in official OpenELEC image would be useful for many users. Especially because they don't interfere with each others.
