### PR TITLE
Put libthread_db.so into the correct location for gdb

### DIFF
--- a/packages/toolchain/devel/eglibc/install
+++ b/packages/toolchain/devel/eglibc/install
@@ -44,7 +44,7 @@ mkdir -p $INSTALL/usr/lib
   cp $PKG_BUILD/objdir-$1/login/libutil.so.1 $INSTALL/usr/lib # e.g. for utmp support, needed by PAM_filter
 
 
-  [ "$DEVTOOLS" = yes ] && cp $PKG_BUILD/objdir-$1/nptl_db/libthread_db.so.1 $INSTALL/lib # for GDB
+  [ "$DEVTOOLS" = yes ] && cp $PKG_BUILD/objdir-$1/nptl_db/libthread_db.so.1 $INSTALL/usr/lib # for GDB
 
 mkdir -p $INSTALL/usr/bin
   cp $PKG_BUILD/objdir-$1/elf/ldd $INSTALL/usr/bin


### PR DESCRIPTION
Otherwise we get:

```
warning: Unable to find libthread_db matching inferior's thread library, thread debugging will not be available.
```
