### PR TITLE
Fix the default terminal

### DIFF
--- a/packages/devel/ncurses/install
+++ b/packages/devel/ncurses/install
@@ -36,6 +36,10 @@
     TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe linux \
       $PKG_BUILD/misc/terminfo.src
 
+  mkdir -p $INSTALL/usr/share/terminfo/s
+    TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe screen \
+      $PKG_BUILD/misc/terminfo.src
+
   mkdir -p $INSTALL/usr/share/terminfo/v
     TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe vt100 \
       $PKG_BUILD/misc/terminfo.src
@@ -44,6 +48,4 @@
     TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe xterm \
       $PKG_BUILD/misc/terminfo.src
     TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe xterm-color \
-      $PKG_BUILD/misc/terminfo.src
-    TERMINFO=$INSTALL/usr/share/terminfo $ROOT/$TOOLCHAIN/bin/tic -xe vt100 \
       $PKG_BUILD/misc/terminfo.src

--- a/packages/sysutils/bash/profile.d/shell.conf
+++ b/packages/sysutils/bash/profile.d/shell.conf
@@ -26,5 +26,21 @@
 PS1='\[\e[0;32m\]\u\[\e[m\] \[\e[1;34m\]\w\[\e[m\] \[\e[1;32m\]\$\[\e[m\] '
 export PS1
 
-TERM="linux"
+case "$TERM" in
+
+    # Do nothing when TERM already set (e.g. by SSH) and known
+    (linux|nxterm|screen|vt100|vt100-am|xterm|xterm-color)
+        ;;
+
+    # Default to "linux" when unset
+    ("")
+        TERM="linux"
+        ;;
+
+    # Default to "xterm" when unknown
+    (*)
+        TERM="xterm"
+        ;;
+
+esac
 export TERM


### PR DESCRIPTION
Go with whatever is set by SSH, and fall back to "linux" if the terminal is not available.

This is needed to make htop and perf work over SSH (using XTerm and other terminal emulators).

PS Also add "screen" now.

This fixes #1975
