### PR TITLE
atv: advancedsettings.xml tweaks

### DIFF
--- a/projects/ATV/xbmc/advancedsettings.xml
+++ b/projects/ATV/xbmc/advancedsettings.xml
@@ -3,6 +3,8 @@
   <showexitbutton>false</showexitbutton>
   <cputempcommand>gputemp</cputempcommand>
   <gputempcommand>gputemp</gputempcommand>
+  <fanartres>720</fanartres>
+  <imageres>540</imageres>
   <video>
     <latency>
       <delay>0</delay>
@@ -18,9 +20,10 @@
     <clienttimeout>30</clienttimeout>
   </samba>
   <network>
+    <cachemembuffersize>20971520</cachemembuffersize>  
     <curlclienttimeout>30</curlclienttimeout>
   </network>
-<!-- audio workaround for ATV -->
+  <!-- audio workaround for ATV -->
   <audiooutput>
     <dtshdpassthrough>false</dtshdpassthrough>
     <passthroughaac>false</passthroughaac>


### PR DESCRIPTION
default fanart/imgres config borrowed from RPi to improve GUI speed when browsing the library and file lists, and we add some network buffering (not sure if this helps, but I can't see it hurting either).
