### PR TITLE
Fix endpoint handling for MCE remotes

### DIFF
--- a/packages/linux/patches/3.14.1/linux-999.02-0002-fix-mceusb-endpoint-handling.patch
+++ b/packages/linux/patches/3.14.1/linux-999.02-0002-fix-mceusb-endpoint-handling.patch
@@ -1,0 +1,118 @@
+--- mceusb.c	2014-04-09 12:37:46.510492000 -0500
++++ mceusb.c	2014-04-17 20:24:03.319805265 -0500
+@@ -761,11 +761,17 @@
+ 		}
+ 
+ 		/* outbound data */
+-		pipe = usb_sndintpipe(ir->usbdev,
+-				      ir->usb_ep_out->bEndpointAddress);
+-		usb_fill_int_urb(async_urb, ir->usbdev, pipe,
+-			async_buf, size, mce_async_callback,
+-			ir, ir->usb_ep_out->bInterval);
++                if ((ir->usb_ep_out->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_INT) {
++                    pipe = usb_sndintpipe(ir->usbdev, ir->usb_ep_out->bEndpointAddress);
++		    usb_fill_int_urb(async_urb, ir->usbdev, pipe, async_buf, 
++                            size, mce_async_callback, ir, ir->usb_ep_out->bInterval);
++                                
++                } else {
++                    pipe = usb_sndbulkpipe(ir->usbdev, ir->usb_ep_out->bEndpointAddress);
++		    usb_fill_bulk_urb(async_urb, ir->usbdev, pipe, async_buf, 
++                            size, mce_async_callback, ir);
++                }
+ 		memcpy(async_buf, data, size);
+ 
+ 	} else if (urb_type == MCEUSB_RX) {
+@@ -1285,32 +1291,38 @@
+ 
+ 		if ((ep_in == NULL)
+ 			&& ((ep->bEndpointAddress & USB_ENDPOINT_DIR_MASK)
+-			    == USB_DIR_IN)
+-			&& (((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
+-			    == USB_ENDPOINT_XFER_BULK)
+-			|| ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
+-			    == USB_ENDPOINT_XFER_INT))) {
+-
+-			ep_in = ep;
+-			ep_in->bmAttributes = USB_ENDPOINT_XFER_INT;
+-			ep_in->bInterval = 1;
+-			mce_dbg(&intf->dev, "acceptable inbound endpoint "
+-				"found\n");
++ 			    == USB_DIR_IN)) {
++ 			if ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_BULK) {
++ 				ep_in = ep;
++ 				mce_dbg(&intf->dev, "acceptable bulk inbound endpoint "
++ 					"found\n");
++ 			}
++ 			if ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_INT) {
++ 				ep_in = ep;
++ 				ep_in->bInterval = 1;
++ 				mce_dbg(&intf->dev, "acceptable interrupt inbound endpoint "
++ 					"found\n");
++ 			}
+ 		}
+ 
+ 		if ((ep_out == NULL)
+ 			&& ((ep->bEndpointAddress & USB_ENDPOINT_DIR_MASK)
+-			    == USB_DIR_OUT)
+-			&& (((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
+-			    == USB_ENDPOINT_XFER_BULK)
+-			|| ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
+-			    == USB_ENDPOINT_XFER_INT))) {
+-
+-			ep_out = ep;
+-			ep_out->bmAttributes = USB_ENDPOINT_XFER_INT;
+-			ep_out->bInterval = 1;
+-			mce_dbg(&intf->dev, "acceptable outbound endpoint "
+-				"found\n");
++ 			    == USB_DIR_OUT)) {
++ 			if ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_BULK) {
++ 				ep_out = ep;
++ 				mce_dbg(&intf->dev, "acceptable bulk outbound endpoint "
++ 					"found\n");
++ 			}
++ 			if ((ep->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_INT) {
++ 				ep_out = ep;
++ 				ep_out->bInterval = 1;
++ 				mce_dbg(&intf->dev, "acceptable interrupt outbound endpoint "
++ 					"found\n");
++ 			}
+ 		}
+ 	}
+ 	if (ep_in == NULL) {
+@@ -1318,7 +1330,13 @@
+ 		return -ENODEV;
+ 	}
+ 
+-	pipe = usb_rcvintpipe(dev, ep_in->bEndpointAddress);
++        if ((ep_in->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_INT) {
++            pipe = usb_rcvintpipe(dev, ep_in->bEndpointAddress);
++        } else {
++            pipe = usb_rcvbulkpipe(dev, ep_in->bEndpointAddress);
++        }
++
+ 	maxp = usb_maxpacket(dev, pipe, usb_pipeout(pipe));
+ 
+ 	ir = kzalloc(sizeof(struct mceusb_dev), GFP_KERNEL);
+@@ -1359,8 +1377,15 @@
+ 		goto rc_dev_fail;
+ 
+ 	/* wire up inbound data handler */
+-	usb_fill_int_urb(ir->urb_in, dev, pipe, ir->buf_in, maxp,
++        if ((ep_in->bmAttributes & USB_ENDPOINT_XFERTYPE_MASK)
++ 			    == USB_ENDPOINT_XFER_INT) {
++            usb_fill_int_urb(ir->urb_in, dev, pipe, ir->buf_in, maxp,
+ 				mceusb_dev_recv, ir, ep_in->bInterval);
++        } else {
++            usb_fill_bulk_urb(ir->urb_in, dev, pipe, ir->buf_in, maxp,
++				mceusb_dev_recv, ir);
++        }
++	
+ 	ir->urb_in->transfer_dma = ir->dma_in;
+ 	ir->urb_in->transfer_flags |= URB_NO_TRANSFER_DMA_MAP;
+ 


### PR DESCRIPTION
The existing driver implementation forces bulk endpoints to act as interrupt
endpoints, which causes some MCE IR receivers (which use bulk transfer endpoints exclusively) to not work when connected to USB 3.0 controllers running in xhci mode.  This patch changes the endpoint handling (and URB initialization) so that both bulk and interrupt endpoints are correctly handled
