### PR TITLE
Change to noop scheduler as default for non rotational media

### DIFF
--- a/packages/linux/udev.d/80-io-scheduler.rules
+++ b/packages/linux/udev.d/80-io-scheduler.rules
@@ -1,0 +1,1 @@
+ACTION=="add|change", KERNEL=="sd[a-z]", ATTR{queue/rotational}=="0", ATTR{queue/scheduler}="noop"


### PR DESCRIPTION
Change to noop scheduler as default for non rotational media.

This will increase performance for flash memory devices.

deadline seems to be the best scheduler for flash memory, but is currently not enabled for OE.
http://www.phoronix.com/scan.php?page=article&item=linux_316_iosched&num=1
