### PR TITLE
Fix to make iRF Media Technology W-01RN_USB_V3.1 IR remote work out of the box

### DIFF
--- a/packages/sysutils/remote/eventlircd/evmap/03_0755_2626.evmap
+++ b/packages/sysutils/remote/eventlircd/evmap/03_0755_2626.evmap
@@ -1,5 +1,18 @@
 # Remote 0755:2626 Aureal Semiconductor (iRF Media Technology W-01RN USB_V3.1)
 
+ KEY_NUMERIC_1     = KEY_NUMERIC_1     # 1
+ KEY_NUMERIC_2     = KEY_NUMERIC_2     # 2
+ KEY_NUMERIC_3     = KEY_NUMERIC_3     # 3
+ KEY_NUMERIC_4     = KEY_NUMERIC_4     # 4
+ KEY_NUMERIC_5     = KEY_NUMERIC_5     # 5
+ KEY_NUMERIC_6     = KEY_NUMERIC_6     # 6
+ KEY_NUMERIC_7     = KEY_NUMERIC_7     # 7
+ KEY_NUMERIC_8     = KEY_NUMERIC_8     # 8
+ KEY_NUMERIC_9     = KEY_NUMERIC_9     # 9
+ KEY_NUMERIC_0     = KEY_NUMERIC_0     # 0
+ KEY_NUMERIC_STAR  = KEY_NUMERIC_STAR  # *
+ KEY_NUMERIC_POUND = KEY_NUMERIC_POUND # #
+
  KEY_1     = KEY_NUMERIC_1             # 1
  KEY_2     = KEY_NUMERIC_2             # 2
  KEY_3     = KEY_NUMERIC_3             # 3
@@ -58,7 +71,9 @@
  ctrl+KEY_I        = KEY_CAMERA        # Pictures
  ctrl+shift+KEY_M  = KEY_DVD           # DVD/VCD
  ctrl+KEY_E        = KEY_VIDEO         # Videos
+ KEY_RADIO         = KEY_RADIO         # Radio
  ctrl+KEY_A        = KEY_RADIO         # Radio
+ KEY_TUNER         = KEY_TUNER         # Tuner
  ctrl+shift+KEY_T  = KEY_TUNER         # Tuner
  KEY_PVR           = KEY_TV            # PVR
 
@@ -73,6 +88,7 @@
  KEY_ENTER         = KEY_OK            # Enter
  KEY_OK            = KEY_OK            # Ok
  KEY_DELETE        = KEY_DELETE        # Clear
+ KEY_EXIT          = KEY_EXIT          # BACK
  KEY_BACKSPACE     = KEY_EXIT          # BACK
 
  KEY_POWER         = KEY_POWER         # Power


### PR DESCRIPTION
Fixed eventlircd's 03_0755_2626.evmap to make most of the buttons of iRF Media Technology W-01RN_USB_V3.1 IR remote (http://wiki.xbmc.org/index.php?title=Remote_control_reviews#IRF_Media_W-01RN) work out of the box.
Before the fix all numeric buttons, Back button, My TV, Rewind and some others were not working.
