### PR TITLE
tvheadend resets on xbmc reset fix

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
+++ b/packages/addons/service/multimedia/tvheadend/source/bin/tvheadend.start
@@ -115,7 +115,6 @@ cat "$ADDON_SETTINGS" | awk -F\" '{print $2"=\""$4"\""}' | sed '/^=/d' > /var/co
 . /var/config/tvheadend.conf
 
 rm -rf "$LOCKDIR/$LOCKFILE_SLEEP" &>/dev/null
-tvheadend.stop
 rm -rf "$LOCKDIR/$LOCKFILE" &>/dev/null
 if [ ! "$(pidof $ADDON_BIN)" ]; then
    while [ true ] ; do


### PR DESCRIPTION
tvheadend is reset/killed when xbmc is reset/killed due to stop in start script.

not a big deal but very annoying...

tested and working
