### PR TITLE
new package: add package 'watchdog'

### DIFF
--- a/packages/sysutils/watchdog/build
+++ b/packages/sysutils/watchdog/build
@@ -1,0 +1,38 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2013 Dag Wieers (dag@wieers.com)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+cd $PKG_BUILD
+./configure --host=$TARGET_NAME \
+           --build=$HOST_NAME \
+           --prefix=/usr \
+           --bindir=/bin \
+           --disable-nfs \
+           --with-minload=2 \
+           --with-timermargin=60 \
+
+make PREFIX=/usr \
+     CC="$TARGET_CC" \
+     AR="$TARGET_AR" \
+     CFLAGS="$TARGET_CFLAGS " \
+     CPPFLAGS="$TARGET_CPPFLAGS" \

--- a/packages/sysutils/watchdog/config/watchdog.conf
+++ b/packages/sysutils/watchdog/config/watchdog.conf
@@ -1,0 +1,5 @@
+interval = 10
+watchdog-device = /dev/watchdog
+admin = root
+realtime = yes
+priority = 1

--- a/packages/sysutils/watchdog/init.d/17_watchdog
+++ b/packages/sysutils/watchdog/init.d/17_watchdog
@@ -1,0 +1,32 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2013 Dag Wieers (dag@wieers.com)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+# start watchdog daemon
+#
+# runlevels: openelec, textmode
+
+if [ -c /dev/watchdog ]; then
+  progress "starting watchdog daemon"
+  if [ -f /storage/.config/watchdog.conf ]; then
+    watchdog -c /storage/.config/watchdog.conf
+  else
+    watchdog
+  fi
+fi

--- a/packages/sysutils/watchdog/install
+++ b/packages/sysutils/watchdog/install
@@ -1,0 +1,29 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2013 Dag Wieers (dag@wieers.com)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+. config/options $1
+
+mkdir -p $INSTALL/usr/bin/
+cp $PKG_BUILD/src/{watchdog,wd_identify,wd_keepalive} $INSTALL/usr/bin/
+mkdir -p $INSTALL/etc/init.d/
+cp $PKG_DIR/config/watchdog.conf $INSTALL/etc/
+cp $PKG_DIR/init.d/17_watchdog $INSTALL/etc/init.d/

--- a/packages/sysutils/watchdog/meta
+++ b/packages/sysutils/watchdog/meta
@@ -1,0 +1,36 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2013 Dag Wieers (dag@wieers.com)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="watchdog"
+PKG_VERSION="5.13"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://sourceforge.net/projects/watchdog/"
+PKG_URL="http://ignum.dl.sourceforge.net/project/watchdog/watchdog/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS=""
+PKG_BUILD_DEPENDS="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="system"
+PKG_SHORTDESC="watchdog: check if your system is still alive"
+PKG_LONGDESC="Watchdog is a daemon that checks if your system is still working. If programs in user space are not longer executed it will reboot the system."
+PKG_IS_ADDON="no"
+
+PKG_AUTORECONF="no"

--- a/projects/ATV/options
+++ b/projects/ATV/options
@@ -161,7 +161,7 @@
 # for a list of additinoal drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU dvbhdhomerun bcm_sta"
+  ADDITIONAL_DRIVERS="RTL8192CU dvbhdhomerun"
 
 # build with network support (yes / no)
   NETWORK="yes"
@@ -308,6 +308,9 @@
 
 # build with lm_sensors hardware monitoring support (yes / no)
   SENSOR_SUPPORT="yes"
+
+# build with Watchdog support (yes / no)
+  WATCHDOG_SUPPORT="yes"
 
 # build with swap support (yes / no)
   SWAP_SUPPORT="yes"

--- a/scripts/image
+++ b/scripts/image
@@ -135,6 +135,9 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
 # Sensors support
   [ "$SENSOR_SUPPORT" = "yes" ] && $SCRIPTS/install lm_sensors
 
+# Watchdog support
+  [ "$WATCHDOG_SUPPORT" = "yes" ] && $SCRIPTS/install watchdog
+
 # Update support
   [ "$UPDATE_SUPPORT" = "yes" ] && $SCRIPTS/install autoupdate
 


### PR DESCRIPTION
This package adds a watchdog daemon, and only starts it at boot if there is a /dev/watchdog device.
