### PR TITLE
Mount /var as tmpfs (not ramfs) and limit the use of tmpfs

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -23,9 +23,9 @@
 ################################################################################
 
 # mount all needed special filesystems
-  /bin/busybox mount -t devtmpfs none /dev
-  /bin/busybox mount -t proc none /proc
-  /bin/busybox mount -t sysfs none /sys
+  /bin/busybox mount -t devtmpfs devtmpfs /dev
+  /bin/busybox mount -t proc proc /proc
+  /bin/busybox mount -t sysfs sysfs /sys
 
 # set needed variables
   MODULE_DIR=/lib/modules

--- a/packages/sysutils/busybox/init.d/01_mount-filesystem
+++ b/packages/sysutils/busybox/init.d/01_mount-filesystem
@@ -25,10 +25,10 @@
 
 progress "mounting needed filesystems"
   mkdir -p /dev/pts
-  mount -n -t devpts -o gid=5,mode=620 none /dev/pts
+  mount -n -t devpts -o gid=5,mode=620 devpts /dev/pts
 
   mkdir -p /dev/shm
-  mount -n -t tmpfs none /dev/shm
+  mount -n -t tmpfs -o size=20% tmpfs /dev/shm
 
-  mount -n -t ramfs none /var
-  mount -n -t debugfs none /sys/kernel/debug
+  mount -n -t tmpfs -o size=5% tmpfs /var
+  mount -n -t debugfs debugfs /sys/kernel/debug


### PR DESCRIPTION
This commit (apart from the cosmetic change to avoid using 'none') changes the use of ramfs into tmpfs. The reason for this is that ramfs usage can fill 100% of RAM and cannot be swapped out. While tmpfs can be swapped out and can be limited in size.

The size chosen is arbitrary, but taking into account the ATV1 hardware 5% of 256MB means 12MB and 20% means 50MB, considering we have swap this is not too drastic. For any larger system, these sizes are fine as well as we do not expect /var or /dev/shm to be filled completely. So worst case is covered, but not expected.
