### PR TITLE
Allow syslog.conf to be locally customized from /storage/.config/syslog.conf

### DIFF
--- a/packages/sysutils/busybox/init.d/08_syslogd
+++ b/packages/sysutils/busybox/init.d/08_syslogd
@@ -25,7 +25,11 @@
 
 (
   progress "Starting Syslog daemon"
+  if [ -f /storage/.config/syslog.conf ]; then
+    syslogd -f /storage/.config/syslog.conf
+  else
     syslogd
+  fi
 
   progress "Starting Kernellog daemon"
     klogd


### PR DESCRIPTION
Since I would like to remotely log whatever goes on on my AppleTV devices, I need a way to modify the _syslog.conf_ that is used, or need to provide options to `syslogd`. This was the easiest pick of the two :)
