### PR TITLE
linux: hide 'TSC calibration failed' kernel message

### DIFF
--- a/packages/linux/patches/linux-900-hide_tsc_error.patch
+++ b/packages/linux/patches/linux-900-hide_tsc_error.patch
@@ -1,0 +1,12 @@
+diff -uNr linux-3.6.4-orig/arch/x86/kernel/tsc.c linux-3.6.4-new/arch/x86/kernel/tsc.c
+--- linux-3.6.4-orig/arch/x86/kernel/tsc.c	2012-11-03 14:19:55.000000000 +0100
++++ linux-3.6.4-new/arch/x86/kernel/tsc.c	2012-11-03 14:23:05.000000000 +0100
+@@ -374,7 +374,7 @@
+ 			goto success;
+ 		}
+ 	}
+-	pr_err("Fast TSC calibration failed\n");
++	pr_info("Fast TSC calibration failed\n");
+ 	return 0;
+ 
+ success:


### PR DESCRIPTION
Useful when using hidden syslinux bootloader.
