### PR TITLE
gdb: fix thread debugging

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -38,6 +38,11 @@ PKG_AUTORECONF="no"
 CC_FOR_BUILD="$HOST_CC"
 CFLAGS_FOR_BUILD="$HOST_CFLAGS"
 
+pre_configure_target() {
+    strip_gold
+    strip_lto
+}
+
 PKG_CONFIGURE_OPTS_TARGET="bash_cv_have_mbstate_t=set \
                            --disable-shared \
                            --enable-static \


### PR DESCRIPTION
This fix solves the gdb thread debugging problem on OE.
lto simply strips the "ps_pd*" functions in gdb, which are necessary to debug threads.
In addition, it's one of the reasons for "warning: Unable to find libthread_db matching inferior's thread library, thread debugging will not be available."
