### PR TITLE
VAAPI: Revert Patch to make VC-1 working again (fixes sever heap corruption)

### DIFF
--- a/packages/mediacenter/xbmc/patches/xbmc-991.03-Revert-Ensure-that-the-decoder-is-init-once-only.patch
+++ b/packages/mediacenter/xbmc/patches/xbmc-991.03-Revert-Ensure-that-the-decoder-is-init-once-only.patch
@@ -1,0 +1,29 @@
+From d6a8898b3bffd0960806eed84efe0ce438ba7b84 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Mon, 2 Dec 2013 19:00:44 +0100
+Subject: [PATCH] Revert "Ensure that the decoder is init once only."
+
+This reverts commit 6d637d4801095acfe5b6a7e56f446aa2e4602bfa.
+---
+ xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp | 5 -----
+ 1 file changed, 5 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+index 09551c4..5692faf 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecFFmpeg.cpp
+@@ -107,11 +107,6 @@ enum PixelFormat CDVDVideoCodecFFmpeg::GetFormat( struct AVCodecContext * avctx
+     if(*cur == PIX_FMT_VAAPI_VLD && CSettings::Get().GetBool("videoplayer.usevaapi") 
+     && (avctx->codec_id != AV_CODEC_ID_MPEG4 || g_advancedSettings.m_videoAllowMpeg4VAAPI)) 
+     {
+-      if (ctx->GetHardware() != NULL)
+-      {
+-        ctx->SetHardware(NULL);
+-      }
+-
+       VAAPI::CDecoder* dec = new VAAPI::CDecoder();
+       if(dec->Open(avctx, *cur, ctx->m_uSurfacesCount))
+       {
+-- 
+1.8.3.2
+


### PR DESCRIPTION
That one needs to be revisited upstream. It produced heap corruption like hell.
