### PR TITLE
propects/Generic/options: lcdproc: enable serialVFD

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -311,7 +311,7 @@
 # 'all' compiles all drivers;
 # 'all,!xxx,!yyy' de-selects previously selected drivers
 # "none" for disable LCD support
-  LCD_DRIVER="irtrans,imon,imonlcd,mdm166a,MtxOrb,lis,dm140,hd44780,CFontz,SureElec,vlsys_m428"
+  LCD_DRIVER="irtrans,imon,imonlcd,mdm166a,MtxOrb,lis,dm140,hd44780,CFontz,SureElec,vlsys_m428,serialVFD"
 
 # Modules to install in initramfs for early boot
   INITRAMFS_MODULES="xhci-hcd"


### PR DESCRIPTION
closes #3341

let me know if it does not make sense on RPi/Cuboxi
