### PR TITLE
Wrong partition name used for devices ending with numbers

### DIFF
--- a/packages/tools/syslinux/files/create_livestick
+++ b/packages/tools/syslinux/files/create_livestick
@@ -42,7 +42,12 @@ if [ -z "$1" ]; then
 fi
 
 DISK="$1"
-PART="${DISK}1"
+
+### If DISK ends with a number, add "p1" instead of "1" for the first partition
+case "${DISK: -1:1}" in
+    ([0-9]) PART="${DISK}p1";;
+    (*)     PART="${DISK}1";;
+esac
 
 clear
 echo "#########################################################"


### PR DESCRIPTION
On Linux when a block device ends with a number (like my SD card device: **/dev/mmcblk0**) the first partition is called **/dev/mmcblk0p1** (with an added **p**). This snippet makes sure that the correct partition name is used in both cases.
