### PR TITLE
Added patch for sql_lex.h

### DIFF
--- a/packages/databases/mysql/patches/mysql-020-fix-sql_lex-header.patch
+++ b/packages/databases/mysql/patches/mysql-020-fix-sql_lex-header.patch
@@ -1,0 +1,16 @@
+--- mysql-5.1.72/sql/sql_lex.h	2013-11-03 12:10:05.779245202 +0100
++++ mysql-5.1.72/sql/sql_lex.patched.h	2013-11-03 12:06:26.387234521 +0100
+@@ -47,11 +47,7 @@
+ #else
+ #include "lex_symbol.h"
+ #if MYSQL_LEX
+-#  if YACC_HEXT_HH
+-#    include "sql_yacc.hh"
+-#  else
+-#    include "sql_yacc.h"
+-#  endif
++#include "sql_yacc.h"
+ #define LEX_YYSTYPE YYSTYPE *
+ #else
+ #define LEX_YYSTYPE void *
+-


### PR DESCRIPTION
This enables us to compile MySQL with server support (i.e. remove `--without-server` `--without-embedded-server`) in `package.mk`.

This is useful for people wanting to use the MySQL daemon on the Raspberry Pi for example.

However, this commit should be seen as a discussion topic, since the environment variable `YACC_HEXT_HH` seems to be set, but it doesn't build the .hh file (builds the regular .h file) so this patch pretty much works around that by hardcoding the `sql_yacc.h`-reference instead.