### PR TITLE
deinitialize NFS before going to suspend

### DIFF
--- a/packages/mediacenter/xbmc/patches/12.2.0/xbmc-990.24-smbnfsdeinit-and-wait-for-nic-on-wakeup.patch
+++ b/packages/mediacenter/xbmc/patches/12.2.0/xbmc-990.24-smbnfsdeinit-and-wait-for-nic-on-wakeup.patch
@@ -1,7 +1,7 @@
 diff -rupN xbmc-upstream/xbmc/Application.cpp xbmc-vbs/xbmc/Application.cpp
 --- xbmc-upstream/xbmc/Application.cpp	2013-06-12 00:24:40.486262597 +0200
 +++ xbmc-vbs/xbmc/Application.cpp	2013-06-12 01:23:11.948400122 +0200
-@@ -5907,3 +5907,33 @@ CPerformanceStats &CApplication::GetPerf
+@@ -5907,3 +5907,37 @@ CPerformanceStats &CApplication::GetPerf
  }
  #endif
  
@@ -11,6 +11,10 @@ diff -rupN xbmc-upstream/xbmc/Application.cpp xbmc-vbs/xbmc/Application.cpp
 +
 +#if defined(HAS_FILESYSTEM_SMB) && !defined(_WIN32)
 +  smb.Deinit();
++#endif
++
++#if defined(HAS_FILESYSTEM_NFS)
++  gNfsConnection.Deinit();
 +#endif
 +}
 +
@@ -59,6 +63,18 @@ diff -rupN xbmc-upstream/xbmc/filesystem/SmbFile.cpp xbmc-vbs/xbmc/filesystem/Sm
    if (!m_context)
    {
  #ifdef TARGET_POSIX
+diff -rupN xbmc-upstream/xbmc/filesystem/NFSFile.cpp xbmc-vbs/xbmc/filesystem/NFSFile.cpp
+--- xbmc-upstream/xbmc/filesystem/NFSFile.cpp	2013-07-12 22:18:51.062605410 +0200
++++ xbmc-vbs/xbmc/filesystem/NFSFile.cpp	2013-07-12 22:19:27.069861082 +0200
+@@ -308,6 +308,8 @@
+
+ void CNfsConnection::Deinit()
+ {
++  CLog::Log(LOGNOTICE,"CNfsConnection::Deinit");
++
+   if(m_pNfsContext && m_pLibNfs->IsLoaded())
+   {
+     destroyOpenContexts();
 diff -rupN xbmc-upstream/xbmc/powermanagement/PowerManager.cpp xbmc-vbs/xbmc/powermanagement/PowerManager.cpp
 --- xbmc-upstream/xbmc/powermanagement/PowerManager.cpp	2013-06-12 00:24:41.634276292 +0200
 +++ xbmc-vbs/xbmc/powermanagement/PowerManager.cpp	2013-06-12 01:15:32.166859998 +0200


### PR DESCRIPTION
Is meant to fix problems after suspend with NFS shares (in the same way they got fixed for SMB shares recently)
