### PR TITLE
Disable curses support for cmake

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -33,7 +33,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 configure_host() {
-  ../configure --no-qt-gui
+  ../configure --no-qt-gui -- -DBUILD_CursesDialog=0
 }
 
 makeinstall_host() {


### PR DESCRIPTION
This change disables curses support for CMake, which is not used in the OpenELEC build system.
