### PR TITLE
connman: disable unstable dnsproxy in connman. fixes unstable Internet on WIFI

### DIFF
--- a/packages/network/connman/init.d/21_network
+++ b/packages/network/connman/init.d/21_network
@@ -271,9 +271,9 @@ set_interface() {
     set_hwclock
 
     if [ -f $HOME/.config/debug.connman ]; then
-      /usr/sbin/connmand -nd > /dev/null 2>&1
+      /usr/sbin/connmand -nrd > /dev/null 2>&1
     else
-      /usr/sbin/connmand -n > /dev/null 2>&1
+      /usr/sbin/connmand -nr > /dev/null 2>&1
     fi
     usleep 250000
   done

--- a/packages/network/connman/install
+++ b/packages/network/connman/install
@@ -26,7 +26,7 @@ add_user system x 430 430 "service" "/var/run/connman" "/bin/sh"
 add_group system 430
 
 mkdir -p $INSTALL/etc
-  cp $PKG_DIR/config/resolv.conf $INSTALL/etc
+  ln -sf /var/cache/resolv.conf $INSTALL/etc/resolv.conf
 
 mkdir -p $INSTALL/etc/connman
   cp $PKG_DIR/config/main.conf $INSTALL/etc/connman


### PR DESCRIPTION
Hi,

I am trying to run OpenELEC over a WiFi connection but this is extremely unstable...
I always recommend not running on wifi do to this issue, cant we just solve this now. :-)

connman crashes from time to time and does not start right again.
dns servers are gone...

The wifi link is up and the local network is working but no dns so cant resolve...

I use the 8192cu driver with a dlink dwa-121 usb card... the router is 40cm from HTPC
this happens on bot RPi and ION system 
same with the built in card in ION box...

when this happens if I kill connmand a few times it starts working again...
in the wifi profile log it seams it cant connect or get the card status so it wont start right...
but the card seems up and running...

seems to be an issue in dnsproxy thats causing the crash...

running connmand -nr fixes this... "disabling dnsproxy"
reslov.conf needs to be writable to

I recommend disabling this until tested stable again.

Logs:
messages log: http://sprunge.us/Hdcf

wifi profile log: http://sprunge.us/iAFh
debug messages log: http://paste.ubuntu.com/1544383/

Bug Reported to meego: https://bugs.meego.com/show_bug.cgi?id=25956
