### PR TITLE
MySQL support should not be magically detected (xbmc-pvr-addons fails to build)

### DIFF
--- a/packages/mediacenter/xbmc-pvr-addons/build
+++ b/packages/mediacenter/xbmc-pvr-addons/build
@@ -29,6 +29,7 @@ cd $PKG_BUILD
             --prefix=/usr/share/xbmc \
             --disable-static \
             --enable-addons-with-dependencies \
+	    --$( [[ $MYSQL_SUPPORT = yes ]] && echo enable || echo disable)-mysql \
             --enable-shared
 
 make


### PR DESCRIPTION
MySQL installed on the build host would get autodetected even if `MYSQL_SUPPORT` is not set to yes. And then xbmc-pvr-addons fails to build with:

```
libcmyth/cmyth_local.h:39:25: fatal error: mysql/mysql.h: No such file
```

or directory

To reproduce, I guess you can have MySQL installed on the host, and `MSYQL_SUPPORT=no` in your config. MySQL will not get pulled in as a dependency when building OpenELEC, but building xbmc-pvr-addons would fail. That's on Gentoo 64-bit.
