### PR TITLE
xbmc: revert 799d6ff03 (setwakeup.sh)

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-996.02-xbmc-revert-799d6ff03-setwakeup.sh.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-996.02-xbmc-revert-799d6ff03-setwakeup.sh.patch
@@ -1,0 +1,27 @@
+From 7abb1f31a53cc0147ba6f5ed5fc796e2ac8584ff Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Thu, 9 May 2013 21:11:47 +0300
+Subject: [PATCH] xbmc: revert 799d6ff03 (setwakeup.sh)
+
+this reverts upstream commit 799d6ff03
+https://github.com/xbmc/xbmc/commit/799d6ff03
+---
+ xbmc/settings/GUISettings.cpp |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/xbmc/settings/GUISettings.cpp b/xbmc/settings/GUISettings.cpp
+index 67aeec9..96f738c 100644
+--- a/xbmc/settings/GUISettings.cpp
++++ b/xbmc/settings/GUISettings.cpp
+@@ -1001,7 +1001,7 @@ void CGUISettings::Initialize()
+   AddBool(pvrpwr, "pvrpowermanagement.enabled", 305, false);
+   AddSeparator(pvrpwr, "pvrpowermanagement.sep1");
+   AddInt(pvrpwr, "pvrpowermanagement.backendidletime", 19244, 15, 0, 5, 360, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF);
+-  AddString(pvrpwr, "pvrpowermanagement.setwakeupcmd", 19245, "", EDIT_CONTROL_INPUT, true);
++  AddString(pvrpwr, "pvrpowermanagement.setwakeupcmd", 19245, "/usr/bin/setwakeup.sh", EDIT_CONTROL_INPUT, true);
+   AddInt(pvrpwr, "pvrpowermanagement.prewakeup", 19246, 15, 0, 1, 60, SPIN_CONTROL_INT_PLUS, MASK_MINS, TEXT_OFF);
+   AddSeparator(pvrpwr, "pvrpowermanagement.sep2");
+   AddBool(pvrpwr, "pvrpowermanagement.dailywakeup", 19247, false);
+-- 
+1.7.2.5
+


### PR DESCRIPTION
as we ship own setwakeup.sh script, with the above upstream
commit wakeup for recording with tvheadend/vdr
won't work with *new installs". most of our novice users
are clueless how to configure it
