### PR TITLE
smem: update to v1.3 (for kernel 3.8)

### DIFF
--- a/packages/debug/smem/meta
+++ b/packages/debug/smem/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="smem"
-PKG_VERSION="1.2"
+PKG_VERSION="1.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
Needed for new kernel 3.8.5
