### PR TITLE
atv: add ModeDebug back to xorg.conf

### DIFF
--- a/projects/ATV/filesystem/etc/X11/xorg-nvidia.conf
+++ b/projects/ATV/filesystem/etc/X11/xorg-nvidia.conf
@@ -7,6 +7,8 @@ Section "Device"
     Option         "ConnectToAcpid" "0"
     Option         "ModeValidation" "NoVesaModes, NoXServerModes"
     Option         "HWCursor" "false"
+    # To put Xorg in debug mode change "false" to "true" in the line below:
+    Option         "ModeDebug" "false"
     Option         "RegistryDwords" "RMDisableRenderToSysmem=1"
     # To use a local /storage/.config/edid.bin file uncomment the 4 lines below:
 #    Option         "ConnectedMonitor" "DFP-0"


### PR DESCRIPTION
we no longer support /storage/.config/xorg.debug so this comment needs to be added back
