### PR TITLE
xf86-video-nvidia: fix acpi support

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/patches/xf86-video-nvidia-01-kernel-3.14.patch
+++ b/packages/x11/driver/xf86-video-nvidia/patches/xf86-video-nvidia-01-kernel-3.14.patch
@@ -8,7 +8,7 @@ index 801c88c..78f8889 100644
  #include <acpi/acpi_drivers.h>
 +
 +#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 14, 0)
-+#include <acpi/acpi_bus.h>
++#include <linux/acpi.h>
 +#endif
 +
  #if defined(NV_ACPI_DEVICE_OPS_HAS_MATCH) || defined(ACPI_VIDEO_HID)


### PR DESCRIPTION
This patch fixes ACPI support in Nvidia driver on 3.14 kernel.
Without this patch I am not able to initiate Nvidia GPU on Optimus based machine.

Explanation
linux/acpi.h defines ACPI_HANDLE macro which is used in Nvidia sources
linux/acpi.h include was removed from acpi/acpi_drivers.h in 3.14

Related topics
https://devtalk.nvidia.com/default/topic/699422/nvidia-linux-334-21-drivers/?offset=4
https://devtalk.nvidia.com/default/topic/683534/331-38-on-3-14-rc1-kernel/?offset=5
