### PR TITLE
connman: re-enable background scanning, needed for router changes.

### DIFF
--- a/packages/network/connman/config/main.conf
+++ b/packages/network/connman/config/main.conf
@@ -4,4 +4,4 @@
 # Background scanning will start every 5 minutes unless
 # the scan list is empty. In that case, a simple backoff
 # mechanism starting from 10s up to 5 minutes will run.
-BackgroundScanning = false
+BackgroundScanning = true


### PR DESCRIPTION
Yes we do need this.
don't think it did any real difference in the first place.

with out:
if channel change connection lost.
if router restart connection lost.

so lets re-enable this again. :-)
