### PR TITLE
[RFC] disable suspend if booting from removable storage

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -588,6 +588,25 @@
 
   BOOT_STEP=final
 
+  # no suspend when booted from nonpersistent storage
+  STORAGE=$(cat /proc/mounts | grep " /sysroot/storage " | awk '{print $1}' | awk -F '/' '{print $3}')
+  if [ -n "$STORAGE" ] ; then
+    removable="/sys/class/block/*/$STORAGE/../removable"
+    if [ -e $removable ] ; then
+      if [ "$(cat $removable 2>/dev/null)" = "1" ] ; then
+        SUSPEND_DISABLED=yes
+      fi
+    fi
+  fi
+  FLASH=$(cat /proc/mounts | grep " /sysroot/flash " | awk '{print $1}' | awk -F '/' '{print $3}')
+  if [ -n "$FLASH" ] ; then
+    removable="/sys/class/block/*/$FLASH/../removable"
+    if [ -e $removable ] ; then
+      if [ "$(cat $removable 2>/dev/null)" = "1" ] ; then
+        SUSPEND_DISABLED=yes
+      fi
+    fi
+  fi
   # move some special filesystems
   /bin/busybox mount --move /dev /sysroot/dev
   /bin/busybox mount --move /proc /sysroot/proc
@@ -600,6 +619,10 @@
   # swap can not be used over nfs.(see scripts/mount-swap)
   if [ "$STORAGE_NETBOOT" = "yes" ] ; then
     echo "" > /sysroot/dev/.storage_netboot
+  fi
+  # no suspend when booted from nonpersistent storage
+  if [ "$SUSPEND_DISABLED" = "yes" ] ; then
+    echo "" > /sysroot/dev/.suspend_disabled
   fi
   # switch to new sysroot and start real init
   exec /bin/busybox switch_root /sysroot /usr/lib/systemd/systemd $INIT_ARGS

--- a/packages/sysutils/systemd/patches/systemd-11_disable-suspend-if-dev-.suspend_disabled-exist.patch
+++ b/packages/sysutils/systemd/patches/systemd-11_disable-suspend-if-dev-.suspend_disabled-exist.patch
@@ -1,0 +1,27 @@
+From a8ad8aadc39820594f89d43aa0f8d527b256aa99 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sat, 22 Mar 2014 13:40:55 +0200
+Subject: [PATCH] disable suspend if /dev/.suspend_disabled exist
+
+---
+ src/shared/sleep-config.c | 4 ++++
+ 1 file changed, 4 insertions(+)
+
+diff --git a/src/shared/sleep-config.c b/src/shared/sleep-config.c
+index cf1cd40..f6ad307 100644
+--- a/src/shared/sleep-config.c
++++ b/src/shared/sleep-config.c
+@@ -256,6 +256,10 @@ int can_sleep(const char *verb) {
+                streq(verb, "hibernate") ||
+                streq(verb, "hybrid-sleep"));
+ 
++        // boo
++        if (access("/dev/.suspend_disabled", F_OK) == 0)
++                return false;
++
+         r = parse_sleep_config(verb, &modes, &states);
+         if (r < 0)
+                 return false;
+-- 
+1.9.1
+


### PR DESCRIPTION
suspend/resume is miserably broken (by design) when booting from removable storage (usb sticks). lets not allow xbmc to suspend/autosuspend

consoder the following scenario:
- user boots from usb stick
- user tries to suspend
- here usb host got reset. bye bye /dev/sda
- resume. /dev/sda is no more. bye bye /storage
- as a side effect - udevil would mount /dev/sda2 as /var/media/Whatever

with this commit, there will be NO "suspend" entry in xbmc shutdown menu. shutdown function CAN NOT be set to "suspend" and is forced as "shutdown"

needs testing on RPi, also need to ensure if it doesnt break something with netboot (this I can test myself next monday).

also, it has been reported several times that resume with NBD/ISCSI boot is broken. let me know if we need to disable suspend also for netboot. EDIT: suspend with nfs is quite fine after we decreased default retrans,timeo options, just some noticeable 5-10 sec delay on resume. 
