### PR TITLE
Nvidia driver - update to latest version

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xf86-video-nvidia"
-PKG_VERSION="331.49"
+PKG_VERSION="331.67"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
from changelog:

Fixed a bug that could lead to crashes when running Left 4 Dead 2 with threaded optimizations enabled.
Updated the makefile for the NVIDIA kernel module to work around a bug in older versions of GNU Make that prevented the NVIDIA kernel module from building correctly. This bug was fixed in version 3.81 of GNU Make.
Fixed a bug that causes some X clients to be disconnected from the X server when the screen is resized while RandR 1.4 display offloading is in use.
Fixed a bug that could cause display corruption when resuming from suspend on systems using RandR 1.4 display offloading with recent Linux kernels.
Added support for Tridelity SL stereo mode.
Fixed a bug that could cause nvidia-settings to crash or display incorrect information after switching virtual terminals while a color correction confirmation countdown was active.
