### PR TITLE
Additional support for Cypress remote buttons

### DIFF
--- a/packages/sysutils/remote/eventlircd/evmap/cypress.evmap
+++ b/packages/sysutils/remote/eventlircd/evmap/cypress.evmap
@@ -1,20 +1,23 @@
 # Cypress Receiver support
 # Bus=0003 Vendor=04b4 Product=0101 Version=0100
 # N: Name="Cypress Cypress USB Keyboard / PS2 Mouse"
+# Bus=0003 Vendor=04b4 Product=0100 Version=0001
+# N: Name="Cyp Se WitheHome"
 
  KEY_POWER           = KEY_POWER       # Power
  alt+meta+KEY_ENTER  = KEY_PROG1       # Start Key
  ctrl+shift+KEY_P    = KEY_PLAY        # Play
  ctrl+KEY_R          = KEY_RECORD      # Record
  ctrl+KEY_P          = KEY_PAUSE       # Pause
+ ctrl+KEY_S          = KEY_STOP        # Stop
  ctrl+shift+KEY_S    = KEY_STOP        # Stop
  KEY_VOLUMEUP        = KEY_VOLUMEUP    # Volume Up
  KEY_VOLUMEDOWN      = KEY_VOLUMEDOWN  # Volume Down
  KEY_MUTE            = KEY_MUTE        # Mute
 
-
  ctrl+shift+KEY_F    = KEY_FASTFORWARD # Forward
  ctrl+shift+KEY_B    = KEY_REWIND      # Reverse
+ ctrl+shift+KEY_R    = KEY_MEDIA_REPEAT # Repeat
  ctrl+KEY_F          = KEY_NEXT        # Next track
  ctrl+KEY_B          = KEY_PREVIOUS    # Pre-track
  KEY_PAGEDOWN        = KEY_CHANNELDOWN # Channel Up
@@ -31,7 +34,7 @@
  KEY_8               = KEY_NUMERIC_8   # 8
  KEY_9               = KEY_NUMERIC_9   # 9
  KEY_KPASTERISK      = KEY_NUMERIC_STAR # *
- shift+KEY_3         = KEY_POUND       # #
+ shift+KEY_3         = KEY_NUMERIC_POUND # #
 
  KEY_UP              = KEY_UP          # Direction Up
  KEY_DOWN            = KEY_DOWN        # Direction Down
@@ -41,14 +44,17 @@
  KEY_BACKSPACE       = KEY_EXIT        # Back
  KEY_DELETE          = KEY_DELETE      # Clear
 
- KEY_COMPOSE         = KEY_INFO        # Information (also used for Mouse Right) # maybe contextmenu (KEY_EPG)
+ ctrl+KEY_V          = KEY_MENU        # Menu
+ ctrl+shift+KEY_M    = KEY_MENU        # Menu
+ KEY_COMPOSE         = KEY_INFO        # Information (also used for Mouse Right)
+ KEY_F1              = KEY_EPG         # Guide (also contextmenu)
  alt+KEY_ENTER       = KEY_ZOOM        # Zoom
 
  ctrl+KEY_E          = KEY_VIDEO       # My Videos
  ctrl+KEY_M          = KEY_AUDIO       # My Music
- ctrl+KEY_A          = KEY_INFO        # My Audio
  ctrl+KEY_I          = KEY_CAMERA      # My Pictures
+ ctrl+KEY_T          = KEY_TV          # My TV
  ctrl+shift+KEY_T    = KEY_TV          # My TV
  ctrl+KEY_A          = KEY_RADIO       # Radio
  ctrl+KEY_O          = KEY_TUNER       # Record TV
- ctrl+shift+KEY_M    = KEY_DVD         # DVD Menu
+ ctrl+KEY_N          = KEY_DVD         # DVD


### PR DESCRIPTION
Add Stop, Repeat, Guide, Menu, TV, DVD buttons for "WitheHome" remote.
Fix existing Menu, pound, and Radio button mappings.
