### PR TITLE
bcm_sta: use $TARGET_ARCH instead of $ARCH

### DIFF
--- a/packages/linux-drivers/bcm_sta/build
+++ b/packages/linux-drivers/bcm_sta/build
@@ -27,4 +27,4 @@ cd $PKG_BUILD
 [ "$TARGET_ARCH" = "i386" ] && cd x86-32
 [ "$TARGET_ARCH" = "x86_64" ] && cd x86-64
 
-KBUILD_NOPEDANTIC=1 make V=1 CC=$CC -C $(kernel_path) M=`pwd` BINARCH=$ARCH
+KBUILD_NOPEDANTIC=1 make V=1 CC=$CC -C $(kernel_path) M=`pwd` BINARCH=$TARGET_ARCH


### PR DESCRIPTION
fixes build when people don't include ARCH=BLAH in the build command
