### PR TITLE
Added AUGUST DVB-T205 usb stick ID in rtl28xxu kernel module

### DIFF
--- a/packages/linux/patches/3.6.11/linux-060-add_AUGUST_DVB-T205.patch
+++ b/packages/linux/patches/3.6.11/linux-060-add_AUGUST_DVB-T205.patch
@@ -1,0 +1,46 @@
+diff -Naur linux-3.6.11/drivers/media/dvb/dvb-usb/rtl28xxu.c linux-3.6.11.patch/drivers/media/dvb/dvb-usb/rtl28xxu.c
+--- linux-3.6.11/drivers/media/dvb/dvb-usb/rtl28xxu.c	2012-12-17 18:27:45.000000000 +0100
++++ linux-3.6.11.patch/drivers/media/dvb/dvb-usb/rtl28xxu.c	2013-06-09 13:59:45.099765027 +0200
+@@ -1154,6 +1154,7 @@
+ 	RTL2831U_0BDA_2831,
+ 	RTL2831U_14AA_0160,
+ 	RTL2831U_14AA_0161,
++	RTL2832U_1F4D_A803,
+ 	RTL2832U_0CCD_00A9,
+ 	RTL2832U_1F4D_B803,
+ 	RTL2832U_0CCD_00B3,
+@@ -1169,6 +1170,8 @@
+ 		USB_DEVICE(USB_VID_WIDEVIEW, USB_PID_FREECOM_DVBT_2)},
+ 
+ 	/* RTL2832U */
++	[RTL2832U_1F4D_A803] = {
++		USB_DEVICE(USB_VID_GTEK, USB_PID_AUGUST_DVB_T205_STICK)},
+ 	[RTL2832U_0CCD_00A9] = {
+ 		USB_DEVICE(USB_VID_TERRATEC, USB_PID_TERRATEC_CINERGY_T_STICK_BLACK_REV1)},
+ 	[RTL2832U_1F4D_B803] = {
+@@ -1288,9 +1291,15 @@
+ 
+ 		.i2c_algo = &rtl28xxu_i2c_algo,
+ 
+-		.num_device_descs = 3,
++		.num_device_descs = 4,
+ 		.devices = {
+ 			{
++				.name = "August DVB-T205",
++				.warm_ids = {
++					&rtl28xxu_table[RTL2832U_1F4D_A803],
++				},
++			},
++			{
+ 				.name = "Terratec Cinergy T Stick Black",
+ 				.warm_ids = {
+ 					&rtl28xxu_table[RTL2832U_0CCD_00A9],
+diff -Naur linux-3.6.11/drivers/media/dvb/dvb-usb/dvb-usb-ids.h linux-3.6.11.patch/drivers/media/dvb/dvb-usb/dvb-usb-ids.h
+--- linux-3.6.11/drivers/media/dvb/dvb-usb/dvb-usb-ids.h	2012-12-17 18:27:45.000000000 +0100
++++ linux-3.6.11.patch/drivers/media/dvb/dvb-usb/dvb-usb-ids.h	2013-06-09 13:59:47.127739532 +0200
+@@ -358,4 +358,5 @@
+ #define USB_PID_TECHNISAT_USB2_HDCI_V2			0x0002
+ #define USB_PID_TECHNISAT_AIRSTAR_TELESTICK_2		0x0004
+ #define USB_PID_TECHNISAT_USB2_DVB_S2			0x0500
++#define USB_PID_AUGUST_DVB_T205_STICK			0xa803
+ #endif


### PR DESCRIPTION
Allows AUGUST DVB-T205 usb stick to be recognized by rtl28xxu driver
