### PR TITLE
Linux (Radeon): Take care that post and ref divider don't grow too large

### DIFF
--- a/packages/linux/patches/3.14/linux-997-drm-radeon-rework-finding-display-PLL-numbers-fix-range.patch
+++ b/packages/linux/patches/3.14/linux-997-drm-radeon-rework-finding-display-PLL-numbers-fix-range.patch
@@ -1,0 +1,31 @@
+From 146b3e334cdbfa4bf5b5d3a4162f7b677356773d Mon Sep 17 00:00:00 2001
+From: =?UTF-8?q?Christian=20K=C3=B6nig?= <christian.koenig@amd.com>
+Date: Fri, 4 Apr 2014 13:45:42 +0200
+Subject: [PATCH] drm/radeon: apply more strict limits for PLL params
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+Letting post and refernce divider get to big is bad for signal stability.
+
+Signed-off-by: Christian KÃ¶nig <christian.koenig@amd.com>
+---
+ drivers/gpu/drm/radeon/radeon_display.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/radeon/radeon_display.c b/drivers/gpu/drm/radeon/radeon_display.c
+index 386cfa4..d68863e 100644
+--- a/drivers/gpu/drm/radeon/radeon_display.c
++++ b/drivers/gpu/drm/radeon/radeon_display.c
+@@ -937,6 +937,9 @@ void radeon_compute_pll_avivo(struct radeon_pll *pll,
+ 	}
+ 	post_div = post_div_best;
+ 
++	/* limit reference * post divider to a maximum */
++	ref_div_max = min(100 / post_div, ref_div_max);
++
+ 	/* get matching reference and feedback divider */
+ 	ref_div = max(den / post_div, 1u);
+ 	fb_div = nom;
+-- 
+1.9.1


### PR DESCRIPTION
Please do a build test before. This and the other one in 996 should be replaced when Christian updates the v2 patch on the ML.

It fixes fractional Modelines for some people.
