### PR TITLE
Fixed binutils build on multilib platforms like OpenSUSE.

### DIFF
--- a/packages/toolchain/devel/binutils/build
+++ b/packages/toolchain/devel/binutils/build
@@ -26,6 +26,13 @@ if [ "$TARGET_ARCH" = "x86_64" ]; then
   WITH_64B_BFD="--enable-64-bit-bfd"
 fi
 
+if [ "$(uname -m)" = "x86_64" ] && [ -d $ROOT/$TOOLCHAIN/lib64 ]; then
+  pushd $ROOT/$TOOLCHAIN
+  ln -sv lib64 lib 
+  popd
+fi
+
+
 setup_toolchain host
 
 CPPFLAGS=""


### PR DESCRIPTION
On OpenSUSE x86_64 libraries in toolchain will be installed in "lib64" folder, but binutils will try to configure itself with "lib" folder and will fail... This commit fixes this issue by creating "lib" link to "lib64" folder if building on x86_64 platform and toolchain libs was installed in "lib64" folder.
