### PR TITLE
lircd_helper: lircd needs to start if there is a .config/lircd.conf

### DIFF
--- a/packages/sysutils/remote/lirc/scripts/lircd_helper
+++ b/packages/sysutils/remote/lirc/scripts/lircd_helper
@@ -27,9 +27,6 @@ case "$ACTION" in
     if [ "x$DRIVER" = "x" ]; then
       exit 1;
     fi
-    if [ "x$CONFIG" = "x" ]; then
-      exit 1;
-    fi
 
     mkdir -p '/run/lirc'
 
@@ -40,12 +37,16 @@ case "$ACTION" in
       LIRCD_CONFIG="$LIRCD_CONFIG --output=/run/lirc/lircd-$DEVICE"
       LIRCD_CONFIG="$LIRCD_CONFIG --pidfile=/run/lirc/lircd-$DEVICE.pid"
 
-      if [ -e "/storage/.config/$CONFIG" ]; then
-        LIRCD_CONFIG="$LIRCD_CONFIG /storage/.config/$CONFIG"
-      elif [ -e "/storage/.config/lircd.conf" ]; then
+      if [ -e "/storage/.config/lircd.conf" ]; then
         LIRCD_CONFIG="$LIRCD_CONFIG /storage/.config/lircd.conf"
-      elif [ -e "/etc/lirc/$CONFIG" ]; then
-        LIRCD_CONFIG="$LIRCD_CONFIG /etc/lirc/$CONFIG"
+      elif [ -n "$CONFIG" ]; then
+        if [ -e "/storage/.config/$CONFIG" ]; then
+          LIRCD_CONFIG="$LIRCD_CONFIG /storage/.config/$CONFIG"
+        elif [ -e "/etc/lirc/$CONFIG" ]; then
+          LIRCD_CONFIG="$LIRCD_CONFIG /etc/lirc/$CONFIG"
+        else
+          exit 1
+        fi
       else
         exit 1
       fi


### PR DESCRIPTION
Else we need every working remote in udev, 98-lircd.rules.
I dont think we want to maintain this. :-)
