### PR TITLE
Remote syslog support from OpenELEC settings

### DIFF
--- a/packages/mediacenter/xbmc-addon-settings/config/default_settings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/config/default_settings.xml
@@ -31,6 +31,8 @@
     <setting id="SAMBA_SECURITY" value="false" />
     <setting id="SAMBA_USERNAME" value="openelec" />
     <setting id="SAMBA_PASSWORD" value="openelec" />
+    <setting id="SYSLOG_REMOTE" value="false" />
+    <setting id="SYSLOG_SERVER" value="" />
     <setting id="CROND_START" value="false" />
     <setting id="UPDATE_AUTO" value="manual" />
     <setting id="X11_KEYMAP" value="us" />

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/language/English/strings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/language/English/strings.xml
@@ -50,4 +50,8 @@
 	<string id="5030">crond</string>
 	<string id="5031">Start cron daemon at boot</string>
 
+	<string id="5040">syslog</string>
+	<string id="5041">Use remote syslog server</string>
+	<string id="5042">Remote syslog IP address</string>
+
 </strings>

--- a/packages/mediacenter/xbmc-addon-settings/source/resources/settings.xml
+++ b/packages/mediacenter/xbmc-addon-settings/source/resources/settings.xml
@@ -81,5 +81,9 @@
 		<setting label="5030" type="lsep"/>
 		<setting type="sep" />
 		<setting id="CROND_START" type="bool" label="5031" default="false" />
+		<setting label="5040" type="lsep"/>
+		<setting type="sep" />
+		<setting id="SYSLOG_REMOTE" type="bool" label="5041" default="false" />
+		<setting id="SYSLOG_SERVER" type="ipaddress" label="5042" default="" visible="eq(-1,true)" />
     </category>
 </settings>

--- a/packages/sysutils/busybox/init.d/08_syslogd
+++ b/packages/sysutils/busybox/init.d/08_syslogd
@@ -25,11 +25,20 @@
 
 (
   progress "Starting Syslog daemon"
-  if [ -f /storage/.config/syslog.conf ]; then
-    syslogd -f /storage/.config/syslog.conf
-  else
-    syslogd
+
+  source /var/config/settings.conf
+
+  SYSLOGD_OPTIONS="-L"
+
+  if [ "$SYSLOG_REMOTE" == "true" -a "$SYSLOG_SERVER" ]; then
+    SYSLOGD_OPTIONS="$SYSLOGD_OPTIONS -R $SYSLOG_SERVER"
   fi
+
+  if [ -f /storage/.config/syslog.conf ]; then
+    SYSLOGD_OPTIONS="$SYSLOGD_OPTIONS -f /storage/.config/syslog.conf"
+  fi
+
+  syslogd $SYSLOGD_OPTIONS
 
   progress "Starting Kernellog daemon"
     klogd


### PR DESCRIPTION
This patch remote syslog support. The syslog startup script will add the necessary options, and leaves room for a custom syslog.conf from /storage/.config (as it was before).

This implements #1861 in the old settings interface.
