### PR TITLE
Add missing gmake symlink to toolchain

### DIFF
--- a/packages/devel/make/package.mk
+++ b/packages/devel/make/package.mk
@@ -35,5 +35,7 @@ PKG_AUTORECONF="no"
 export CC=$LOCAL_CC
 
 post_makeinstall_host() {
-  ln -s make "${ROOT}/${TOOLCHAIN}/bin/gmake"
+  if [ ! -f "${ROOT}/${TOOLCHAIN}/bin/gmake" ]; then
+    ln -s make "${ROOT}/${TOOLCHAIN}/bin/gmake"
+  fi
 }


### PR DESCRIPTION
When trying to build OpenELEC om my (Gentoo Linux) system I get the error shown below. This is caused by my system having a newer make version (4.0) that is not accepted by gcc, which provides a gmake binary, and the OpenELEC build system not providing such a binary while gcc checks for that first and hence finds one outside the OpenELEC toolchain.

This can be resolved by adding a gmake symlink to make which makes sure that gcc detects the make tool provided by the OpenELEC toolchain.

```
checking version of /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/armv6zk-openelec-linux-gnueabi-gcc... 4.8.2, ok
checking for gnumake... no
checking for gmake... gmake
checking version of gmake... 4.0, bad
checking for gnumsgfmt... no
checking for gmsgfmt... gmsgfmt
checking version of gmsgfmt... 0.18.3, ok
checking for makeinfo... makeinfo
checking version of makeinfo... 5.2, ok
checking for sed... sed
checking version of sed... 4.2.2, ok
checking for gawk... gawk
checking version of gawk... 4.1.0, ok
checking for armv6zk-openelec-linux-gnueabi-nm... /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/armv6zk-openelec-linux-gnueabi-nm
checking for autoconf... autoconf
checking whether autoconf works... no
configure: error: 
*** These critical programs are missing or too old: make
*** Check the INSTALL file for required versions.
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 1
```
