### PR TITLE
optional mdns resolution (issue #3187)

### DIFF
--- a/packages/devel/eglibc/package.mk
+++ b/packages/devel/eglibc/package.mk
@@ -178,10 +178,17 @@ post_makeinstall_target() {
 
 # create default configs
   mkdir -p $INSTALL/etc
-    cp $PKG_DIR/config/nsswitch.conf $INSTALL/etc
+    ln -s /var/run/nsswitch.conf $INSTALL/etc/nsswitch.conf
     cp $PKG_DIR/config/host.conf $INSTALL/etc
     cp $PKG_DIR/config/gai.conf $INSTALL/etc
 
+  mkdir -p $INSTALL/usr/config
+    cp $PKG_DIR/config/nsswitch.conf $INSTALL/usr/config
+
+# copy script
+  mkdir -p $INSTALL/usr/lib/openelec
+  cp $PKG_DIR/scripts/nsswitch-setup $INSTALL/usr/lib/openelec
+   
   if [ "$TARGET_ARCH" = "arm" -a "$TARGET_FLOAT" = "hard" ]; then
     ln -sf ld.so $INSTALL/lib/ld-linux.so.3
   fi
@@ -205,4 +212,8 @@ makeinstall_init() {
     if [ "$TARGET_ARCH" = "arm" -a "$TARGET_FLOAT" = "hard" ]; then
       ln -sf ld.so $INSTALL/lib/ld-linux.so.3
     fi
+}
+
+post_install() {
+  enable_service nsswitch.service
 }

--- a/packages/devel/eglibc/scripts/nsswitch-setup
+++ b/packages/devel/eglibc/scripts/nsswitch-setup
@@ -1,0 +1,25 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2014 Jean-Charles Andlauer (andlauer@gmail.com)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+if [[ -f /storage/.cache/services/mdns4.conf && -f /storage/.cache/services/avahi.conf ]]; then
+  cp /usr/config/nsswitch.mdns4 /var/run/nsswitch.conf
+else
+  cp /usr/config/nsswitch.conf  /var/run/nsswitch.conf
+fi
+

--- a/packages/devel/eglibc/system.d/nsswitch.service
+++ b/packages/devel/eglibc/system.d/nsswitch.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=nsswitch.conf Setup
+After=local-fs.target
+
+[Service]
+Type=oneshot
+ExecStart=/usr/lib/openelec/nsswitch-setup
+RemainAfterExit=yes
+
+[Install]
+WantedBy=network.target

--- a/packages/network/nss-mdns/config/nsswitch.mdns4
+++ b/packages/network/nss-mdns/config/nsswitch.mdns4
@@ -1,0 +1,18 @@
+#
+# Configuration of GNU Name Service Switch functionality with mdns4.
+#
+
+passwd:		files
+group:		files
+shadow:		files
+gshadow:	files
+
+hosts:		files mdns4_minimal [NOTFOUND=return] dns mdns4
+networks:	files dns
+
+protocols:	files
+services:	files
+ethers:		files
+rpc:		files
+
+netgroup:	files

--- a/packages/network/nss-mdns/package.mk
+++ b/packages/network/nss-mdns/package.mk
@@ -1,0 +1,51 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2014 Jean-Charles Andlauer (andlauer@gmail.com)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="nss-mdns"
+PKG_VERSION="0.10"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GNU LGPL"
+PKG_SITE="http://0pointer.de/lennart/projects/nss-mdns/"
+PKG_URL="${PKG_SITE}$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain avahi"
+PKG_PRIORITY="optional"
+PKG_SECTION="network"
+PKG_SHORTDESC="NSS module for Multicast DNS name resolution"
+PKG_LONGDESC="nss-mdns is a plugin for the GNU Name Service Switch (NSS) functionality of the GNU C Library (glibc) providing host name resolution via Multicast DNS (aka Zeroconf, aka Apple Rendezvous), effectively allowing name resolution by common Unix/Linux programs in the ad-hoc mDNS domain .local."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--prefix=/"
+
+MAKEFLAGS="-j1"
+
+post_makeinstall_target() {
+
+  mkdir -p $INSTALL/usr/config
+  cp $PKG_DIR/config/nsswitch.mdns4 $INSTALL/usr/config
+
+  mkdir -p $INSTALL/usr/lib
+  ln -s ../../lib/libnss_mdns.so.2          $INSTALL/usr/lib/libnss_mdns.so
+  ln -s ../../lib/libnss_mdns4.so.2         $INSTALL/usr/lib/libnss_mdns4.so
+  ln -s ../../lib/libnss_mdns4_minimal.so.2 $INSTALL/usr/lib/libnss_mdns4_minimal.so
+  ln -s ../../lib/libnss_mdns6.so.2         $INSTALL/usr/lib/libnss_mdns6.so
+  ln -s ../../lib/libnss_mdns6_minimal.so.2 $INSTALL/usr/lib/libnss_mdns6_minimal.so
+  ln -s ../../lib/libnss_mdns_minimal.so.2  $INSTALL/usr/lib/libnss_mdns_minimal.so
+}


### PR DESCRIPTION
Hello,

Could issue #3187 be solved as proposed here?

/etc/nsswitch.conf is a symbolic link to /var/run/nsswitch.conf

nsswitch.conf (without mdns) and nsswitch.mdns4 (with mdns4) configuration files sit in usr/config.

/usr/lib/openelec/nsswitch-setup copies the appropriate nsswitch configuration file from /usr/config to /var/run/nsswitch.conf, i.e. nsswitch.mdns4 if mdns4.conf and avahi.conf files exist in /storage/.cache/services, nsswitch.conf otherwise.

nsswitch.service runs nsswitch-setup after local-fs.target and before network.target.

I have succesfully tested this on my Raspberry Pi (even though I had to install nss-mdns via the testing package, because make release would not install it from packages/network/nss-mdns, maybe someone here could tell me what I am doing wrong).

Thank you for your attention, and regards,

Jean-Charles
