### PR TITLE
Fix build issue associated with XBMC PR2387

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-990.29-PR2387.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-990.29-PR2387.patch
@@ -6,9 +6,6 @@ Subject: [PATCH] [cec] rebased PR1794 + fixes for Frodo
 ---
  XBMC.xcodeproj/project.pbxproj                     |   13 +++
  configure.in                                       |   40 +------
- project/BuildDependencies/scripts/libcec_d.txt     |    2 +-
- project/VS2010Express/XBMC.vcxproj                 |    2 +
- project/VS2010Express/XBMC.vcxproj.filters         |    6 +
  system/peripherals.xml                             |   31 ++----
  tools/android/depends/libcec/Makefile              |    4 +-
  tools/darwin/depends/libcec/Makefile               |    2 +-
@@ -134,12 +131,6 @@ index 4769315..4472e3e 100644
  AC_SUBST(USE_MYSQL)
  AC_SUBST(USE_WEB_SERVER)
  AC_SUBST(USE_UPNP)
-diff --git a/project/BuildDependencies/scripts/libcec_d.txt b/project/BuildDependencies/scripts/libcec_d.txt
-index c1419b5..2c7d495 100644
-diff --git a/project/VS2010Express/XBMC.vcxproj b/project/VS2010Express/XBMC.vcxproj
-index fb0947e..7e32ccc 100644
-diff --git a/project/VS2010Express/XBMC.vcxproj.filters b/project/VS2010Express/XBMC.vcxproj.filters
-index 53a6c97..52a5373 100644
 diff --git a/system/peripherals.xml b/system/peripherals.xml
 index 967b96c..68205df 100644
 --- a/system/peripherals.xml


### PR DESCRIPTION
The patch attempted to patch 3 files located in ${XBMC_SRC}/project/ -- This directory does not exist in the OpenELEC-provided XBMC tarballs.

The associated lines have been removed from the patch, and the build progresses (past that point).
