### PR TITLE
Ignore diagonals for iMON PAD in keyboard mode

### DIFF
--- a/packages/linux/patches/linux-999_imon_pad_ignore_diagonal.patch
+++ b/packages/linux/patches/linux-999_imon_pad_ignore_diagonal.patch
@@ -1,0 +1,20 @@
+--- a/drivers/media/rc/imon.c	2014-06-29 15:15:50.187264025 -0400
++++ b/drivers/media/rc/imon.c	2014-06-29 15:15:35.731220648 -0400
+@@ -1406,6 +1415,16 @@
+ 			buf[3] = (dir >> 8) & 0xFF;
+ 			scancode = be32_to_cpu(*((u32 *)buf));
+ 		} else {
++			/*
++			 * For users without stabilized, just ignore any value getting
++			 * to close to the diagonal.
++			 */
++			if ((abs(rel_y) < 2 && abs(rel_x) < 2) ||
++				abs(abs(rel_y) - abs(rel_x)) < 2 ) {
++				spin_lock_irqsave(&ictx->kc_lock, flags);
++				ictx->kc = KEY_UNKNOWN;
++				spin_unlock_irqrestore(&ictx->kc_lock, flags);
++				return;
++			}
+ 			/*
+ 			 * Hack alert: instead of using keycodes, we have
+ 			 * to use hard-coded scancodes here...


### PR DESCRIPTION
For user with an iMON PAD Remote, the keyboard mode is very touchy and almost useless with XBMC. To make it less touchy, I make it ignore the diagonals.
