### PR TITLE
installer: fix misleading menu entry

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -381,7 +381,7 @@ do_install_quick() {
 
 do_install_custom() {
   # show menu
-  MSG_TITLE="\Z4[ CUSTOM INSTALL MENU ]\Zn"
+  MSG_TITLE="\Z4[ REPAIR/UPGRADE MENU ]\Zn"
   MSG_MENU="\nUse the up/down arrows to select the correct partition where you want to overwrite KERNEL and SYSTEM files.\n\n Please select a partition:"
   MSG_CANCEL="Back"
   DIALOG_OPTIONS="--defaultno"
@@ -614,7 +614,7 @@ menu_main() {
   MSG_TITLE="\Z4[ MAIN MENU ]\Zn"
   MSG_MENU="\n\ZbQuick Install:\Zn do a default installation on a specific device \
             \Z1\Zb(this will delete ALL data on this device!)\Zn \
-            \n\ZbCustom Install:\Zn do a custom installation \
+            \n\ZbRepair / Upgrade:\Zn do repair / upgrade \
             \n\ZbSetup:\Zn change some settings to run OpenELEC \
             \n\ZbBIOS Update:\Zn backup and update your BIOS (only for OEMs) \
             \n\ZbShow logfile:\Zn show and save the logfile \
@@ -625,7 +625,7 @@ menu_main() {
   dialog --colors --backtitle "$BACKTITLE" --cancel-label "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 20 70 5 \
       1 "Quick Install of OpenELEC" \
-      2 "Custom Install of OpenELEC" \
+      2 "Repair / Upgrade" \
       3 "Setup OpenELEC" \
       4 "BIOS update (only for OEM's)" \
       5 "Show logfile" 2> $TMPDIR/mainmenu


### PR DESCRIPTION
"Custom Install" is not install at all, it is there to be used for
upgrade / downgrade / repair. however, people are trying to use it
and get their disks not detected (which is expected)
so, make it clear what it does
