### PR TITLE
acpica: crosscompile patch

### DIFF
--- a/packages/debug/acpica/build
+++ b/packages/debug/acpica/build
@@ -26,9 +26,10 @@
 [ "$TARGET_ARCH" = "x86_64" ] && ACPICA_BITS="64"
 
 cd $PKG_BUILD
+
 make PREFIX=/usr \
      CC="$TARGET_CC" \
      AR="$TARGET_AR" \
      BITS=$ACPICA_BITS \
-     YACC=$ROOT/$TOOLCHAIN/bin/bison
-     CWARNINGFLAGS="-O2 $TARGET_CFLAGS" \
+     YACC=$ROOT/$TOOLCHAIN/bin/bison \
+     CWARNINGFLAGS="-O2 $TARGET_CFLAGS"

--- a/packages/debug/acpica/patches/acpica-unix2-20130117-01-crosscompile.patch
+++ b/packages/debug/acpica/patches/acpica-unix2-20130117-01-crosscompile.patch
@@ -1,0 +1,12 @@
+diff -uNr acpica-unix2-20130117-orig/generate/unix/Makefile.common acpica-unix2-20130117/generate/unix/Makefile.common
+--- acpica-unix2-20130117-orig/generate/unix/Makefile.common	2013-01-17 20:47:44.000000000 +0100
++++ acpica-unix2-20130117/generate/unix/Makefile.common	2013-02-07 15:13:59.000000000 +0100
+@@ -6,7 +6,7 @@
+ # Get the OS machine architecture. Anything with a "64" in the returned
+ # string will be treated as a 64-bit OS. Otherwise, the default is 32-bit.
+ #
+-HARDWARE_NAME := $(shell uname -m)
++HARDWARE_NAME=$(BITS)
+ BITS=0
+ 
+ #


### PR DESCRIPTION
fix when building 64bit target on 32bit host
