### PR TITLE
oe_setup_addon: create missing folder

### DIFF
--- a/packages/mediacenter/xbmc-master/profile.d/03-addons.conf
+++ b/packages/mediacenter/xbmc-master/profile.d/03-addons.conf
@@ -23,6 +23,7 @@ oe_setup_addon() {
 
     # copy defaults
     if [ -f "$DEF" -a ! -f "$CUR" ] ; then
+      mkdir -p "/storage/.xbmc/userdata/addon_data/$1"
       cp "$DEF" "$CUR"
     fi
 

--- a/packages/mediacenter/xbmc/profile.d/03-addons.conf
+++ b/packages/mediacenter/xbmc/profile.d/03-addons.conf
@@ -23,6 +23,7 @@ oe_setup_addon() {
 
     # copy defaults
     if [ -f "$DEF" -a ! -f "$CUR" ] ; then
+      mkdir -p "/storage/.xbmc/userdata/addon_data/$1"
       cp "$DEF" "$CUR"
     fi
 


### PR DESCRIPTION
On first run of the addon the folder doesn't exist yet and xml file is not copied.
