### PR TITLE
xf86-video-vmware: bump to 45b2457516a9db4bd1d60fbb24a1efbe2d9dd932

### DIFF
--- a/packages/x11/driver/xf86-video-vmware/meta
+++ b/packages/x11/driver/xf86-video-vmware/meta
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="xf86-video-vmware"
-PKG_VERSION="13.0.0"
+PKG_VERSION="45b2457516a9db4bd1d60fbb24a1efbe2d9dd932"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
fixes xf86-video-vmware build
