### PR TITLE
Added shutdown script:

### DIFF
--- a/packages/mediacenter/xbmc/init.d/93_xbmc
+++ b/packages/mediacenter/xbmc/init.d/93_xbmc
@@ -37,7 +37,7 @@ fi
   chmod +x /storage/.xbmc/addons/*/bin/* > /dev/null 2>&1
 
 # write Logs to storage if needed 
-  LOGFILE="$((test -d /storage/log) && echo '/var' || echo '/storage')/log/messages"
+  LOGFILE="/var/log/messages"
 
 # starting autostart script
   AUTOSTART="/storage/.config/autostart.sh"


### PR DESCRIPTION
Call of user script in /storage/.config/shutdown.sh from /etc/init.d/93_xbmc.
It also gets the current exit code of xbmc.bin (quit|powerdown|reboot) as parameter ($1), so the script can differentiate spezial actions.
