### PR TITLE
Samba build fix.

### DIFF
--- a/packages/network/samba/package.mk
+++ b/packages/network/samba/package.mk
@@ -193,7 +193,9 @@ makeinstall_target() {
 }
 
 post_install() {
+	if [ "$SAMBA_SERVER" = "yes" ]; then
       enable_service samba-defaults.service
       enable_service nmbd.service
       enable_service smbd.service
+	fi
 }


### PR DESCRIPTION
If SAMBA_SERVER are set to no, build process will fail because specified service files do not exists in INSTALL directory. "enable_service" function calls exit in case of failure which in turn aborts whole build process.
Do not add/enable samba services if samba server is disabled in project
options.
