### PR TITLE
Added wildcard to mmcblk/loop if statement

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/create_sdcard
+++ b/packages/tools/bcm2835-bootloader/files/create_sdcard
@@ -1,4 +1,4 @@
-#!/bin/bash
+#!/bin/sh
 
 ################################################################################
 #      This file is part of OpenELEC - http://www.openelec.tv
@@ -50,18 +50,19 @@ if [ -z "$1" ]; then
 fi
 
 DISK="$1"
-if [[ "$DISK" = "/dev/mmcblk"* ]]; then
-  PART1="${DISK}p1"
-  PART2="${DISK}p2"
-elif [[ "$DISK" = "/dev/loop"* ]]; then
-  PART1="${DISK}p1"
-  PART2="${DISK}p2"
-  IMGFILE="$2"
-  losetup $DISK $IMGFILE
-else
-  PART1="${DISK}1"
-  PART2="${DISK}2"
-fi
+case $DISK in
+  "/dev/mmcblk1"*)
+    PART1="${DISK}p1";
+    PART2="${DISK}p2";;
+  "/dev/loop"*)
+    PART1="${DISK}p1";
+    PART2="${DISK}p2";
+    IMGFILE="$2";
+    losetup $DISK $IMGFILE;;
+  *)
+    PART1="${DISK}1";
+    PART2="${DISK}2";;
+esac
 
 clear
 echo "#########################################################"


### PR DESCRIPTION
This wound me up no end until I realised it was only checking for mmcblk0. My chromebook has mmcblk0 in use so the SD card was showing up as mmcblk1. It's also not inconceivable for people to have more than one SD card plugged in at once (or more than one loopback device, for that matter).

Note that I did change from sh to bash - I see no reason why this would be a problem but maybe someone else does?
