### PR TITLE
tvheadend service addon: Version update, new tool & a build fix.

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/package.mk
+++ b/packages/addons/service/multimedia/tvheadend/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="tvheadend"
-PKG_VERSION="3.9.1050"
+PKG_VERSION="3.9.1085"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -36,6 +36,9 @@ PKG_AUTORECONF="no"
 pre_build_target() {
   mkdir -p $PKG_BUILD/.$TARGET_NAME
   cp -RP $PKG_BUILD/* $PKG_BUILD/.$TARGET_NAME
+  # Copy git repository as well. It is needed during tvheadend build 
+  # to determine version number (see script tvheadend/support/version)
+  cp -RP $PKG_BUILD/.git* $PKG_BUILD/.$TARGET_NAME
 }
 
 configure_target() {

--- a/tools/mkpkg/mkpkg_tvheadend
+++ b/tools/mkpkg/mkpkg_tvheadend
@@ -1,0 +1,49 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+echo "getting sources..."
+  if [ ! -d tvheadend.git ]; then
+    git clone git://github.com/tvheadend/tvheadend.git tvheadend.git
+  fi
+
+  VER="0.0.0"
+  
+  cd tvheadend.git
+    git pull
+    # Calculate version
+    VER=$(git describe --dirty --match "v*" 2> /dev/null)
+    VER=$(echo $VER | sed "s/^v//" | sed "s/-\([0-9]*\)-\(g[0-9a-f]*\)/.\1/")
+  cd ..
+
+echo "copying sources..."
+  rm -rf tvheadend-$VER
+  cp -R tvheadend.git tvheadend-$VER
+
+# Don't delete repository. It is needed during tvheadend build to determine 
+# version number (see script tvheadend/support/version)
+#echo "cleaning sources..."
+#  rm -rf tvheadend-$VER/.git
+
+echo "packing sources..."
+  tar cvzf tvheadend-$VER.tar.gz tvheadend-$VER
+
+echo "remove temporary sourcedir..."
+  rm -rf tvheadend-$VER


### PR DESCRIPTION
Updated: tvheadend version to 3.9.1085 (seems to be very stable).
New: tools/mkpkg/mkpkg_tvheadend
Fixed: copy .git during build. Otherwise tvheadend version will be 0.0.0~unknown.
