### PR TITLE
Changed any found references to INSTALL file, which is empty for now.

### DIFF
--- a/README.md
+++ b/README.md
@@ -14,7 +14,7 @@ providing cutting edge hardware support to deliver a set-top box experience.
 
 **Installation**
 
-* Please read INSTALL for instructions on how to install.
+* Installation instructions can be found on [OpenELEC Wiki](http://wiki.openelec.tv/index.php?title=Installation)
 
 **Known issues**
 

--- a/packages/tools/syslinux/files/create_livestick
+++ b/packages/tools/syslinux/files/create_livestick
@@ -228,7 +228,6 @@ EOF
 #  cp Autorun.inf /tmp/usb_install
   cp openelec.ico /tmp/usb_install
   cp CHANGELOG /tmp/usb_install
-  cp INSTALL /tmp/usb_install
   cp README.md /tmp/usb_install
   cp RELEASE /tmp/usb_install
 

--- a/packages/tools/syslinux/files/create_livestick.bat
+++ b/packages/tools/syslinux/files/create_livestick.bat
@@ -93,7 +93,6 @@ IF ERRORLEVEL 1 goto InvalidDrive
 >NUL 3rdparty\syslinux\win32\syslinux.exe -f -m -a %DRIVE%
 >NUL copy target\* %DRIVE%
 >NUL copy CHANGELOG %DRIVE%
->NUL copy INSTALL %DRIVE%
 >NUL copy README.md %DRIVE%
 >NUL copy RELEASE %DRIVE%
 >NUL copy openelec.ico %DRIVE%

--- a/tools/nsis-installer/oeinstaller.nsi
+++ b/tools/nsis-installer/oeinstaller.nsi
@@ -104,7 +104,6 @@ Section "oeusbstart"
   nsExec::Exec `"$0" /c copy Autorun.inf $DRIVE_LETTER`
   nsExec::Exec `"$0" /c copy openelec.ico $DRIVE_LETTER`
   nsExec::Exec `"$0" /c copy CHANGELOG $DRIVE_LETTER`
-  nsExec::Exec `"$0" /c copy INSTALL $DRIVE_LETTER`
   nsExec::Exec `"$0" /c copy README.md $DRIVE_LETTER`
   nsExec::Exec `"$0" /c copy RELEASE $DRIVE_LETTER`
   nsExec::Exec `"$0" /c copy 3rdparty\syslinux\vesamenu.c32 $DRIVE_LETTER`


### PR DESCRIPTION
"Fixes" #1654

As far as all install instructions are available online, there's no sense of keeping `INSTALL` file, which BTW is empty. 
