### PR TITLE
Move syslogd after network so we can log kernel messages to remote server

### DIFF
--- a/packages/sysutils/busybox/init.d/23_syslogd
+++ b/packages/sysutils/busybox/init.d/23_syslogd
@@ -28,10 +28,10 @@
 
   source /var/config/settings.conf
 
-  SYSLOGD_OPTIONS="-L"
+  SYSLOGD_OPTIONS="-L -D"
 
   if [ "$SYSLOG_REMOTE" == "true" -a "$SYSLOG_SERVER" ]; then
-    SYSLOGD_OPTIONS="$SYSLOGD_OPTIONS -R $SYSLOG_SERVER"
+    SYSLOGD_OPTIONS="-R $SYSLOG_SERVER $SYSLOGD_OPTIONS"
   fi
 
   if [ -f /storage/.config/syslog.conf ]; then


### PR DESCRIPTION
Since syslogd was started before the network was up, all syslog messages before the network was up were discarded and not send to the remoe syslog server. By moving the syslogd startup until after the network, the kernel boot messages are available on the central syslog.
