### PR TITLE
Make tvheadend not send debug message to syslog

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
+++ b/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
@@ -94,7 +94,11 @@ if [ ! -f "$TIMESHIFT_SETTINGS_FILE" ]; then
   fi
 fi
 
-TVHEADEND_ARG="-C -s -u root -g video -c $ADDON_HOME"
+if [ "$DEBUG" = "yes" ]; then
+    TVHEADEND_ARG="-C -s -u root -g video -c $ADDON_HOME"
+else
+    TVHEADEND_ARG="-C -u root -g video -c $ADDON_HOME"
+fi
 
 mkdir -p /var/config
   if [ -f $ADDON_DIR/settings-default.xml ]; then


### PR DESCRIPTION
Apparently tvheadend by default uses the syslog service, and the `-s` option that we provide in the startup script in fact makes tvheadend send debug messages to syslog (which we obviously do not want by default as this causes for my single DVB card 1k/min to /var, which is 4MB/month). So this fix disables the `-s` option in the tvheadend startup script.
