### PR TITLE
[rbp] Preserve timestamps when updating Raspberry Pi firmware

### DIFF
--- a/packages/tools/bcm2835-bootloader/scripts/update.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/update.sh
@@ -27,10 +27,10 @@
   mount -o remount,rw $BOOT_ROOT
 
 # update bootloader files
-  cp $SYSTEM_ROOT/usr/share/bootloader/LICENCE* $BOOT_ROOT
-  cp $SYSTEM_ROOT/usr/share/bootloader/bootcode.bin $BOOT_ROOT
-  cp $SYSTEM_ROOT/usr/share/bootloader/fixup.dat $BOOT_ROOT
-  cp $SYSTEM_ROOT/usr/share/bootloader/start.elf $BOOT_ROOT
+  cp -p $SYSTEM_ROOT/usr/share/bootloader/LICENCE* $BOOT_ROOT
+  cp -p $SYSTEM_ROOT/usr/share/bootloader/bootcode.bin $BOOT_ROOT
+  cp -p $SYSTEM_ROOT/usr/share/bootloader/fixup.dat $BOOT_ROOT
+  cp -p $SYSTEM_ROOT/usr/share/bootloader/start.elf $BOOT_ROOT
 
 # cleanup not more needed files
   rm -rf $BOOT_ROOT/loader.bin
@@ -39,7 +39,7 @@
 
 # some config.txt magic
   if [ ! -f $BOOT_ROOT/config.txt ]; then
-    cp $SYSTEM_ROOT/usr/share/bootloader/config.txt $BOOT_ROOT
+    cp -p $SYSTEM_ROOT/usr/share/bootloader/config.txt $BOOT_ROOT
   elif [ -z "`grep "^[ ]*gpu_mem.*" $BOOT_ROOT/config.txt`" ]; then
     mv $BOOT_ROOT/config.txt $BOOT_ROOT/config.txt.bk
     cat $SYSTEM_ROOT/usr/share/bootloader/config.txt \


### PR DESCRIPTION
This will ensure that the timestamps on updated R-Pi firmware files will not be set to 1 Jan 1980.
