### PR TITLE
[Rbp] Enable mmal libraries

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -48,6 +48,10 @@ make_target() {
     cp -PRv $FLOAT/opt/vc/lib/libbcm_host.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvchiq_arm.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvcos.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $SYSROOT_PREFIX/usr/lib
 }
 
 makeinstall_target() {
@@ -61,6 +65,10 @@ makeinstall_target() {
     cp -PRv $FLOAT/opt/vc/lib/libopenmaxil.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvchiq_arm.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libvcos.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $INSTALL/usr/lib
 
 # some usefull debug tools
   mkdir -p $INSTALL/usr/bin


### PR DESCRIPTION
As [requested](http://forum.xbmc.org/showthread.php?tid=202984), this PR adds the Raspberry Pi mmal libraries in preparation for newclock4 patches.
