### PR TITLE
Add missing automake symlink

### DIFF
--- a/packages/devel/automake/package.mk
+++ b/packages/devel/automake/package.mk
@@ -37,4 +37,8 @@ PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME --disable-silent-rules"
 post_makeinstall_host() {
   make prefix=$SYSROOT_PREFIX/usr install
   cp -P $PKG_DIR/files/*.m4 $SYSROOT_PREFIX/usr/share/aclocal
+
+  if [ ! -f "${ROOT}/${TOOLCHAIN}/bin/automake" ]; then
+    ln -s make "${ROOT}/${TOOLCHAIN}/bin/automake-1.14"
+  fi
 }


### PR DESCRIPTION
Automake 1.14 apparently does not provide an automake binary, only automake-1.14. This is an issue since the autoreconf script just checks for automake when setting the AUTOMAKE variable. This causes trouble, as can be seen below, since versions get mixed up when autoreconf is used (as all other tools operate within the OpenELEC toolchain).

```
              AUTORECONF   libusb
autoreconf: Entering directory `build.OpenELEC-Nox.arm-devel/libusb-1.0.9'
autoreconf: configure.ac: not using Gettext
autoreconf: running: /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/aclocal -I /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/armv6zk-openelec-linux-gnueabi/sysroot/usr/share/aclocal -I /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/armv6zk-openelec-linux-gnueabi/sysroot/usr/share/aclocal --force -I m4
autoreconf: configure.ac: tracing
autoreconf: running: /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/libtoolize --copy --force
libtoolize: putting auxiliary files in `.'.
libtoolize: copying file `./ltmain.sh'
libtoolize: putting macros in AC_CONFIG_MACRO_DIR, `m4'.
libtoolize: copying file `m4/libtool.m4'
libtoolize: copying file `m4/ltoptions.m4'
libtoolize: copying file `m4/ltsugar.m4'
libtoolize: copying file `m4/ltversion.m4'
libtoolize: copying file `m4/lt~obsolete.m4'
autoreconf: running: /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/autoconf --include=/home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/armv6zk-openelec-linux-gnueabi/sysroot/usr/share/aclocal --force
autoreconf: running: /home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/bin/autoheader --include=/home/pim/raspberrypi/OpenELEC.tv/build.OpenELEC-Nox.arm-devel/toolchain/armv6zk-openelec-linux-gnueabi/sysroot/usr/share/aclocal --force
autoreconf: running: automake --add-missing --copy --force-missing
configure.ac:29: version mismatch.  This is Automake 1.11.6,
configure.ac:29: but the definition used by this AM_INIT_AUTOMAKE
configure.ac:29: comes from Automake 1.14.1.  You should recreate
configure.ac:29: aclocal.m4 with aclocal and run automake again.
autoreconf: automake failed with exit status: 63
Makefile:9: recipe for target 'release' failed
make: *** [release] Error 63
```
