### PR TITLE
linux: revert "drm/radeon: use variable UVD clocks"

### DIFF
--- a/packages/linux/patches/3.15-rc8/linux-999.05-revert-drm-radeon-use-variable-UVD-clocks.patch
+++ b/packages/linux/patches/3.15-rc8/linux-999.05-revert-drm-radeon-use-variable-UVD-clocks.patch
@@ -1,0 +1,74 @@
+From 51e32a86c64021b370d621a8bdf2369303af6e65 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sat, 7 Jun 2014 15:27:20 +0300
+Subject: [PATCH] revert "drm/radeon: use variable UVD clocks"
+
+this reverts upstream commit 14a9579, reported to cause
+UVD performance regression.
+
+original commit:
+> From 14a9579ddbf15dd1992a9481a4ec80b0b91656d5 Mon Sep 17 00:00:00 2001
+> From: Alex Deucher <alexdeucher@gmail.com>
+> Date: Fri, 21 Feb 2014 11:34:35 -0500
+> Subject: drm/radeon: use variable UVD clocks
+> MIME-Version: 1.0
+> Content-Type: text/plain; charset=UTF-8
+> Content-Transfer-Encoding: 8bit
+
+> Now that Christian fixed the performance problems with
+> the feedback buffer in mesa, we can enable variable UVD
+> clocks.  There are multiple UVD power states associated
+> with different types and numbers of streams.  This uses
+> the appropriate state based on that information rather
+> than always using the fastest UVD clocks which saves some
+> power.  One possible downside is that this may adversely
+> affect decode benchmarks since these power states target
+> specific playback requirements rather than maximum
+> performance.  If that becomes an issue, we can add a
+> sysfs attribute to force the max UVD state.
+
+> Signed-off-by: Alex Deucher <alexander.deucher@amd.com>
+> Reviewed-by: Christian K?nig <christian.koenig@amd.com>
+---
+ drivers/gpu/drm/radeon/radeon_pm.c  |    3 +++
+ drivers/gpu/drm/radeon/radeon_uvd.c |    3 ++-
+ 2 files changed, 5 insertions(+), 1 deletions(-)
+
+diff --git a/drivers/gpu/drm/radeon/radeon_pm.c b/drivers/gpu/drm/radeon/radeon_pm.c
+index 53d6e1b..1d01a07 100644
+--- a/drivers/gpu/drm/radeon/radeon_pm.c
++++ b/drivers/gpu/drm/radeon/radeon_pm.c
+@@ -984,6 +984,8 @@ void radeon_dpm_enable_uvd(struct radeon_device *rdev, bool enable)
+ 		if (enable) {
+ 			mutex_lock(&rdev->pm.mutex);
+ 			rdev->pm.dpm.uvd_active = true;
++			/* disable this for now */
++#if 0
+ 			if ((rdev->pm.dpm.sd == 1) && (rdev->pm.dpm.hd == 0))
+ 				dpm_state = POWER_STATE_TYPE_INTERNAL_UVD_SD;
+ 			else if ((rdev->pm.dpm.sd == 2) && (rdev->pm.dpm.hd == 0))
+@@ -993,6 +995,7 @@ void radeon_dpm_enable_uvd(struct radeon_device *rdev, bool enable)
+ 			else if ((rdev->pm.dpm.sd == 0) && (rdev->pm.dpm.hd == 2))
+ 				dpm_state = POWER_STATE_TYPE_INTERNAL_UVD_HD2;
+ 			else
++#endif
+ 				dpm_state = POWER_STATE_TYPE_INTERNAL_UVD;
+ 			rdev->pm.dpm.state = dpm_state;
+ 			mutex_unlock(&rdev->pm.mutex);
+diff --git a/drivers/gpu/drm/radeon/radeon_uvd.c b/drivers/gpu/drm/radeon/radeon_uvd.c
+index 1b65ae2..a4ad270 100644
+--- a/drivers/gpu/drm/radeon/radeon_uvd.c
++++ b/drivers/gpu/drm/radeon/radeon_uvd.c
+@@ -812,7 +812,8 @@ void radeon_uvd_note_usage(struct radeon_device *rdev)
+ 		    (rdev->pm.dpm.hd != hd)) {
+ 			rdev->pm.dpm.sd = sd;
+ 			rdev->pm.dpm.hd = hd;
+-			streams_changed = true;
++			/* disable this for now */
++			/*streams_changed = true;*/
+ 		}
+ 	}
+ 
+-- 
+1.7.2.5
+


### PR DESCRIPTION
thanks @fritsch
