### PR TITLE
add BOOT to partitions we don't mount

### DIFF
--- a/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
+++ b/packages/sysutils/udevil/udev.d/95-udevil-mount.rules
@@ -7,7 +7,7 @@ SUBSYSTEM!="block", KERNEL!="sd*|sr*", GOTO="exit"
 
 # check for special partitions we dont want mount
 IMPORT{builtin}="blkid"
-ENV{ID_FS_LABEL}=="EFI|Recovery|System|SYSTEM|Storage|STORAGE|Flash|FLASH", GOTO="exit"
+ENV{ID_FS_LABEL}=="EFI|BOOT|Recovery|System|SYSTEM|Storage|STORAGE|Flash|FLASH", GOTO="exit"
 
 # /dev/sd* with partitions/disk and filesystems only and /dev/sr* disks only
 KERNEL=="sd*", ENV{DEVTYPE}=="partition|disk", ENV{ID_FS_USAGE}=="filesystem", GOTO="harddisk"


### PR DESCRIPTION
BOOT is the name of the Recovery partition on ATV installs
