### PR TITLE
Fix weird typo

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
+++ b/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
@@ -95,9 +95,9 @@ if [ ! -f "$TIMESHIFT_SETTINGS_FILE" ]; then
 fi
 
 if [ "$DEBUG" = "yes" ]; then
-  ADEND_ARG="-C -s -u root -g video -c $ADDON_HOME"
+  TVHEADEND_ARG="-C -s -u root -g video -c $ADDON_HOME"
 else
-  ADEND_ARG="-C -u root -g video -c $ADDON_HOME"
+  TVHEADEND_ARG="-C -u root -g video -c $ADDON_HOME"
 fi
 
 mkdir -p /var/config


### PR DESCRIPTION
Not sure what happened here, but obviously ADEND_ARG should have been TVHEADEND_ARG. Completely clueness how this has come about.
