### PR TITLE
libdrm isn't build with radeon support if GRAPHIC_DRIVERS is radeonsi

### DIFF
--- a/packages/graphics/libdrm/package.mk
+++ b/packages/graphics/libdrm/package.mk
@@ -49,7 +49,7 @@ configure_target() {
       DRM_CONFIG=`echo $DRM_CONFIG | sed -e 's/disable-libkms/enable-libkms/'` && \
       DRM_CONFIG=`echo $DRM_CONFIG | sed -e 's/disable-intel/enable-intel/'`
 
-    [ "$drv" = "r200" -o "$drv" = "r300" -o "$drv" = "r600" -o "$drv" = "radeon" ] && \
+    [ "$drv" = "r200" -o "$drv" = "r300" -o "$drv" = "r600" -o "$drv" = "radeonsi" ] && \
       DRM_CONFIG=`echo $DRM_CONFIG | sed -e 's/disable-libkms/enable-libkms/'` && \
       DRM_CONFIG=`echo $DRM_CONFIG | sed -e 's/disable-radeon/enable-radeon/'`
 


### PR DESCRIPTION
The package config for libdrm looks for "radeon" in the GRAPHIC_DRIVERS var which is wrong since it should be radeonsi. Otherwise Mesa will not compile, since it depends on libdrm radeon support. Since the GRAPHIC_DRIVERS var isn't used somewher, where the "radeon" could make any sense, i've removed it.
