### PR TITLE
scripts/image: no more KERNEL in ATV builds

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -181,11 +181,12 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
     KERNEL_ARCH="arm"
   fi
 
-  cp -PR $BUILD/linux-*/arch/$KERNEL_ARCH/boot/$KERNEL_IMAGE $TARGET_IMG/$IMAGE_NAME.kernel
-
   if [ "$BOOTLOADER" = "atv-bootloader" ]; then
     cp -PR $BUILD/atv-bootloader-*/mach_kernel $TARGET_IMG/$IMAGE_NAME.mach_kernel
     chmod 0644 $TARGET_IMG/$IMAGE_NAME.mach_kernel
+  else
+    cp -PR $BUILD/linux-*/arch/$KERNEL_ARCH/boot/$KERNEL_IMAGE $TARGET_IMG/$IMAGE_NAME.kernel
+    chmod 0644 $TARGET_IMG/$IMAGE_NAME.kernel
   fi
 
 # create squashfs file
@@ -202,7 +203,6 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
 
 # set permissions
   chmod 0644 $TARGET_IMG/$IMAGE_NAME.system
-  chmod 0644 $TARGET_IMG/$IMAGE_NAME.kernel
 
   if [ "$1" = "release" -o "$1" = "mkimage" ]; then
 
@@ -242,18 +242,20 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
 
       mkdir -p $RELEASE_DIR/target
         cp $TARGET_IMG/$IMAGE_NAME.system $RELEASE_DIR/target/SYSTEM
-        cp $TARGET_IMG/$IMAGE_NAME.kernel $RELEASE_DIR/target/KERNEL
 
         if [ -f $TARGET_IMG/$IMAGE_NAME.mach_kernel ]; then
           cp $TARGET_IMG/$IMAGE_NAME.mach_kernel $RELEASE_DIR/target/MACH_KERNEL
+        else
+          cp $TARGET_IMG/$IMAGE_NAME.kernel $RELEASE_DIR/target/KERNEL
         fi
 
     # create md5sum's
       ( cd $RELEASE_DIR;
         md5sum -t target/SYSTEM > target/SYSTEM.md5;
-        md5sum -t target/KERNEL > target/KERNEL.md5;
         if [ -f target/MACH_KERNEL ]; then
           md5sum -t target/MACH_KERNEL > target/MACH_KERNEL.md5;
+        else
+          md5sum -t target/KERNEL > target/KERNEL.md5;
         fi
       )
 


### PR DESCRIPTION
don’t build KERNEL and KERNEL.md5 (or .kernel) when atv-bootloader is set in project options; from this point forward we only support MACH_KERNEL (aka single-boot) ATV installations
