### PR TITLE
atvclient: add support for macmini and macbook ir sensors

### DIFF
--- a/packages/sysutils/remote/atvclient/patches/atvclient-0.1-macbook_macmini_support.patch
+++ b/packages/sysutils/remote/atvclient/patches/atvclient-0.1-macbook_macmini_support.patch
@@ -1,0 +1,31 @@
+--- a/src/atvclient.cpp
++++ b/src/atvclient.cpp
+@@ -24,8 +24,16 @@
+ 
+ #include "xbmcclient.h"
+ 
+-#define VENDOR_APPLE		0x05ac
+-#define PRODUCT_IR		0x8241
++#define VENDOR_APPLE          0x05ac
++#define PRODUCT_APPLE_IR_0    0x8240
++#define PRODUCT_APPLE_IR_1    0x8241
++#define PRODUCT_APPLE_IR_2    0x8242
++
++#define IS_APPLE_REMOTE(dev) ((dev->descriptor.idVendor == VENDOR_APPLE) && \
++                              ((dev->descriptor.idProduct == PRODUCT_APPLE_IR_0) || \
++                               (dev->descriptor.idProduct == PRODUCT_APPLE_IR_1) || \
++                               (dev->descriptor.idProduct == PRODUCT_APPLE_IR_2)))
++
+ 
+ #define LEDMODE_OFF		0
+ #define LEDMODE_AMBER		1
+@@ -264,8 +272,7 @@ static usb_dev_handle *find_ir(void)
+ 
+ 	for (bus = usb_busses; bus; bus = bus->next) {
+ 		for (dev = bus->devices; dev; dev = dev->next)
+-			if (dev->descriptor.idVendor == VENDOR_APPLE
+-			    && dev->descriptor.idProduct == PRODUCT_IR)
++			    if(IS_APPLE_REMOTE(dev))
+ 				return usb_open(dev);
+ 	}
+


### PR DESCRIPTION
thanks to fritsch, this adds support for Apple IR sensors used with MacBook and Mac mini hardware - confirmed working via users in the forums
