### PR TITLE
Fix for issue #1987

### DIFF
--- a/packages/linux/patches/3.8.6/linux-700-jmicron_1_0_8_5.patch
+++ b/packages/linux/patches/3.8.6/linux-700-jmicron_1_0_8_5.patch
@@ -979,9 +979,9 @@ diff -Naur linux-3.7.2/drivers/net/ethernet/jme.c linux-3.7.2.patch/drivers/net/
  	.ndo_start_xmit		= jme_start_xmit,
  	.ndo_set_mac_address	= jme_set_macaddr,
 -	.ndo_set_rx_mode	= jme_set_multi,
-+#if LINUX_VERSION_CODE < KERNEL_VERSION(3,2,0)
-+	.ndo_set_multicast_list	= jme_set_multi,
-+#endif
++	.ndo_set_rx_mode	= jme_set_multi,
++
++
  	.ndo_change_mtu		= jme_change_mtu,
  	.ndo_tx_timeout		= jme_tx_timeout,
 -	.ndo_fix_features       = jme_fix_features,


### PR DESCRIPTION
The problem exists in the jmicron 1.0.8.5 source.
The problem has been fixed in the vanilla kernel.
This patch file appears to be generated by diffing the vanilla kernel source
and the jmicron source, thus introducing the problem to the build.
This changeset edits the patch file to remove the problem.
This is not ideal as this fix will be easily lost if a new patch file is
generated.
The best solution would be to fix the problem in the original jmicron source.
However this dpoes not appear to possible at the moment.
