### PR TITLE
fix for cleaning the working directory for packages without version

### DIFF
--- a/scripts/clean
+++ b/scripts/clean
@@ -29,7 +29,7 @@ if [ ! -z "$1" ]; then
     return
   fi
 
-  for i in $BUILD/$1-*; do
+  for i in $BUILD/$1*; do
     if [ -d $i -a -f "$i/.openelec-unpack" ] ; then
       . "$i/.openelec-unpack"
       if [ "$STAMP_PKG_NAME" = "$1" ]; then


### PR DESCRIPTION
scripts/clean removes directories with dash between the name and version, so it's not working for packages without version (e.g.: initramfs) because it can't find directory "build.../initramfs-". This patch just removes dash from the for loop and causes that initramfs is cleaned correctly.
