### PR TITLE
Add bdftopcf to build deps (part of xfonts-utils in debian)

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -34,7 +34,7 @@ case $1 in
     ;;
   build)
     deps="bash bc gcc g++ sed patch touch tar bzip2 gzip perl cp gawk makeinfo gperf cvs zip unzip mkfontscale mkfontdir bdftopcf diff xsltproc java"
-    deps_pkg="bash bc gcc g++ sed patch fileutils tar bzip2 gzip perl coreutils gawk texinfo gperf cvs zip unzip xutils xfonts-utils diff xsltproc default-jre"
+    deps_pkg="bash bc gcc g++ sed patch fileutils tar bzip2 gzip perl coreutils gawk texinfo gperf cvs zip unzip xutils xfonts-utils xfonts-utils diff xsltproc default-jre"
     files="/usr/include/stdio.h /usr/include/ncurses.h"
     files_pkg="libc6-dev libncurses5-dev"
     ;;


### PR DESCRIPTION
I'm building on gentoo and found that this package/binary was missing
