### PR TITLE
suspend-modules: added brcmfmac

### DIFF
--- a/packages/sysutils/busybox/config/suspend-modules.conf
+++ b/packages/sysutils/busybox/config/suspend-modules.conf
@@ -1,1 +1,1 @@
-SUSPEND_MODULES="xhci-hcd jme asix anysee rtl8192se imon r8712u cx23885 cdc_acm ddbridge"
+SUSPEND_MODULES="xhci-hcd jme asix anysee rtl8192se imon r8712u cx23885 cdc_acm ddbridge brcmfmac"


### PR DESCRIPTION
brcmfmac, used in Cubox-i, cant handle suspend right now and needs unloading.
