### PR TITLE
- libnfs: update to 1.9.5

### DIFF
--- a/packages/network/libnfs/package.mk
+++ b/packages/network/libnfs/package.mk
@@ -16,10 +16,8 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
-# TODO: libnfs-1.9.3 fails at runtime (xbmc)
-
 PKG_NAME="libnfs"
-PKG_VERSION="1.8.0"
+PKG_VERSION="1.9.5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
By upgrading we get new features like directory caching and file read-
ahead support.

I successfully tested against 2a7749b4cbc4bcaf0509cf7ff69ee5a3eca02013
