### PR TITLE
When init starts daemons through a shell script, replace the shell altogether

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
+++ b/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
@@ -134,9 +134,9 @@ mkdir -p $ADDON_HOME
       fi
       if [ "$PRELOAD_CAPMT_CA" == "true" ] ; then
         logger -t Tvheadend "### Preloading capmt_ca.so library ###"
-        LD_PRELOAD=$ADDON_DIR/bin/capmt_ca.so $ADDON_BIN $TVHEADEND_ARG &>$LOG_FILE
+        LD_PRELOAD=$ADDON_DIR/bin/capmt_ca.so exec $ADDON_BIN $TVHEADEND_ARG &>$LOG_FILE
       else
-        $ADDON_BIN $TVHEADEND_ARG &>$LOG_FILE
+        exec $ADDON_BIN $TVHEADEND_ARG &>$LOG_FILE
       fi
     done &
   fi

--- a/packages/sysutils/remote/atvclient/init.d/63_atvclient
+++ b/packages/sysutils/remote/atvclient/init.d/63_atvclient
@@ -24,6 +24,6 @@
 
 (
   progress "starting ATVclient"
-    mkdir -p /storage/.cache
-    atvclient -m > /dev/null 2>&1
+  mkdir -p /storage/.cache
+  exec atvclient -m > /dev/null 2>&1
 )&

--- a/packages/sysutils/systemd/init.d/12_udev-monitor
+++ b/packages/sysutils/systemd/init.d/12_udev-monitor
@@ -25,5 +25,5 @@
 
 (
   progress "monitoring udev events"
-    udevadm monitor -e > /dev/udev.log
+  exec udevadm monitor -e > /dev/udev.log
 )&

--- a/packages/x11/other/ratpoison/init.d/73_ratpoison
+++ b/packages/x11/other/ratpoison/init.d/73_ratpoison
@@ -30,8 +30,8 @@
 
   # starting ratpoison
     if [ -f /storage/.config/ratpoisonrc ]; then
-      DISPLAY=:0.0 ratpoison -f /storage/.config/ratpoisonrc > /dev/null 2>&1
+      exec ratpoison -f /storage/.config/ratpoisonrc -d :0.0 > /dev/null 2>&1
     else
-      DISPLAY=:0.0 ratpoison > /dev/null 2>&1
+      exec ratpoison -d :0.0 > /dev/null 2>&1
     fi
 )&


### PR DESCRIPTION
A few daemons are being started from init through a shell script. Since the daemon does not "daemonizes" properly, it's been put in the background from the shell by using `( ... ) &`, however this leaves a lingering shell that serves no purpose. This patch improves this situation.

In case of `tvheadend`, we replaced the shell script `tvheadend.start`.

The situation before this change looked like:

```
    init-+-Xorg
         |-avahi-daemon
         |-console-kit-dae-+-62*[{console-kit-da}]
         |                 `-{gdbus}
         |-dbus-daemon
         |-eventlircd
         |-klogd
:        |-init---atvclient
         |-init---connmand
:        |-init---ratpoison
:        |-init---udevadm
         |-polkitd---{gdbus}
         |-rpcbind
         |-syslogd
         |-systemd-udevd
:        |-tvheadend.start---tvheadend---12*[{tvheadend}]
         |-udisks-daemon-+-udisks-daemon
         |               |-{gdbus}
         |               `-{gmain}
         |-upowerd-+-{gdbus}
         |         `-{gmain}
         |-watchdog
         |-wpa_supplicant
         `-xbmc.bin---17*[{xbmc.bin}]
```

After this change, it looks like:

```
    init-+-Xorg
:        |-atvclient
         |-avahi-daemon
         |-console-kit-dae-+-62*[{console-kit-da}]
         |                 `-{gdbus}
         |-dbus-daemon
         |-eventlircd
         |-init---connmand
         |-klogd
         |-polkitd---{gdbus}
:        |-ratpoison
         |-rpcbind
         |-syslogd
         |-systemd-udevd
:        |-tvheadend---12*[{tvheadend}]
:        |-udevadm
         |-udisks-daemon-+-udisks-daemon
         |               |-{gdbus}
         |               `-{gmain}
         |-upowerd-+-{gdbus}
         |         `-{gmain}
         |-watchdog
         |-wpa_supplicant
         `-xbmc.bin---17*[{xbmc.bin}]
```

Only for `connmand` this is not easily done since the shell loops and restarts `connmand`. In different circumstances _/etc/inittab_ would respawn the process.
