### PR TITLE
sudo: exit with exit status 1

### DIFF
--- a/packages/sysutils/busybox/scripts/sudo
+++ b/packages/sysutils/busybox/scripts/sudo
@@ -28,3 +28,5 @@ message="$message\n With OpenELEC you have root access by default, so you dont n
 message="$message\n "
 
 echo -e $message
+
+exit 1


### PR DESCRIPTION
When there's no working sudo on OpenELEC, it should then return an [exit status](http://tldp.org/LDP/abs/html/exit-status.html) that reflects this alongside the already shown message.

With this change scripts that need to detect if there's a working sudo doesn't need to parse the shown message and can rely on the exit status.
