### PR TITLE
linux modules : adding support for AUGUST DVB-T205 USB DVB stick to 3.9.5 kernel module rtl28xxu

### DIFF
--- a/packages/linux/patches/3.9.5/linux-060-add_AUGUST_DVB-T205.patch
+++ b/packages/linux/patches/3.9.5/linux-060-add_AUGUST_DVB-T205.patch
@@ -1,0 +1,12 @@
+diff -Naur linux-3.9.5/drivers/media/usb/dvb-usb-v2/rtl28xxu.c linux-3.9.5.patch/drivers/media/usb/dvb-usb-v2/rtl28xxu.c
+--- linux-3.9.5/drivers/media/usb/dvb-usb-v2/rtl28xxu.c	2013-06-07 21:54:00.000000000 +0200
++++ linux-3.9.5.patch/drivers/media/usb/dvb-usb-v2/rtl28xxu.c	2013-06-13 14:48:38.110705193 +0200
+@@ -1372,6 +1372,8 @@
+ 		&rtl2832u_props, "Digivox Micro Hd", NULL) },
+ 	{ DVB_USB_DEVICE(USB_VID_COMPRO, 0x0620,
+ 		&rtl2832u_props, "Compro VideoMate U620F", NULL) },
++	{ DVB_USB_DEVICE(USB_VID_GTEK, 0xa803,
++		&rtl2832u_props, "Realtek RTL2832U reference design", NULL) },
+ 	{ }
+ };
+ MODULE_DEVICE_TABLE(usb, rtl28xxu_id_table);


### PR DESCRIPTION
So that this device is supported on 3.0.x branch and master branch
