### PR TITLE
create_installstick: update mbr for Debian Jessie

### DIFF
--- a/packages/tools/syslinux/files/create_installstick
+++ b/packages/tools/syslinux/files/create_installstick
@@ -245,7 +245,9 @@ EOF
     MBR="/usr/share/syslinux/mbr.bin"     # example: fedora
   elif [ -f /usr/lib/syslinux/bios/mbr.bin ]; then
     MBR="/usr/lib/syslinux/bios/mbr.bin"  # example: arch
-  else
+  elif [ -f /usr/lib/syslinux/mbr/mbr.bin ]; then
+    MBR="/usr/lib/syslinux/mbr/mbr.bin"   # example: Debian Jessie
+   else
     echo "ERROR: Can't find syslinux's mbr.bin on Host OS" >&2
   fi
 


### PR DESCRIPTION
In Debian Jessie, the path to `mbr.bin` is `/usr/lib/syslinux/mbr/mbr.bin`.
