### PR TITLE
busybox-initramfs: run fsck not in background to prevent race contitions

### DIFF
--- a/packages/initramfs/sysutils/busybox-initramfs/scripts/init
+++ b/packages/initramfs/sysutils/busybox-initramfs/scripts/init
@@ -272,7 +272,7 @@
         MOUNT_TARGET="$1"
         # check filesystem
           if [ -x /sbin/fsck ]; then
-            /sbin/fsck -a $1 &>/dev/null
+            /sbin/fsck -a $1
           fi
         ;;
       CIFS=*|SMB=*)


### PR DESCRIPTION
fsck in the initramfs fails, as the partitions are mounted before fsck is able to do anything.
To avoid unnecesary repetitions see also: 
