### PR TITLE
Replaced /bin/sh with /bin/bash.

### DIFF
--- a/packages/debug/i2c-tools/install
+++ b/packages/debug/i2c-tools/install
@@ -1,4 +1,4 @@
-#!/bin/sh
+#!/bin/bash
 
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv


### PR DESCRIPTION
This solves an error on debian systems with /bin/dash as /bin/sh. The dash shell does not understand bash’s shell globbing.
