### PR TITLE
lcdproc: enable shuttleVFD

### DIFF
--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -311,7 +311,7 @@
 # 'all' compiles all drivers;
 # 'all,!xxx,!yyy' de-selects previously selected drivers
 # "none" for disable LCD support
-  LCD_DRIVER="irtrans,imon,imonlcd,mdm166a,MtxOrb,lis,dm140,hd44780,CFontz,SureElec,vlsys_m428,serialVFD"
+  LCD_DRIVER="irtrans,imon,imonlcd,mdm166a,MtxOrb,lis,dm140,hd44780,CFontz,SureElec,vlsys_m428,serialVFD,shuttleVFD"
 
 # Modules to install in initramfs for early boot
   INITRAMFS_MODULES=""


### PR DESCRIPTION
build test passed. reported working. see http://openelec.tv/forum/41-supported-hardware/72621-shuttlevfd-driver-of-lcdproc
