### PR TITLE
openssh: add cosmetic patch to silence 'no such identity: xxxx' errors

### DIFF
--- a/packages/network/openssh/patches/openssh-silence-missing-identity-error.patch
+++ b/packages/network/openssh/patches/openssh-silence-missing-identity-error.patch
@@ -1,0 +1,14 @@
+diff --git a/sshconnect2.c b/sshconnect2.c
+index d6af0b9..22c0aa6 100644
+--- a/sshconnect2.c
++++ b/sshconnect2.c
+@@ -1320,8 +1320,7 @@ load_identity_file(char *filename, int userprovided)
+ 	struct stat st;
+ 
+ 	if (stat(filename, &st) < 0) {
+-		(userprovided ? logit : debug3)("no such identity: %s: %s",
+-		    filename, strerror(errno));
++		debug3("no such identity: %s", filename);
+ 		return NULL;
+ 	}
+ 	private = key_load_private_type(KEY_UNSPEC, filename, "", NULL, &perm_ok);


### PR DESCRIPTION
after update to openssh-6.2p1 there is an annoying error message on every connect.

```
no such identity: /storage/.ssh/id_rsa: No such file or directory
no such identity: /storage/.ssh/id_dsa: No such file or directory
```

the error should be printed only in debug level 3 (ssh -vvv). this cosmetial patch restores the old behaviour.
