### PR TITLE
AppleTV: Skip internal auto-mounting of EFI and Recovery

### DIFF
--- a/packages/sysutils/udisks/init.d/31_mount-disks
+++ b/packages/sysutils/udisks/init.d/31_mount-disks
@@ -27,20 +27,34 @@
   progress "automount internal disks"
 
   drive_dump () {
-    udisks --dump | tr -d ' ' | grep 'device-file:' | cut -d ':' -f2
+    udisks --dump | awk '/^  device-file:/ { print $2 }'
   }
 
   show_info () {
-    udisks --show-info $2 | grep "$1:" | tr -d ' ' | cut -d ":" -f2
+    udisks --show-info $2 | awk "/$1:/ { print \$2; nextfile }"
   }
 
-  for DEVICE in `drive_dump`; do
-    REMOVABLE="`show_info "removable" $DEVICE`"
-    MOUNTED="`show_info "is mounted" $DEVICE`"
-    USAGE="`show_info "usage" $DEVICE`"
+  for DEVICE in $(drive_dump); do
 
-    if [ "$REMOVABLE" = "0" -a "$MOUNTED" = "0" -a "$USAGE" = "filesystem" ]; then
-      udisks --mount "$DEVICE" >/dev/null
+    if [ "$(show_info 'usage' $DEVICE)" != "filesystem" ]; then
+      # Skip device if not a filesystem
+      continue
+    elif [ "$(show_info 'removable' $DEVICE)" == "1" ]; then
+      # Skip device if removable
+      continue
+    elif [ "$(show_info 'is mounted' $DEVICE)" == "1" ]; then
+      # Skip device if already mounted
+      continue
+    else
+      case "$(show_info 'label' $DEVICE)" in
+        # Skip devices with known filesystem labels
+        ("EFI"|"Recovery")
+          ;;
+        # Mount everything else
+        (*)
+          udisks --mount "$DEVICE" >/dev/null
+          ;;
+      esac
     fi
 
   done


### PR DESCRIPTION
On AppleTV devices both EFI and Recovery are shown in the XBMC interface as a source for media (because they are mounted filesystems), however both partitions are not required for OpenELEC during XBMC runtime, so we avoid mounting them by default. As a positive side-effect it also prevents triggering hfsplus and vfat modules during boot.

Note that once we go back to single-boot mode, Recovery will be mounted during boot, so this change should not affect any progress in that field.

I also cleaned up the script so it is easier to read and needs less invocations of commands, and less system utilities are forked for parsing output (as we use awk now). So it should be somewhat faster.
