### PR TITLE
openvpn: enable management interface

### DIFF
--- a/packages/network/openvpn/package.mk
+++ b/packages/network/openvpn/package.mk
@@ -38,7 +38,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_have_decl_TUNSETPERSIST=no \
                            --enable-password-save \
                            --disable-plugins \
                            --enable-iproute2 IPROUTE=/sbin/ip \
-                           --disable-management \
+                           --enable-management \
                            --disable-socks \
                            --disable-http-proxy \
                            --disable-fragment \


### PR DESCRIPTION
This allows https://github.com/brianhornsby/script.openvpn to work as an openvpn configuration interface with OE. Once this has been field-tested we can remove the horribly-broken openvpn support from the OE settings addon. In ref: https://github.com/brianhornsby/script.openvpn/issues/13#issuecomment-42759934
