### PR TITLE
Added caching patch files for XBMC

### DIFF
--- a/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.30-caching-updates.patch
+++ b/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.30-caching-updates.patch
@@ -1,0 +1,21 @@
+Changes required to apply backported patches.
+Simply moves flags off the Open call so they can be updated.
+
+---
+diff --git a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+index 6662686..a3f0e32 100644
+--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
++++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+@@ -51,7 +51,9 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
+   if (!m_pFile)
+     return false;
+ 
++  unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
++
+   // open file in binary mode
+-  if (!m_pFile->Open(strFile, READ_TRUNCATED | READ_BITRATE | READ_CHUNKED))
++  if (!m_pFile->Open(strFile, flags))
+   {
+     delete m_pFile;
+     m_pFile = NULL;
+---

--- a/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.40-caching-updates.patch
+++ b/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.40-caching-updates.patch
@@ -1,0 +1,71 @@
+From 018fab22495e5de370b1e6b69e37e93657921f89 Mon Sep 17 00:00:00 2001
+From: alex <alex@XBMCBuild.(none)>
+Date: Thu, 6 Jun 2013 22:09:01 -0400
+Subject: [PATCH] Optionally allow caching for all network streams, including
+ those on LAN (via new advanced setting 'alwaysforcebuffer')
+
+---
+ xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp | 7 +++++++
+ xbmc/settings/AdvancedSettings.cpp                          | 2 ++
+ xbmc/settings/AdvancedSettings.h                            | 1 +
+ 3 files changed, 10 insertions(+)
+
+diff --git a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+index f37177e..3e8343c 100644
+--- a/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
++++ b/xbmc/cores/dvdplayer/DVDInputStreams/DVDInputStreamFile.cpp
+@@ -21,6 +21,7 @@
+ #include "DVDInputStreamFile.h"
+ #include "filesystem/File.h"
+ #include "filesystem/IFile.h"
++#include "settings/AdvancedSettings.h"
+ #include "utils/log.h"
+ #include "utils/URIUtils.h"
+ 
+@@ -53,6 +54,11 @@ bool CDVDInputStreamFile::Open(const char* strFile, const std::string& content)
+ 
+   unsigned int flags = READ_TRUNCATED | READ_BITRATE | READ_CHUNKED;
+ 
++  if ( g_advancedSettings.m_alwaysForceBuffer && 
++       !URIUtils::IsOnDVD(strFile) && 
++       !URIUtils::IsBluray(strFile) )
++    flags |= READ_CACHED; 
++ 
+   // open file in binary mode
+   if (!m_pFile->Open(strFile, flags))
+   {    
+diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
+index 59ae01a..ff73527 100644
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -308,6 +308,7 @@ void CAdvancedSettings::Initialize()
+   m_measureRefreshrate = false;
+ 
+   m_cacheMemBufferSize = 1024 * 1024 * 20;
++  m_alwaysForceBuffer = false;
+   m_addonPackageFolderSize = 200;
+ 
+   m_jsonOutputCompact = true;
+@@ -707,6 +708,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
+     XMLUtils::GetInt(pElement, "curlretries", m_curlretries, 0, 10);
+     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
+     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
++    XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
+   }
+ 
+   pElement = pRootElement->FirstChildElement("jsonrpc");
+diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
+index 1e119e2..dc0c854 100644
+--- a/xbmc/settings/AdvancedSettings.h
++++ b/xbmc/settings/AdvancedSettings.h
+@@ -359,6 +359,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+     unsigned int m_addonPackageFolderSize;
+ 
+     unsigned int m_cacheMemBufferSize;
++    bool m_alwaysForceBuffer;
+ 
+     bool m_jsonOutputCompact;
+     unsigned int m_jsonTcpPort;
+-- 
+1.8.1.6
+

--- a/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.50-caching-updates.patch
+++ b/packages/mediacenter/xbmc/patches/12.2-a603ef9/xbmc-996.50-caching-updates.patch
@@ -1,0 +1,75 @@
+From c90da1375e57c7b1db0f39353830d08adc9dd6be Mon Sep 17 00:00:00 2001
+From: fritsch <peter.fruehberger@gmail.com>
+Date: Tue, 13 Aug 2013 16:39:58 +0200
+Subject: [PATCH] Use advancedsetting to speed up ReadRate in players
+
+---
+ xbmc/cores/dvdplayer/DVDPlayer.cpp | 2 +-
+ xbmc/cores/omxplayer/OMXPlayer.cpp | 2 +-
+ xbmc/settings/AdvancedSettings.cpp | 4 ++++
+ xbmc/settings/AdvancedSettings.h   | 1 +
+ 4 files changed, 7 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDPlayer.cpp b/xbmc/cores/dvdplayer/DVDPlayer.cpp
+index 5375535..d12121f 100644
+--- a/xbmc/cores/dvdplayer/DVDPlayer.cpp
++++ b/xbmc/cores/dvdplayer/DVDPlayer.cpp
+@@ -687,7 +687,7 @@ bool CDVDPlayer::OpenDemuxStream()
+   int64_t len = m_pInputStream->GetLength();
+   int64_t tim = m_pDemuxer->GetStreamLength();
+   if(len > 0 && tim > 0)
+-    m_pInputStream->SetReadRate(len * 1000 / tim);
++    m_pInputStream->SetReadRate(g_advancedSettings.m_readBufferFactor * len * 1000 / tim);
+ 
+   return true;
+ }
+diff --git a/xbmc/cores/omxplayer/OMXPlayer.cpp b/xbmc/cores/omxplayer/OMXPlayer.cpp
+index b0ea05b..1bfbdaf 100644
+--- a/xbmc/cores/omxplayer/OMXPlayer.cpp
++++ b/xbmc/cores/omxplayer/OMXPlayer.cpp
+@@ -735,7 +735,7 @@ bool COMXPlayer::OpenDemuxStream()
+   int64_t len = m_pInputStream->GetLength();
+   int64_t tim = m_pDemuxer->GetStreamLength();
+   if(len > 0 && tim > 0)
+-    m_pInputStream->SetReadRate(len * 1000 / tim);
++    m_pInputStream->SetReadRate(g_advancedSettings.m_readBufferFactor * len * 1000 / tim);
+ 
+   return true;
+ }
+diff --git a/xbmc/settings/AdvancedSettings.cpp b/xbmc/settings/AdvancedSettings.cpp
+index 053b5e7..5feaf8a 100644
+--- a/xbmc/settings/AdvancedSettings.cpp
++++ b/xbmc/settings/AdvancedSettings.cpp
+@@ -309,6 +309,9 @@ void CAdvancedSettings::Initialize()
+ 
+   m_cacheMemBufferSize = 1024 * 1024 * 20;
+   m_alwaysForceBuffer = false;
++  // the following setting determines the readRate of a player data
++  // as multiply of the default data read rate
++  m_readBufferFactor = 1.0f;
+   m_addonPackageFolderSize = 200;
+ 
+   m_jsonOutputCompact = true;
+@@ -709,6 +812,7 @@ void CAdvancedSettings::ParseSettingsFile(const CStdString &file)
+     XMLUtils::GetBoolean(pElement,"disableipv6", m_curlDisableIPV6);
+     XMLUtils::GetUInt(pElement, "cachemembuffersize", m_cacheMemBufferSize);
+     XMLUtils::GetBoolean(pElement, "alwaysforcebuffer", m_alwaysForceBuffer);
++    XMLUtils::GetFloat(pElement, "readbufferfactor", m_readBufferFactor);
+   }
+ 
+   pElement = pRootElement->FirstChildElement("jsonrpc");
+diff --git a/xbmc/settings/AdvancedSettings.h b/xbmc/settings/AdvancedSettings.h
+index e7adbea..72716ee 100644
+--- a/xbmc/settings/AdvancedSettings.h
++++ b/xbmc/settings/AdvancedSettings.h
+@@ -360,6 +360,7 @@ class CAdvancedSettings : public ISettingCallback, public ISettingsHandler
+ 
+     unsigned int m_cacheMemBufferSize;
+     bool m_alwaysForceBuffer;
++    float m_readBufferFactor;
+ 
+     bool m_jsonOutputCompact;
+     unsigned int m_jsonTcpPort;
+-- 
+1.8.1.6
+


### PR DESCRIPTION
Backports two patches for caching from XBMC:

https://github.com/xbmc/xbmc/commit/018fab22495e5de370b1e6b69e37e93657921f89
https://github.com/xbmc/xbmc/commit/c90da1375e57c7b1db0f39353830d08adc9dd6be

Improves cache handling on Raspberry Pi's enourmously.

While I realize these will go ahead when gotham gets pulled down, the quality of life these changes make for Raspberry Pi, I'd greatly appreciate if these patches could be added meanwhile.
