### PR TITLE
ALSA: Change amd hda patch to make advanced features for rev3+ working

### DIFF
--- a/packages/linux/patches/3.10.15/linux-990.11-ALSA-AMD-HD-Audio.patch
+++ b/packages/linux/patches/3.10.15/linux-990.11-ALSA-AMD-HD-Audio.patch
@@ -202,7 +202,7 @@ index 2e7493e..7c0b89e 100644
 +/* shared with patch_hdmi.c and hda_eld.c */
 +#define is_atihdmi(codec) (((codec)->vendor_id & 0xffff0000) == 0x10020000)
 +#define is_amdhdmi_rev3(codec) \
-+	((codec)->vendor_id == 0x1002791a && ((codec)->revision_id & 0xff00) >= 0x0300)
++	((codec)->vendor_id == 0x1002aa01 && ((codec)->revision_id & 0xff00) >= 0x0300)
 +
  #endif /* __SOUND_HDA_LOCAL_H */
 diff --git a/sound/pci/hda/patch_hdmi.c b/sound/pci/hda/patch_hdmi.c


### PR DESCRIPTION
Address was wrong.
