### PR TITLE
lirc_rpi: added vista mce and changed KEY_BACK to KEY_EXIT

### DIFF
--- a/packages/sysutils/remote/lirc/config/lircd.conf.rpi
+++ b/packages/sysutils/remote/lirc/config/lircd.conf.rpi
@@ -140,7 +140,7 @@ begin remote
         KEY_TV        0x00007bda
         KEY_DVD           0x00007bdb
 #NoGap
-        KEY_BACK          0x00007bdc
+        KEY_EXIT          0x00007bdc
         KEY_OK            0x00007bdd
         KEY_RIGHT         0x00007bde
         KEY_LEFT          0x00007bdf
@@ -186,6 +186,83 @@ begin remote
 
 end remote
 
+#
+# contributed by stevvie and jenkins101 
+#
+# brand:  SIIG Vista MCE remote
+# model no. of remote control: older Harmony and some vista mce remotes
+# devices being controlled by this remote:
+#
+
+begin remote
+
+  name  vista_mce
+  bits           16
+  flags RC6
+  eps            30
+  aeps          100
+
+  header       2654   889
+  one           427   427
+  zero          427   427
+  pre_data_bits   21
+  pre_data       0x37FF0
+  gap          69850
+  min_repeat      4
+# increase to suppress unwanted repeats
+  suppress_repeat 4
+  toggle_bit_mask 0x8000
+  rc6_mask    0x100000000
+
+      begin codes
+          KEY_POWER                0xEBF3 # Power
+          KEY_CAMERA          	   0x6BB6 # Pictures
+          KEY_RADIO                0xEBAF # Radio
+          KEY_VIDEO            	   0x6BB5 # Videos
+          KEY_MUSIC          	   0xEBB8 # Music
+          KEY_RECORD               0x6BE8 # Rec
+          KEY_PAUSE          	   0xEBE7 # Pause
+          KEY_STOP          	   0x6BE6 # Stop
+          KEY_PREVIOUS        	   0xEBE4 # Skipback
+          KEY_PLAY          	   0x6BE9 # Play
+          KEY_NEXT          	   0xEBE5 # Skipfwd
+          KEY_REWIND          	   0x6BEA # Rwd
+          KEY_FORWARD              0xEBEB # Fwd
+          KEY_HOME                 0x6BF2 # Start
+          KEY_EXIT          	   0xEBDC # Back
+          KEY_INFO          	   0x6BF0 # More
+          KEY_VOLUMEUP             0xEBEF # Volup
+          KEY_VOLUMEDOWN           0x6BEE # Voldown
+          KEY_CHANNELUP            0xEBED # Chup
+          KEY_CHANNELDOWN          0x6BEC # Chdown
+          KEY_UP          	   0xEBE1 # Up
+          KEY_DOWN          	   0x6BE0 # Down
+          KEY_LEFT          	   0xEBDF # Left
+          KEY_RIGHT          	   0x6BDE # Right
+          KEY_MUTE          	   0xEBF1 # Mute
+          KEY_PVR                  0x6BB7 # Rectv
+          KEY_TITLE          	   0xEBD9 # Guide
+          KEY_TV                   0x6BDA # Livetv
+          KEY_MENU          	   0xEBDB # Dvdmenu
+          KEY_1          	   0x6BFE # 1
+          KEY_2          	   0xEBFD # 2
+          KEY_3          	   0x6BFC # 3
+          KEY_4          	   0xEBFB # 4
+          KEY_5          	   0x6BFA # 5
+          KEY_6          	   0xEBF9 # 6
+          KEY_7          	   0x6BF8 # 7
+          KEY_8          	   0xEBF7 # 8
+          KEY_9          	   0x6BF6 # 9
+          KEY_NUMERIC_STAR         0xEBE2 # *
+          KEY_0          	   0x6BFF # 0
+          KEY_NUMERIC_POUND        0xEBE3 # #
+          KEY_CLEAR          	   0x6BF5 # Clear
+          KEY_ENTER          	   0xEBF4 # Enter
+      end codes
+
+end remote
+
+#
 # this config file was automatically generated
 # using lirc-0.8.2(macmini) on Tue Dec 11 11:35:26 2007
 #
@@ -340,7 +417,7 @@ begin remote
           KEY_REWIND               0x0BEA
           KEY_PLAYPAUSE            0x0BE9
           KEY_FASTFORWARD          0x0BEB
-          KEY_BACK                 0x0BDC
+          KEY_EXIT                 0x0BDC
           KEY_TITLE                0x0BAE
           KEY_STOP                 0x0BE6
           KEY_INFO                 0x0BF0


### PR DESCRIPTION
added vista mce, some Harmonys use this. and changed BACK to EXIT, it is missing in Lircmap.xml
