### PR TITLE
Add patches for drm/i915: set HDMI pixel clock in audio configuration

### DIFF
--- a/packages/linux/patches/3.11.5/linux-992.01.i915_pass_mode_to_write_eld.patch
+++ b/packages/linux/patches/3.11.5/linux-992.01.i915_pass_mode_to_write_eld.patch
@@ -1,0 +1,66 @@
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+---
+ drivers/gpu/drm/i915/i915_drv.h      |    3 ++-
+ drivers/gpu/drm/i915/intel_display.c |   11 +++++++----
+ 2 files changed, 9 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
+index 6106d3d..caee590 100644
+--- a/drivers/gpu/drm/i915/i915_drv.h
++++ b/drivers/gpu/drm/i915/i915_drv.h
+@@ -379,7 +379,8 @@ struct drm_i915_display_funcs {
+ 	void (*crtc_disable)(struct drm_crtc *crtc);
+ 	void (*off)(struct drm_crtc *crtc);
+ 	void (*write_eld)(struct drm_connector *connector,
+-			  struct drm_crtc *crtc);
++			  struct drm_crtc *crtc,
++			  struct drm_display_mode *mode);
+ 	void (*fdi_link_train)(struct drm_crtc *crtc);
+ 	void (*init_clock_gating)(struct drm_device *dev);
+ 	int (*queue_flip)(struct drm_device *dev, struct drm_crtc *crtc,
+diff --git a/drivers/gpu/drm/i915/intel_display.c b/drivers/gpu/drm/i915/intel_display.c
+index 4f1b636..55740f2 100644
+--- a/drivers/gpu/drm/i915/intel_display.c
++++ b/drivers/gpu/drm/i915/intel_display.c
+@@ -6752,7 +6752,8 @@ static bool intel_eld_uptodate(struct drm_connector *connector,
+ }
+ 
+ static void g4x_write_eld(struct drm_connector *connector,
+-			  struct drm_crtc *crtc)
++			  struct drm_crtc *crtc,
++			  struct drm_display_mode *mode)
+ {
+ 	struct drm_i915_private *dev_priv = connector->dev->dev_private;
+ 	uint8_t *eld = connector->eld;
+@@ -6792,7 +6793,8 @@ static void g4x_write_eld(struct drm_connector *connector,
+ }
+ 
+ static void haswell_write_eld(struct drm_connector *connector,
+-				     struct drm_crtc *crtc)
++			      struct drm_crtc *crtc,
++			      struct drm_display_mode *mode)
+ {
+ 	struct drm_i915_private *dev_priv = connector->dev->dev_private;
+ 	uint8_t *eld = connector->eld;
+@@ -6879,7 +6881,8 @@ static void haswell_write_eld(struct drm_connector *connector,
+ }
+ 
+ static void ironlake_write_eld(struct drm_connector *connector,
+-				     struct drm_crtc *crtc)
++			       struct drm_crtc *crtc,
++			       struct drm_display_mode *mode)
+ {
+ 	struct drm_i915_private *dev_priv = connector->dev->dev_private;
+ 	uint8_t *eld = connector->eld;
+@@ -6974,7 +6977,7 @@ void intel_write_eld(struct drm_encoder *encoder,
+ 	connector->eld[6] = drm_av_sync_delay(connector, mode) / 2;
+ 
+ 	if (dev_priv->display.write_eld)
+-		dev_priv->display.write_eld(connector, crtc);
++		dev_priv->display.write_eld(connector, crtc, mode);
+ }
+ 
+ static void i845_update_cursor(struct drm_crtc *crtc, u32 base)
+-- 
+1.7.9.5
+

--- a/packages/linux/patches/3.11.5/linux-992.02-i915_set_hdmi_audio_clock.patch
+++ b/packages/linux/patches/3.11.5/linux-992.02-i915_set_hdmi_audio_clock.patch
@@ -1,0 +1,110 @@
+Reference: http://mid.gmane.org/CAGpEb3Ep1LRZETPxHGRfBDqr5Ts2tAc8gCukWwugUf1U5NYv1g@mail.gmail.com
+Reference: http://mid.gmane.org/20130206213533.GA16367@hardeman.nu
+Reported-by: David HÃ¤rdeman <david@hardeman.nu>
+Reported-by: Jasper Smet <josbeir@gmail.com>
+Tested-by: Jasper Smet <josbeir@gmail.com>
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+---
+ drivers/gpu/drm/i915/i915_reg.h      |   12 ++++++++-
+ drivers/gpu/drm/i915/intel_display.c |   48 +++++++++++++++++++++++++++++++---
+ 2 files changed, 55 insertions(+), 5 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_reg.h b/drivers/gpu/drm/i915/i915_reg.h
+index 13153c3..3266819 100644
+--- a/drivers/gpu/drm/i915/i915_reg.h
++++ b/drivers/gpu/drm/i915/i915_reg.h
+@@ -4875,7 +4875,17 @@
+ #define   AUD_CONFIG_LOWER_N_SHIFT		4
+ #define   AUD_CONFIG_LOWER_N_VALUE		(0xfff << 4)
+ #define   AUD_CONFIG_PIXEL_CLOCK_HDMI_SHIFT	16
+-#define   AUD_CONFIG_PIXEL_CLOCK_HDMI		(0xf << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_MASK	(0xf << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_25175	(0 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_25200	(1 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_27000	(2 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_27027	(3 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_54000	(4 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_54054	(5 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_74176	(6 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_74250	(7 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_148352	(8 << 16)
++#define   AUD_CONFIG_PIXEL_CLOCK_HDMI_148500	(9 << 16)
+ #define   AUD_CONFIG_DISABLE_NCTS		(1 << 3)
+ 
+ /* HSW Audio */
+diff --git a/drivers/gpu/drm/i915/intel_display.c b/drivers/gpu/drm/i915/intel_display.c
+index 55740f2..a097f84 100644
+--- a/drivers/gpu/drm/i915/intel_display.c
++++ b/drivers/gpu/drm/i915/intel_display.c
+@@ -6722,6 +6722,44 @@ static int intel_crtc_mode_set(struct drm_crtc *crtc,
+ 	return 0;
+ }
+ 
++static struct {
++	int clock;
++	u32 config;
++} hdmi_audio_clock[] = {
++	{ DIV_ROUND_UP(25200 * 1000, 1001), AUD_CONFIG_PIXEL_CLOCK_HDMI_25175 },
++	{ 25200, AUD_CONFIG_PIXEL_CLOCK_HDMI_25200 }, /* default per bspec */
++	{ 27000, AUD_CONFIG_PIXEL_CLOCK_HDMI_27000 },
++	{ 27000 * 1001 / 1000, AUD_CONFIG_PIXEL_CLOCK_HDMI_27027 },
++	{ 54000, AUD_CONFIG_PIXEL_CLOCK_HDMI_54000 },
++	{ 54000 * 1001 / 1000, AUD_CONFIG_PIXEL_CLOCK_HDMI_54054 },
++	{ DIV_ROUND_UP(74250 * 1000, 1001), AUD_CONFIG_PIXEL_CLOCK_HDMI_74176 },
++	{ 74250, AUD_CONFIG_PIXEL_CLOCK_HDMI_74250 },
++	{ DIV_ROUND_UP(148500 * 1000, 1001), AUD_CONFIG_PIXEL_CLOCK_HDMI_148352 },
++	{ 148500, AUD_CONFIG_PIXEL_CLOCK_HDMI_148500 },
++};
++
++/* get AUD_CONFIG_PIXEL_CLOCK_HDMI_* value for mode */
++static u32 audio_config_hdmi_pixel_clock(struct drm_display_mode *mode)
++{
++	int i;
++
++	for (i = 0; i < ARRAY_SIZE(hdmi_audio_clock); i++) {
++		if (mode->clock == hdmi_audio_clock[i].clock)
++			break;
++	}
++
++	if (i == ARRAY_SIZE(hdmi_audio_clock)) {
++		DRM_DEBUG_KMS("HDMI audio pixel clock setting for %d not found, falling back to defaults\n", mode->clock);
++		i = 1;
++	}
++
++	DRM_DEBUG_KMS("Configuring HDMI audio for pixel clock %d (0x%08x)\n",
++		      hdmi_audio_clock[i].clock,
++		      hdmi_audio_clock[i].config);
++
++	return hdmi_audio_clock[i].config;
++}
++
+ static bool intel_eld_uptodate(struct drm_connector *connector,
+ 			       int reg_eldv, uint32_t bits_eldv,
+ 			       int reg_elda, uint32_t bits_elda,
+@@ -6847,8 +6885,9 @@ static void haswell_write_eld(struct drm_connector *connector,
+ 		DRM_DEBUG_DRIVER("ELD: DisplayPort detected\n");
+ 		eld[5] |= (1 << 2);	/* Conn_Type, 0x1 = DisplayPort */
+ 		I915_WRITE(aud_config, AUD_CONFIG_N_VALUE_INDEX); /* 0x1 = DP */
+-	} else
+-		I915_WRITE(aud_config, 0);
++	} else {
++		I915_WRITE(aud_config, audio_config_hdmi_pixel_clock(mode));
++	}
+ 
+ 	if (intel_eld_uptodate(connector,
+ 			       aud_cntrl_st2, eldv,
+@@ -6926,8 +6965,9 @@ static void ironlake_write_eld(struct drm_connector *connector,
+ 		DRM_DEBUG_DRIVER("ELD: DisplayPort detected\n");
+ 		eld[5] |= (1 << 2);	/* Conn_Type, 0x1 = DisplayPort */
+ 		I915_WRITE(aud_config, AUD_CONFIG_N_VALUE_INDEX); /* 0x1 = DP */
+-	} else
+-		I915_WRITE(aud_config, 0);
++	} else {
++		I915_WRITE(aud_config, audio_config_hdmi_pixel_clock(mode));
++	}
+ 
+ 	if (intel_eld_uptodate(connector,
+ 			       aud_cntrl_st2, eldv,
+-- 
+1.7.9.5
+


### PR DESCRIPTION
Intel drm-intel Patches fixing HDMI audio clock
As of today both patches are merged in the drm-intel-nightly branch

This makes audio work on some devices that expect strict audio clock. (like of Pioneer AV receivers)

> The HDMI audio expects HDMI pixel clock to be set in the audio
> configuration. We've currently just set 0, using 25.2 / 1.001 kHz
> frequency, which fails with some modes.

http://cgit.freedesktop.org/~danvet/drm-intel/commit/?h=drm-intel-nightly&id=e9705499ace4be45c09ec5e2aaddc126f6746f1f

http://cgit.freedesktop.org/~danvet/drm-intel/commit/?h=drm-intel-nightly&id=20571990f217284aea1093dc72a1c43c0f255057
