### PR TITLE
boost/package.mk: added --ignore-site-config to ignore external site-config.jam

### DIFF
--- a/packages/devel/boost/package.mk
+++ b/packages/devel/boost/package.mk
@@ -69,6 +69,7 @@ make_target() {
 makeinstall_target() {
   $ROOT/$TOOLCHAIN/bin/bjam -d2 --toolset=gcc link=static \
                                 --prefix=$SYSROOT_PREFIX/usr \
+				--ignore-site-config \
                                   --layout=system \
                                   --with-thread \
                                   --with-iostreams \


### PR DESCRIPTION
When trying to build OpenELEC I ran into the following problem:

```
  BUILD    boost (target)
Detecting Python version... 2.7
Detecting Python root... /home/pim/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/toolchain
Unicode/ICU support for Boost.Regex?... /usr
Generating Boost.Build configuration in project-config.jam...

Bootstrapping is done. To build, run:

    ./b2

To adjust configuration, edit 'project-config.jam'.
Further information:

   - Command line help:
     ./b2 --help

   - Getting started guide: 
     http://www.boost.org/more/getting_started/unix-variants.html

   - Boost.Build documentation:
     http://www.boost.org/boost-build2/doc/html/index.html

/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build/feature.jam:493: in feature.validate-value-string from module feature
error: "none" is not a known value of feature <optimization>
error: legal values: "off" "speed" "space"
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build/property.jam:273: in validate1 from module property
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build/property.jam:299: in property.validate from module property
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/tools/builtin.jam:377: in variant from module builtin
/usr/share/boost-build/site-config.jam:9: in modules.load from module site-config
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build-system.jam:249: in load-config from module build-system
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build-system.jam:351: in load-configuration-files from module build-system
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/build-system.jam:524: in load from module build-system
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/kernel/modules.jam:289: in import from module modules
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/tools/build/src/kernel/bootstrap.jam:139: in boost-build from module
/mnt/data/raspberrypi/OpenELEC/build.OpenELEC-Nox.arm-devel/boost-1_56_0/boost-build.jam:17: in module scope from module
```

This is caused by the boost build including the site-config.jam file from the host which is apparently incompatible with the current build.

This commit resolves this problem by ignoring the site-config.jam during the build process. 
