### PR TITLE
connman: disable BackgroundScanning.

### DIFF
--- a/packages/network/connman/config/main.conf
+++ b/packages/network/connman/config/main.conf
@@ -4,4 +4,4 @@
 # Background scanning will start every 5 minutes unless
 # the scan list is empty. In that case, a simple backoff
 # mechanism starting from 10s up to 5 minutes will run.
-BackgroundScanning = true
+BackgroundScanning = false


### PR DESCRIPTION
We don’t use it anyway and it makes WIFI a little unstable.
At least on RPi.

Tested and should be safe.
