### PR TITLE
nvidia: Enable MSI (Message Signaled Interrupts)

### DIFF
--- a/projects/ATV/filesystem/etc/modprobe.d/nvidia.conf
+++ b/projects/ATV/filesystem/etc/modprobe.d/nvidia.conf
@@ -1,0 +1,2 @@
+# Enable MSI (Message Signaled Interrupts)
+options nvidia NVreg_EnableMSI=1


### PR DESCRIPTION
Only tested on ATV1, don't just enable it on other platforms without testing with known hardware.
