### PR TITLE
[systemd] Cosmetic: Fix non-existant display-manager dependency

### DIFF
--- a/packages/sysutils/systemd/patches/systemd-14_remove_nonexistant_dependency.patch
+++ b/packages/sysutils/systemd/patches/systemd-14_remove_nonexistant_dependency.patch
@@ -1,0 +1,8 @@
+--- a/units/graphical.target	2014-09-12 03:41:47.194979504 +0100
+--- b/units/graphical.target	2014-09-12 03:41:47.194979504 +0100
+@@ -11,5 +11,4 @@
+ Requires=multi-user.target
+ After=multi-user.target
+ Conflicts=rescue.target
+-Wants=display-manager.service
+ AllowIsolate=yes


### PR DESCRIPTION
The graphical.target in Systemd-216 has a "Wants" dependency on display-manager.service which is a non-existent service. Consequently, the following message appears in the kernel log:

```
[    5.676728] systemd[1]: Cannot add dependency job for unit display-manager.service, ignoring: Unit display-manager.service failed to load: No such file or directory.
```

Removing this dependency eliminates this message.
