### PR TITLE
provide a /etc/os-release file

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -86,7 +86,8 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
   fi
   
 # create /etc/os-release
-  echo -e "NAME=$DISTRONAME \n" > $INSTALL/etc/os-release
+  echo -e "ID=openelec\n" > $INSTALL/etc/os-release
+  echo -e "NAME=$DISTRONAME\n" >> $INSTALL/etc/os-release
   echo -e "VERSION=$OPENELEC_VERSION\n" >> $INSTALL/etc/os-release
   echo -e "PRETTY_NAME=$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "unofficial")) - Version: $OPENELEC_VERSION\n" >> $INSTALL/etc/os-release
   echo -e "HOME_URL=http://www.openelec.tv\n" >> $INSTALL/etc/os-release


### PR DESCRIPTION
It would be useful for automated scripts to provide a /etc/os-release file.

For more information on /etc/os-release see http://0pointer.de/blog/projects/os-release and http://www.freedesktop.org/software/systemd/man/os-release.html
