### PR TITLE
provide a /etc/os-release file

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -84,6 +84,17 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
   if [ -n "$GIT_HASH" ]; then
     echo "$GIT_HASH" >> $INSTALL/etc/gitrev
   fi
+  
+# create /etc/os-release
+  echo -e "NAME=$DISTRONAME \n" > $INSTALL/etc/os-release
+  echo -e "VERSION=$OPENELEC_VERSION\n" >> $INSTALL/etc/os-release
+  echo -e "PRETTY_NAME=$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "unofficial")) - Version: $OPENELEC_VERSION\n" >> $INSTALL/etc/os-release
+  echo -e "HOME_URL=http://www.openelec.tv\n" >> $INSTALL/etc/os-release
+  echo -e "BUG_REPORT_URL=https://github.com/OpenELEC/OpenELEC.tv\n" >> $INSTALL/etc/os-release
+  if [ -n "$GIT_HASH" ]; then
+	echo -e "BUILD_ID=$GIT_HASH\n" >> $INSTALL/etc/os-release
+  fi
+  
 
   if [ "$OFFICIAL" = "yes" ]; then
     echo "official" > $INSTALL/etc/build


### PR DESCRIPTION
It would be useful for automated scripts to provide a /etc/os-release file.

For more information on /etc/os-release see http://0pointer.de/blog/projects/os-release and http://www.freedesktop.org/software/systemd/man/os-release.html
