### PR TITLE
ASoc: Don't report S24_LE support, it produces white noise with xbmc

### DIFF
--- a/projects/RPi/patches/linux/linux-01-RPi_support-6a6b2b8.patch
+++ b/projects/RPi/patches/linux/linux-01-RPi_support-6a6b2b8.patch
@@ -107210,7 +107210,7 @@ index 0000000..126f1e9
 +		.channels_max = 2,
 +		.rates = SNDRV_PCM_RATE_8000_192000,
 +		.formats = SNDRV_PCM_FMTBIT_S16_LE |
-+			   SNDRV_PCM_FMTBIT_S24_LE |
++			   // SNDRV_PCM_FMTBIT_S24_LE | : disable for now, it causes white noise with xbmc
 +			   SNDRV_PCM_FMTBIT_S32_LE
 +	},
 +};


### PR DESCRIPTION
Something i noticed in the Raspi kernel tree figured it should be done for Openelec.

https://github.com/raspberrypi/linux/commit/f7bef2ee742f78f555a7a36d133c5b39eecff750
