### PR TITLE
init: optimized wake-on-lan script

### DIFF
--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -80,6 +80,7 @@
         case $boot in
           CIFS=*|SMB=*|ISCSI=*|NBD=*|NFS=*)
             UPDATE_DISABLED=yes
+            FLASH_NETBOOT=yes
             ;;
         esac
         ;;
@@ -93,9 +94,6 @@
         ;;
       wol_mac=*)
         wol_mac="${arg#*=}"
-        ;;
-      wol_ip=*)
-        wol_ip="${arg#*=}"
         ;;
       wol_wait=*)
         wol_wait="${arg#*=}"
@@ -415,21 +413,39 @@
     fi
   }
 
+  wakeonlan() {
+    if [ "$STORAGE_NETBOOT" = "yes" ]; then
+      wol_ip=${disk%:*}
+      wol_ip=${wol_ip#*=}
+    elif [ "$FLASH_NETBOOT" = "yes" ]; then
+      wol_ip=${boot%:*}
+      wol_ip=${wol_ip#*=}
+    else
+      return 0
+    fi
+      
+    if [ -n "$wol_ip" -a -n "$wol_mac" -a -n "$wol_wait" ]; then
+      progress "Sending Magic Packet (WOL) if needed"
+
+      if ! ping -q -c 2 "$wol_ip" &>/dev/null; then
+        ether-wake "$wol_mac"
+        sleep "$wol_wait"
+      fi
+    fi
+  }
+
   mount_flash() {
     progress "Mounting flash"
+
+    wakeonlan
 
     mount_part "$boot" "/flash" "ro,noatime"
   }
 
-  mount_storage() {
-    if [ -n "$wol_ip" ] && [ -n "$wol_mac" ] && [ -n "$wol_wait" ]; then
-      if ! (/bin/busybox ping -q -c 2 "$wol_ip" > /dev/null 2>&1); then
-        /bin/busybox ether-wake "$wol_mac"
-        /bin/busybox sleep "$wol_wait"
-      fi
-    fi
-    
+  mount_storage() {    
     progress "Mounting storage"
+
+    wakeonlan
 
     if [ -n "$disk" ]; then
       if [ -n "$OVERLAY" ]; then


### PR DESCRIPTION
- Optimized wol script, since it had no effect if boot=NFS was used (to load SYSTEM image from nfs).
- Removed wol_ip parameter, ip is now obtained from the nfs mountpoint
- ~~Load splash image before trying to mount /flash (only blank screen would be displayed while waiting for wol to finish if boot=NFS is used)~~
