### PR TITLE
media_build: update drivers to version 2014-09-26

### DIFF
--- a/packages/linux-drivers/media_build/package.mk
+++ b/packages/linux-drivers/media_build/package.mk
@@ -19,8 +19,8 @@
 ################################################################################
 
 PKG_NAME="media_build"
-PKG_VERSION="dbc32ea"
-MEDIA_BUILD_VERSION="2014-09-03-89fffac"
+PKG_VERSION="66f4030"
+MEDIA_BUILD_VERSION="2014-09-26-214635f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- added Kernel 3.16/17 compatibility
- removed fw download and install (already at OE)
- media_build_66f4030 needs upload to OE server (/tools/mkpkg/mkpkg_media_build)!
