### PR TITLE
Linux: Add performance patch for radeon 7xxx

### DIFF
--- a/packages/linux/patches/3.13.2/linux-802-fix-radeon-7xxx-performance-issue.patch
+++ b/packages/linux/patches/3.13.2/linux-802-fix-radeon-7xxx-performance-issue.patch
@@ -1,0 +1,27 @@
+From 858a41c853cef2cb01de34dae334c19c1c15b237 Mon Sep 17 00:00:00 2001
+From: Alex Deucher <alexander.deucher@amd.com>
+Date: Thu, 30 Jan 2014 19:35:04 +0000
+Subject: drm/radeon: fix UVD IRQ support on 7xx
+
+Otherwise decoding isn't really useable.
+
+Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+Cc: stable@vger.kernel.org
+---
+diff --git a/drivers/gpu/drm/radeon/r600.c b/drivers/gpu/drm/radeon/r600.c
+index 56140b4..cdbc417 100644
+--- a/drivers/gpu/drm/radeon/r600.c
++++ b/drivers/gpu/drm/radeon/r600.c
+@@ -3991,6 +3991,10 @@ restart_ih:
+ 				break;
+ 			}
+ 			break;
++		case 124: /* UVD */
++			DRM_DEBUG("IH: UVD int: 0x%08x\n", src_data);
++			radeon_fence_process(rdev, R600_RING_TYPE_UVD_INDEX);
++			break;
+ 		case 176: /* CP_INT in ring buffer */
+ 		case 177: /* CP_INT in IB1 */
+ 		case 178: /* CP_INT in IB2 */
+--
+cgit v0.9.0.2-2-gbebe


### PR DESCRIPTION
That's the missing one. We already had it for radeon_si
