### PR TITLE
vdr-plugin: xmltv2vdr:

### DIFF
--- a/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
+++ b/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
@@ -111,7 +111,8 @@ if [ "$ENABLE_EPGSEARCH" == "true" ] ; then
   VDR_ARG="$VDR_ARG -P epgsearch"
 fi
 if [ "$ENABLE_XMLTV2VDR" == "true" ] ; then
-  VDR_ARG="$VDR_ARG -P xmltv2vdr"
+  [ ! -e /var/run/vdr ] && ln -s /dev/shm /var/run/vdr
+  VDR_ARG="$VDR_ARG -P 'xmltv2vdr --epgfile=$ADDON_CACHE_DIR/epg.db'"
 fi
 
 (


### PR DESCRIPTION
use VDR_CACHE_DIR for epg.db

In 5de4a850ecbe9b0e8de35030b4f4bf32357ee412 we introduced tmpfs over ramfs.
At the same time limiting /tmp to 10MB.
Although this sounds reasonabe my grabber needs about 12 MB temoprary storage and thus failing during import.

This commit changes this by createing "/var/run/vdr" which is preferred by xmltv2vdr.
At the same time linking this to /dev/shm which ich mounted as tmpfs as well but using 20% of memory, hoping this is more than 10MB.
