### PR TITLE
Disabling samba autoshare in udevil if samba server is not enabled.

### DIFF
--- a/packages/sysutils/udevil/package.mk
+++ b/packages/sysutils/udevil/package.mk
@@ -52,4 +52,8 @@ post_makeinstall_target() {
 
 post_install() {
   enable_service udevil-mount@.service
+	if [ "$SAMBA_SERVER" == "yes" ]; then
+		echo "ExecStartPost=-/usr/lib/samba/samba-autoshare" >> $INSTALL/lib/systemd/system/udevil-mount@.service
+    echo "ExecStopPost=-/usr/lib/samba/samba-autoshare" >> $INSTALL/lib/systemd/system/udevil-mount@.service
+	fi
 }

--- a/packages/sysutils/udevil/system.d/udevil-mount@.service
+++ b/packages/sysutils/udevil/system.d/udevil-mount@.service
@@ -5,6 +5,4 @@ Description=Udevil mount service
 Type=oneshot
 ExecStart=-/usr/bin/udevil --mount %I
 ExecStop=-/usr/bin/udevil --umount %I
-ExecStartPost=-/usr/lib/samba/samba-autoshare
-ExecStopPost=-/usr/lib/samba/samba-autoshare
 RemainAfterExit=yes


### PR DESCRIPTION
Removed autostart of samba_autoshare script if SAMBA_SERVER is disabled
in project options. It could be commented out with sed instead but I thought it will be cleaner. Otherwise it does not course any problems except for an error message in the system log.
