### PR TITLE
ffmpeg: add patch for backport: fix bug where custom http headers aren't kept with hls streams

### DIFF
--- a/packages/multimedia/ffmpeg/patches/1.2.3/ffmpeg-0058-backport-fixed-not-keeping-custom-http-headers.patch
+++ b/packages/multimedia/ffmpeg/patches/1.2.3/ffmpeg-0058-backport-fixed-not-keeping-custom-http-headers.patch
@@ -1,0 +1,53 @@
+From 9fb6300b1cc36c8111cee017fbb8a3e37b0c4e68 Mon Sep 17 00:00:00 2001
+From: siriuzwhite <siriuz@gmx.net>
+Date: Sun, 10 Nov 2013 23:26:16 +0100
+Subject: [PATCH] [backport] fixed ffmpeg not keep custom http headers when
+ playing hls stream
+
+---
+ libavformat/hls.c | 9 +++++++++
+ 1 file changed, 9 insertions(+)
+
+diff --git a/libavformat/hls.c b/lib/ffmpeg/libavformat/hls.c
+index 7de6059..2e3fd00 100644
+--- a/libavformat/hls.c
++++ b/libavformat/hls.c
+@@ -105,6 +105,7 @@ struct variant {
+     AVIOInterruptCB *interrupt_callback;
+     char *user_agent;                    ///< holds HTTP user agent set as an AVOption to the HTTP protocol context
+     char *cookies;                       ///< holds HTTP cookie values set in either the initial response or as an AVOption to the HTTP protocol context
++    char *headers;			             ///< holds HTTP headers set as an AVOption to the HTTP protocol context (kow|mitm)
+ } HLSContext;
+ 
+ static int read_chomp_line(AVIOContext *s, char *buf, int maxlen)
+@@ -224,6 +225,7 @@ static int parse_playlist(HLSContext *c, const char *url,
+         // broker prior HTTP options that should be consistent across requests
+         av_dict_set(&opts, "user-agent", c->user_agent, 0);
+         av_dict_set(&opts, "cookies", c->cookies, 0);
++        av_dict_set(&opts, "headers", c->headers, 0); // (kow|mitm)
+ 
+         ret = avio_open2(&in, url, AVIO_FLAG_READ,
+                          c->interrupt_callback, &opts);
+@@ -346,6 +348,7 @@ static int open_input(HLSContext *c, struct variant *var)
+     // broker prior HTTP options that should be consistent across requests
+     av_dict_set(&opts, "user-agent", c->user_agent, 0);
+     av_dict_set(&opts, "cookies", c->cookies, 0);
++    av_dict_set(&opts, "headers", c->headers, 0); // (kow|mitm)
+     av_dict_set(&opts, "seekable", "0", 0);
+ 
+     if (seg->key_type == KEY_NONE) {
+@@ -494,6 +497,12 @@ static int hls_read_header(AVFormatContext *s)
+         av_opt_get(u->priv_data, "cookies", 0, (uint8_t**)&(c->cookies));
+         if (c->cookies && !strlen(c->cookies))
+             av_freep(&c->cookies);
++            
++        // get the previous headers & set back to null if string size is zero (kow|mitm)
++        av_freep(&c->headers);
++        av_opt_get(u->priv_data, "headers", 0, (uint8_t**)&(c->headers));
++        if (c->headers && !strlen(c->headers))
++            av_freep(&c->headers);
+     }
+ 
+     if ((ret = parse_playlist(c, s->filename, NULL, s->pb)) < 0)
+-- 
+1.8.4


### PR DESCRIPTION
Original fix: https://github.com/FFmpeg/FFmpeg/commit/4684539c9148050ad26a8b840c4b5ee33799865d
