### PR TITLE
Enable auto-repeat for all non-qualifier keys

### DIFF
--- a/packages/multimedia/SDL/patches/SDL-1.2.15-keyRepeat.patch
+++ b/packages/multimedia/SDL/patches/SDL-1.2.15-keyRepeat.patch
@@ -1,0 +1,10 @@
+--- a/src/events/SDL_keyboard.c	2013-11-09 11:30:21.828161683 +0100
++++ b/src/events/SDL_keyboard.c	2013-11-09 11:30:54.284183206 +0100
+@@ -417,6 +417,7 @@
+ 		keysym->mod = (SDLMod)modstate;
+ 		switch (keysym->sym) {
+ 			case SDLK_UNKNOWN:
++				repeatable = 1;
+ 				break;
+ 			case SDLK_NUMLOCK:
+ 				modstate ^= KMOD_NUM;


### PR DESCRIPTION
For a while now, I'm running OpenELEC 3.2 with XBMC master from git (due to local fixes).

In this constellation, auto-repeat for the volume keys on my Nyxboard Hybrid remote stopped working, AFAICR around April/May this year.

The Nyxboard Hybrid attaches as a USB HID keyboard.

I've tracked this down in the code; XBMC requires keyboard repeat events generated by SDL to react to keys being held down.

Repeat events are generated by SDL only for "known" keys (an arbitrary list of scancodes) that are not qualifiers.

Since the multimedia volume keys are not "known" by SDL 1.2.15, no repeat events are generated.

This patch causes SDL to repeat *any* keys except known qualifiers; i.e. there should be no difference in behaviour across all non-qualifier keys on a keyboard with this applied.
This IMO is the behaviour most suitable in an OpenELEC/XBMC environment; the user would not wish some (unknowable) keys to behave any differently from others.


With this patch applied, the Nyxboard volume keys repeat when held down, as before whatever caused this to stop working.

I'd be interested in any folks using (logical) keyboards for control whether it causes any problems.
