### PR TITLE
Fix slow syslogd remote syslog startup and klogd interaction

### DIFF
--- a/packages/sysutils/busybox/init.d/23_syslogd
+++ b/packages/sysutils/busybox/init.d/23_syslogd
@@ -30,7 +30,7 @@
     source /storage/.cache/syslog/remote
   fi
 
-  SYSLOGD_OPTIONS="-L -D"
+  SYSLOGD_OPTIONS="-L"
 
   if [ "$SYSLOG_REMOTE" == "true" -a "$SYSLOG_SERVER" ]; then
     SYSLOGD_OPTIONS="-R $SYSLOG_SERVER $SYSLOGD_OPTIONS"
@@ -41,6 +41,8 @@
   fi
 
   syslogd $SYSLOGD_OPTIONS
+
+  sleep 3
 
   progress "Starting Kernellog daemon"
     klogd


### PR DESCRIPTION
Because syslogd is not properly started its remote syslog support when klogd dumps its kernel ring buffer content to it, most of the kernel boot output is missing on the remote syslog server. By adding a small delay between syslogd and klogd, we are sure the messages are properly send to the remote syslog by syslogd.
