### PR TITLE
create_addon: adds support for multiple extension points in addon.xml

### DIFF
--- a/config/addon/addon.xml
+++ b/config/addon/addon.xml
@@ -12,6 +12,7 @@
              library="default.py">
         <provides>executable</provides>
   </extension>
+@EXTENSIONS@
   <extension point="xbmc.addon.metadata">
     <summary>@PKG_SHORTDESC@</summary>
     <description>

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -51,6 +51,22 @@ if [ "$PKG_IS_ADDON" = "yes" ] ; then
     REQUIRES_ADDONVERSION=`echo $i | cut -f2 -d ":"`
     REQUIRES="$REQUIRES\n    <import addon=\"$REQUIRES_ADDONNAME\" version=\"$REQUIRES_ADDONVERSION\" />"
   done
+  
+  for i in $PKG_ADDON_EXTENSIONS; do
+    EXTENSIONS_POINT=`echo $i | cut -f1 -d ":"`
+    EXTENSIONS_LIBRARY=`echo $i | cut -f2 -d ":"`
+    EXTENSIONS_SERVICE_START=`echo $i | cut -f3 -d ":"`
+    EXTENTION_TEMP="  <extension point=\"$EXTENSIONS_POINT\" library=\"$EXTENSIONS_LIBRARY\""
+    
+    if [ "$EXTENSIONS_POINT" = "xbmc.service" -a -n "$EXTENSIONS_SERVICE_START" ]; then
+      EXTENTION_TEMP="$EXTENTION_TEMP start=\"$EXTENSIONS_SERVICE_START\">"
+    else
+      EXTENTION_TEMP="$EXTENTION_TEMP>"
+    fi
+    
+    EXTENTION_TEMP="$EXTENTION_TEMP\n    <provides>executable</provides>\n  </extension>"
+    EXTENSIONS="$EXTENSIONS\n$EXTENTION_TEMP"
+  done
 
   unset IFS
 
@@ -72,6 +88,7 @@ if [ "$PKG_IS_ADDON" = "yes" ] ; then
          -e "s|@PKG_LONGDESC@|$PKG_LONGDESC|g" \
          -e "s|@PKG_DISCLAIMER@|$PKG_DISCLAIMER|g" \
          -e "s|@PROVIDER_NAME@|$PROVIDER_NAME|g" \
+         -e "s|@EXTENSIONS@|$EXTENSIONS|g" \
          -i $ADDON_BUILD/$PKG_ADDON_ID/addon.xml
   else
     CUST_ADDON_VERSION="$PKG_VERSION"


### PR DESCRIPTION
This PR adds a possibility to use multiple extension points in addon.xml. it uses PKG_ADDON_EXTENSIONS variable in package.mk. The format of the data in variable is as follows: 
extension_point:python_script  
More extensions are separated by a space. In case the extension point is xbmc.service third parameter is allowed - when the service should be started - startup | login. In this case e.g.:
xbmc.service:python_script:startup
