### PR TITLE
ConsoleKit: limit number of ck threads

### DIFF
--- a/packages/sysutils/ConsoleKit/patches/ConsoleKit-do-not-spawn-too-much-threads.patch
+++ b/packages/sysutils/ConsoleKit/patches/ConsoleKit-do-not-spawn-too-much-threads.patch
@@ -1,0 +1,25 @@
+From e8d8a3dadcaa32eeb9f2f27f9774e52e5ec70dde Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sat, 8 Jun 2013 22:21:41 +0300
+Subject: [PATCH] do not spawn too much threads
+
+---
+ src/ck-sysdeps-linux.c |    2 +-
+ 1 files changed, 1 insertions(+), 1 deletions(-)
+
+diff --git a/src/ck-sysdeps-linux.c b/src/ck-sysdeps-linux.c
+index a95272e..264fe22 100644
+--- a/src/ck-sysdeps-linux.c
++++ b/src/ck-sysdeps-linux.c
+@@ -687,7 +687,7 @@ gboolean
+ ck_get_max_num_consoles (guint *num)
+ {
+         if (num != NULL) {
+-                *num = MAX_NR_CONSOLES;
++                *num = 1;
+         }
+ 
+         return TRUE;
+-- 
+1.7.2.5
+


### PR DESCRIPTION
why fork 63+ threads to moniitor all (possible) VTs when we don't need it? we don't have login/logout stuff. we need ck as a daemon (and dbus service) only for xbmc shutdown/reboot
