### PR TITLE
init: only fsck hfs+ when booting from hfs+

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -342,7 +342,7 @@
   }
 
   hfsdiskprep() {
-    for DEVICE in /dev/sd*; do
+    for DEVICE in $(/bin/busybox blkid /dev/sd* | sed -e "s,\",,g"| grep $boot); do
       for device in $(/bin/busybox blkid $DEVICE); do
         case $device in
           TYPE=*)


### PR DESCRIPTION
Only fsck an HFS+ partition when we booted from an HFS+ partition. This should only be true on AppleTV where we need to ensure the HFSX volume is clean before mounting. It is false on other MacOS dual-boot
configurations where HFS+ partitions are present. This resolves #2929, #2928, #2772 and #1070. Thanks @sraue
