### PR TITLE
Patches to libva and libva-intel driver to solve issues with some h.264 videos

### DIFF
--- a/packages/multimedia/libva-driver-intel/patches.upstream/libva-driver-intel-enlarge_dmv_buffer_ivb-001.patch
+++ b/packages/multimedia/libva-driver-intel/patches.upstream/libva-driver-intel-enlarge_dmv_buffer_ivb-001.patch
@@ -1,0 +1,23 @@
+diff --git a/src/gen7_mfd.c b/src/gen7_mfd.c
+index 5b36c8d..2967347 100755
+--- a/src/gen7_mfd.c
++++ b/src/gen7_mfd.c
+@@ -194,7 +194,7 @@ gen7_mfd_init_avc_surface(VADriverContextP ctx,
+     if (gen7_avc_surface->dmv_top == NULL) {
+         gen7_avc_surface->dmv_top = dri_bo_alloc(i965->intel.bufmgr,
+                                                  "direct mv w/r buffer",
+-                                                 width_in_mbs * height_in_mbs * 64,
++                                                 width_in_mbs * (height_in_mbs + 1) * 64,
+                                                  0x1000);
+         assert(gen7_avc_surface->dmv_top);
+     }
+@@ -203,7 +203,7 @@ gen7_mfd_init_avc_surface(VADriverContextP ctx,
+         gen7_avc_surface->dmv_bottom == NULL) {
+         gen7_avc_surface->dmv_bottom = dri_bo_alloc(i965->intel.bufmgr,
+                                                     "direct mv w/r buffer",
+-                                                    width_in_mbs * height_in_mbs * 64,                                                    
++                                                    width_in_mbs * (height_in_mbs + 1) * 64,                                                    
+                                                     0x1000);
+         assert(gen7_avc_surface->dmv_bottom);
+     }
+

--- a/packages/multimedia/libva/patches/libva-haihao-surface-001.patch
+++ b/packages/multimedia/libva/patches/libva-haihao-surface-001.patch
@@ -1,0 +1,13 @@
+diff --git a/va/glx/va_glx_impl.c b/va/glx/va_glx_impl.c
+index 049be09..72ec9a4 100644
+--- a/va/glx/va_glx_impl.c
++++ b/va/glx/va_glx_impl.c
+@@ -937,6 +937,7 @@ associate_surface(
+         return status;
+ 
+     x11_trap_errors();
++    status = ctx->vtable->vaSyncSurface(ctx, surface);
+     status = ctx->vtable->vaPutSurface(
+         ctx,
+         surface,
+


### PR DESCRIPTION
These patches are to fix crashes and artifacts, when a movie with certain resolution is played on IvyBridge.
1920x1080 play fine without this patch, but there are lot of movies encoded without black borders that causes this issue.

Please be aware that I'm using llibva and and libva-driver-intel directly from freedesktop.org's git (master) so my meta file are modified to download gzip archive
from freedesktop.org but I'm affraid that this breaks OpenELEC's package  versioning.
