### PR TITLE
Add flash share to smb.conf

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -168,3 +168,11 @@
   public = yes
   writable = yes
   root preexec = mkdir -p /storage/backup
+
+[Flash]
+  path = /flash
+  available = yes
+  browsable = no
+  public = yes 
+  writable = yes
+  root preexec = mount -o remount,rw /flash


### PR DESCRIPTION
Add's a hidden flash share to smb.conf, when the share is accessed /flash is remounted as rw. This will allow users to access the /flash folder more easily to add licences for Raspberry Pi codecs or to make other changes etc.
