### PR TITLE
Use the host's vesamenu.c32 as well

### DIFF
--- a/packages/tools/syslinux/files/create_livestick
+++ b/packages/tools/syslinux/files/create_livestick
@@ -232,8 +232,15 @@ EOF
   cp README.md /tmp/usb_install
   cp RELEASE /tmp/usb_install
 
-  cp 3rdparty/syslinux/vesamenu.c32 /tmp/usb_install
   cp splash.png /tmp/usb_install
+
+  if [ -f /usr/lib/syslinux/vesamenu.c32 ]; then
+    cp /usr/lib/syslinux/vesamenu.c32 /tmp/usb_install
+  elif [ -f /usr/share/syslinux/vesamenu.c32 ]; then
+    cp /usr/share/syslinux/vesamenu.c32 /tmp/usb_install
+  else
+    echo "ERROR: Can't find syslinux's vesamenu.c32 on Host OS" >&2
+  fi
 
 # sync disk
   echo "syncing disk..."
@@ -250,7 +257,7 @@ EOF
   elif [ -f /usr/share/syslinux/mbr.bin ]; then
     MBR="/usr/share/syslinux/mbr.bin"     # example: fedora
   else
-    echo "Can't find syslinux's mbr.bin on Host OS"
+    echo "ERROR: Can't find syslinux's mbr.bin on Host OS" >&2
   fi
 
   if [ -n "$MBR" ]; then


### PR DESCRIPTION
When using syslinux and C32 modules it's important to use the C32 modules build with the same syslinux. This patch ensures that we use the host OS's vesamenu.c32, rather than the one shipped in the tarball.
