### PR TITLE
linux 3.12.1: add Haswell HDMI buffer alignment to fix 5.1 pcm

### DIFF
--- a/packages/linux/patches/3.12.1/linux-992.04-ALSA-hda-Force-buffer-alignment-for-Haswell-HDMI-con.patch
+++ b/packages/linux/patches/3.12.1/linux-992.04-ALSA-hda-Force-buffer-alignment-for-Haswell-HDMI-con.patch
@@ -1,0 +1,59 @@
+From 33499a15c2f7addc81695778753c2338b960eff7 Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Tue, 5 Nov 2013 17:34:46 +0100
+Subject: [PATCH] ALSA: hda - Force buffer alignment for Haswell HDMI
+ controllers
+
+Haswell HDMI audio controllers seem to get stuck when unaligned buffer
+size is used.  Let's enable the buffer alignment for the corresponding
+entries.
+
+Since AZX_DCAPS_INTEL_PCH contains AZX_DCAPS_BUFSIZE that disables the
+buffer alignment forcibly, define AZX_DCAPS_INTEL_HASWELL and put the
+necessary AZX_DCAPS bits there.
+
+Bugzilla: https://bugzilla.kernel.org/show_bug.cgi?id=60769
+Reported-by: Alexander E. Patrakov <patrakov@gmail.com>
+Cc: <stable@vger.kernel.org>
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/pci/hda/hda_intel.c |   14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/sound/pci/hda/hda_intel.c b/sound/pci/hda/hda_intel.c
+index d6dcec7..9cbd125 100644
+--- a/sound/pci/hda/hda_intel.c
++++ b/sound/pci/hda/hda_intel.c
+@@ -613,6 +613,11 @@ enum {
+ #define AZX_DCAPS_INTEL_PCH \
+ 	(AZX_DCAPS_INTEL_PCH_NOPM | AZX_DCAPS_PM_RUNTIME)
+ 
++#define AZX_DCAPS_INTEL_HASWELL \
++	(AZX_DCAPS_SCH_SNOOP | AZX_DCAPS_ALIGN_BUFSIZE | \
++	 AZX_DCAPS_COUNT_LPIB_DELAY | AZX_DCAPS_PM_RUNTIME | \
++	 AZX_DCAPS_I915_POWERWELL)
++
+ /* quirks for ATI SB / AMD Hudson */
+ #define AZX_DCAPS_PRESET_ATI_SB \
+ 	(AZX_DCAPS_ATI_SNOOP | AZX_DCAPS_NO_TCSEL | \
+@@ -3992,14 +3997,11 @@ static DEFINE_PCI_DEVICE_TABLE(azx_ids) = {
+ 	  .driver_data = AZX_DRIVER_PCH | AZX_DCAPS_INTEL_PCH },
+ 	/* Haswell */
+ 	{ PCI_DEVICE(0x8086, 0x0a0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_PCH |
+-	  AZX_DCAPS_I915_POWERWELL },
++	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
+ 	{ PCI_DEVICE(0x8086, 0x0c0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_PCH |
+-	  AZX_DCAPS_I915_POWERWELL },
++	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
+ 	{ PCI_DEVICE(0x8086, 0x0d0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_PCH |
+-	  AZX_DCAPS_I915_POWERWELL },
++	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
+ 	/* 5 Series/3400 */
+ 	{ PCI_DEVICE(0x8086, 0x3b56),
+ 	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_PCH_NOPM },
+-- 
+1.7.9.5
+

--- a/packages/linux/patches/3.12.1/linux-992.05-ALSA-hda-Name-Haswell-HDMI-controllers-better.patch
+++ b/packages/linux/patches/3.12.1/linux-992.05-ALSA-hda-Name-Haswell-HDMI-controllers-better.patch
@@ -1,0 +1,51 @@
+From fab1285a51b7bf55adb4678d82e606829c9dab85 Mon Sep 17 00:00:00 2001
+From: Takashi Iwai <tiwai@suse.de>
+Date: Tue, 5 Nov 2013 17:54:05 +0100
+Subject: [PATCH] ALSA: hda - Name Haswell HDMI controllers better
+
+"HDA Intel MID" is no correct name for Haswell HDMI controllers.
+Give them a better name, "HDA Intel HDMI".
+
+Signed-off-by: Takashi Iwai <tiwai@suse.de>
+---
+ sound/pci/hda/hda_intel.c |    8 +++++---
+ 1 file changed, 5 insertions(+), 3 deletions(-)
+
+diff --git a/sound/pci/hda/hda_intel.c b/sound/pci/hda/hda_intel.c
+index 9cbd125..17f4aa8 100644
+--- a/sound/pci/hda/hda_intel.c
++++ b/sound/pci/hda/hda_intel.c
+@@ -569,6 +569,7 @@ enum {
+ 	AZX_DRIVER_ICH,
+ 	AZX_DRIVER_PCH,
+ 	AZX_DRIVER_SCH,
++	AZX_DRIVER_HDMI,
+ 	AZX_DRIVER_ATI,
+ 	AZX_DRIVER_ATIHDMI,
+ 	AZX_DRIVER_ATIHDMI_NS,
+@@ -648,6 +649,7 @@ static char *driver_short_names[] = {
+ 	[AZX_DRIVER_ICH] = "HDA Intel",
+ 	[AZX_DRIVER_PCH] = "HDA Intel PCH",
+ 	[AZX_DRIVER_SCH] = "HDA Intel MID",
++	[AZX_DRIVER_HDMI] = "HDA Intel HDMI",
+ 	[AZX_DRIVER_ATI] = "HDA ATI SB",
+ 	[AZX_DRIVER_ATIHDMI] = "HDA ATI HDMI",
+ 	[AZX_DRIVER_ATIHDMI_NS] = "HDA ATI HDMI",
+@@ -3997,11 +3999,11 @@ static DEFINE_PCI_DEVICE_TABLE(azx_ids) = {
+ 	  .driver_data = AZX_DRIVER_PCH | AZX_DCAPS_INTEL_PCH },
+ 	/* Haswell */
+ 	{ PCI_DEVICE(0x8086, 0x0a0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
++	  .driver_data = AZX_DRIVER_HDMI | AZX_DCAPS_INTEL_HASWELL },
+ 	{ PCI_DEVICE(0x8086, 0x0c0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
++	  .driver_data = AZX_DRIVER_HDMI | AZX_DCAPS_INTEL_HASWELL },
+ 	{ PCI_DEVICE(0x8086, 0x0d0c),
+-	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_HASWELL },
++	  .driver_data = AZX_DRIVER_HDMI | AZX_DCAPS_INTEL_HASWELL },
+ 	/* 5 Series/3400 */
+ 	{ PCI_DEVICE(0x8086, 0x3b56),
+ 	  .driver_data = AZX_DRIVER_SCH | AZX_DCAPS_INTEL_PCH_NOPM },
+-- 
+1.7.9.5
+


### PR DESCRIPTION
These patches make 5.1ch PCM output work on Haswell. They're already included in 3.13-rc1, this adds them to 3.12.1

My first PR, please let me know if this is not the right way to do it. :)
