### PR TITLE
AppleTV: Disable ratpoison as it's not being used

### DIFF
--- a/projects/ATV/options
+++ b/projects/ATV/options
@@ -241,7 +241,7 @@
   OPENGLES="no"
 
 # Windowmanager to use (ratpoison / none)
-  WINDOWMANAGER="ratpoison"
+  WINDOWMANAGER="none"
 
 # Displayserver to use (xorg-server / no)
   DISPLAYSERVER="xorg-server"


### PR DESCRIPTION
Since we're not using a windowmanager, we might as well disable it until we need it. OpenELEC on AppleTV works fine without ratpoison.
