### PR TITLE
busybox: add support for project specific initramfs scripts

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -233,6 +233,11 @@ makeinstall_init() {
     touch $INSTALL/etc/fstab
     ln -sf /proc/self/mounts $INSTALL/etc/mtab
 
+  if [ -x $PROJECT_DIR/$PROJECT/initramfs/initramfs.sh ]; then
+    mkdir -p $INSTALL/usr/bin
+    cp $PROJECT_DIR/$PROJECT/initramfs/initramfs.sh $INSTALL/usr/bin
+  fi
+
   cp $PKG_DIR/scripts/init $INSTALL
   chmod 755 $INSTALL/init
 }

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -55,6 +55,11 @@
   INSTALLED_MEMORY=`cat /proc/meminfo | grep 'MemTotal:' | awk '{print $2}'`
   SYSTEM_TORAM_LIMIT=1024000
 
+  # run project specific settings if available
+  if [ -x "/usr/bin/initramfs.sh" ]; then
+    /usr/bin/initramfs.sh
+  fi
+
   # hide kernel log messages on console
   echo '1 4 1 7' > /proc/sys/kernel/printk
 


### PR DESCRIPTION
@sraue as discussed in e672e6e2496aa4297d7d417ebeab7e439d224303 
how about this? doesn't use a .conf anymore ;-)
Also I am not quite sure if Busybox is capable of the -x (exist and executable).