### PR TITLE
atv: advancedsettings tweak

### DIFF
--- a/projects/ATV/xbmc/advancedsettings.xml
+++ b/projects/ATV/xbmc/advancedsettings.xml
@@ -3,6 +3,8 @@
   <showexitbutton>false</showexitbutton>
   <cputempcommand>gputemp</cputempcommand>
   <gputempcommand>gputemp</gputempcommand>
+  <fanartres>720</fanartres>
+  <imageres>540</imageres>
   <video>
     <latency>
       <delay>0</delay>
@@ -20,7 +22,7 @@
   <network>
     <curlclienttimeout>30</curlclienttimeout>
   </network>
-<!-- audio workaround for ATV -->
+  <!-- audio workaround for ATV -->
   <audiooutput>
     <dtshdpassthrough>false</dtshdpassthrough>
     <passthroughaac>false</passthroughaac>


### PR DESCRIPTION
reduce the default size of thumbnails to improve speed of skin navigation (same as pi)
