### PR TITLE
Added missing vdpau libs for the nvidia legacy driver.

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
@@ -73,4 +73,10 @@ makeinstall_target() {
 
   mkdir -p $INSTALL/usr/bin
     cp nvidia-smi $INSTALL/usr/bin
+
+  if [ "$VDPAU" = yes ]; then
+    mkdir -p $INSTALL/usr/lib/vdpau
+      cp libvdpau_nvidia.so* $INSTALL/usr/lib/vdpau/libvdpau_nvidia.so.1
+      ln -sf libvdpau_nvidia.so.1 $INSTALL/usr/lib/vdpau/libvdpau_nvidia.so
+  fi
 }


### PR DESCRIPTION
The title says it all.
For some reason, vdpau related libs were not copied, causing XBMC to hang on playing media while using the nvidia legacy driver.
