### PR TITLE
connman: allow user editable main.conf

### DIFF
--- a/packages/network/connman/scripts/connman-setup
+++ b/packages/network/connman/scripts/connman-setup
@@ -22,3 +22,10 @@
     mkdir -p /storage/.cache/connman
       cp /usr/share/connman/settings /storage/.cache/connman
   fi
+
+# set variable for connman main.conf location
+  if [ -f /storage/.config/connman_main.conf ]; then
+    export CONNMAN_MAIN="--config=/storage/.config/connman_main.conf"
+  else
+    export CONNMAN_MAIN="--config=/etc/connman/main.conf"
+  fi

--- a/packages/network/connman/system.d/connman.service
+++ b/packages/network/connman/system.d/connman.service
@@ -9,8 +9,7 @@ Type=dbus
 BusName=net.connman
 Restart=on-failure
 EnvironmentFile=-/run/openelec/debug/connman.conf
-ExecStartPre=/usr/lib/connman/connman-setup
-ExecStart=/usr/sbin/connmand -nr $CONNMAN_DEBUG
+ExecStart=/bin/sh -c ". /usr/lib/connman/connman-setup; exec /usr/sbin/connmand -nr $CONNMAN_MAIN $CONNMAN_DEBUG"
 # send SIGKILL on stop to keep ip configuration
 KillSignal=SIGKILL
 StandardOutput=null


### PR DESCRIPTION
In recent months I have seen a number of cases where users need to change connman's ‘prefer ethernet’ to ‘prefer wifi’ behaviour, or where users are trying to enable tethering for ethernet, or are running other daemons that add network interfaces that should not be auto-managed by comman. All of these require user editing of the connman main.conf file, so this change moves it to /storage where it can be tweaked if needed.

NB: I have not actually tested this as i'm in a hotel somewhere, but you get the idea :)
