### PR TITLE
vdr-addon: make searchtimers work

### DIFF
--- a/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
+++ b/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
@@ -62,7 +62,7 @@ done
 . /var/config/vdr.conf.default
 . /var/config/vdr.conf
 
-VDR_ARG="-g /tmp --no-kbd --log=3 --port=0"
+VDR_ARG="-g /tmp --no-kbd --log=3"
 VDR_ARG="$VDR_ARG --config=$ADDON_CONFIG_DIR"
 VDR_ARG="$VDR_ARG --resdir=$ADDON_DIR/res"
 VDR_ARG="$VDR_ARG --cachedir=$ADDON_CACHE_DIR"
@@ -125,7 +125,7 @@ fi
     sed -i -e '/^epgsearch.SVDRPPort.*$/d' $ADDON_CONFIG_DIR/setup.conf
   fi
   cat >>$ADDON_CONFIG_DIR/setup.conf << MYDATA
-epgsearch.SVDRPPort = 2004
+epgsearch.SVDRPPort = 6419
 MYDATA
 
 )


### PR DESCRIPTION
With --port=0 on the command line of vdr, SVDRP is disabled, making the vdr-plugins epgsearch and live much less usefull; default SVDRP port has changed to 6419.
