### PR TITLE
allow packages in projects folder

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -51,12 +51,22 @@ setup_toolchain() {
 }
 
 kernel_path() {
-  . $ROOT/packages/linux/package.mk
+  if [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
+    . $ROOT/projects/$PROJECT/packages/linux/package.mk
+  else
+    . $ROOT/packages/linux/package.mk
+  fi
+
   echo $ROOT/$BUILD/${PKG_NAME}-${PKG_VERSION}
 }
 
 kernel_version() {
-  . $ROOT/packages/linux/package.mk
+  if [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
+    . $ROOT/projects/$PROJECT/packages/linux/package.mk
+  else
+    . $ROOT/packages/linux/package.mk
+  fi
+
   echo ${PKG_VERSION}
 }
 
@@ -68,10 +78,16 @@ get_module_dir() {
 # get package's build dir
 get_build_dir() {
   if [ ! -z $1 ] ; then
-    local _PKG_DIR=$(find $ROOT/packages -name $1)
-    if [ -d $_PKG_DIR -a -f $_PKG_DIR/package.mk ] ; then
+    local _PKG_DIR=$(find $ROOT/projects/$PROJECT/packages -name $1)
+    if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
       . $_PKG_DIR/package.mk
+    else
+      local _PKG_DIR=$(find $ROOT/packages -name $1)
+      if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
+        . $_PKG_DIR/package.mk
+      fi
     fi
+
     echo $ROOT/$BUILD/${PKG_NAME}-${PKG_VERSION}
   fi
 }

--- a/config/path
+++ b/config/path
@@ -64,8 +64,12 @@ SED="sed -i"
   PKG_IS_ADDON="no"
 
   if [ -n "$1" ]; then
+    _PKG_ROOT_NAME=$(echo $1 | cut -d: -f1)
+
+    # first check project folder for a package
     FOUND=0
-    for DIR in $ROOT/`find $PACKAGES -type d -name $(echo $1| awk -F : '{print $1}') ! -wholename \*\/source\/\* 2>/dev/null` ; do
+    ALL_DIRS=""
+    for DIR in $ROOT/`find projects/$PROJECT/packages -type d -name $_PKG_ROOT_NAME ! -wholename \*\/source\/\* 2>/dev/null` ; do
       # keep track of dirs with meta for debugging
       if [ -z "$ALL_DIRS" ] ; then
         ALL_DIRS="$DIR"
@@ -84,6 +88,31 @@ SED="sed -i"
         fi
       fi
     done
+
+    # then check packages folder if not found already
+    if [ $FOUND -eq 0 ] ; then
+      FOUND=0
+      ALL_DIRS=""
+      for DIR in $ROOT/`find $PACKAGES -type d -name $_PKG_ROOT_NAME ! -wholename \*\/source\/\* 2>/dev/null` ; do
+        # keep track of dirs with meta for debugging
+        if [ -z "$ALL_DIRS" ] ; then
+          ALL_DIRS="$DIR"
+        else
+          ALL_DIRS="$ALL_DIRS\\n$DIR"
+        fi
+        if [ -f "$DIR/package.mk" ] ; then
+          FOUND=$((FOUND+1))
+          # found first. set $PKG_DIR
+          PKG_DIR="$DIR"
+          if [ $FOUND -gt 1 ] ; then
+            # found more ? fail
+            echo "Error - multiple package folders:"
+            echo -e "$ALL_DIRS"
+            exit 1
+          fi
+        fi
+      done
+    fi
   fi
 
   if [ -r $PKG_DIR/package.mk ]; then

--- a/scripts/image
+++ b/scripts/image
@@ -237,7 +237,16 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
       # remove n previous created release image
         rm -rf $TARGET_IMG/$IMAGE_NAME.img.gz
         if [ -n "$BOOTLOADER" ]; then
-          BOOTLOADER_DIR=`find $PACKAGES -type d -name $BOOTLOADER 2>/dev/null`
+          if [ -d $ROOT/projects/$PROJECT/packages ]; then
+          	BOOTLOADER_DIR=`find $ROOT/projects/$PROJECT/packages -type d -name $BOOTLOADER 2>/dev/null`
+          else
+          	BOOTLOADER_DIR=""
+          fi
+
+          if [ -z "$BOOTLOADER_DIR" -o ! -d "$BOOTLOADER_DIR" ]; then
+          	BOOTLOADER_DIR=`find $PACKAGES -type d -name $BOOTLOADER 2>/dev/null`
+          fi
+
           if [ -d "$BOOTLOADER_DIR"/files ]; then
             cp -R $BOOTLOADER_DIR/files/* $RELEASE_DIR
           fi


### PR DESCRIPTION
This allows to use local package from project folder instead of system one from packages folder. It simplifies package dependency for newer projects like for TBS Matrix I'm working on. It requires different gcc, u-boot, ...
