### PR TITLE
lcdproc: tune lcdd.service

### DIFF
--- a/packages/sysutils/lcdproc/system.d/lcdd.service
+++ b/packages/sysutils/lcdproc/system.d/lcdd.service
@@ -7,6 +7,10 @@ After=multi-user.target
 EnvironmentFile=-/storage/.cache/services/lcdd.conf
 ExecStart=/bin/sh -c 'exec /usr/lib/openelec/lcd-wrapper'
 TimeoutStopSec=1s
+Restart=always
+RestartSec=5
+StartLimitInterval=30
+StartLimitBurst=5
 
 [Install]
 WantedBy=multi-user.target


### PR DESCRIPTION
this fixes an issue where lcdd will not start at all, if imon driver is initialized late.
should be bacported to 4.0
