### PR TITLE
add package for MT7601U wireless chipsets

### DIFF
--- a/packages/linux-drivers/MT7601U/package.mk
+++ b/packages/linux-drivers/MT7601U/package.mk
@@ -1,0 +1,59 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2014 Christian Hewitt (chewitt@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="MT7601U"
+PKG_VERSION="7a438c9"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+# mediatek: PKG_SITE="http://www.mediatek.com/en/downloads/mt7601u-usb/"
+PKG_SITE="https://github.com/porjo/mt7601"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Mediatek MT7601U Linux 3.x driver"
+PKG_LONGDESC="Mediatek MT7601U Linux 3.x driver"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+make_target() {
+
+  cd src
+
+  sed -i '200s|.*LINUX_SRC.*|LINUX_SRC = '$(kernel_path)'|' Makefile
+  sed -i '203s|.*LINUX_SRC_MODULE.*|LINUX_SRC_MODULE = '$INSTALL'/lib/modules/'$(get_module_dir)'/kernel/drivers/net/wireless/|' Makefile
+  local CROSS_COMPILE=$(echo $TARGET_PREFIX | sed 's|.*/||')
+  sed -i '204s|CROSS_COMPILE =|CROSS_COMPILE = '$CROSS_COMPILE'\
+ARCH = '$TARGET_ARCH'\
+export ARCH\
+export CROSS_COMPILE|' Makefile
+
+  make osdrv
+
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME
+    cp os/linux/mt7601Usta.ko $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME
+
+  mkdir -p $INSTALL/lib/firmware/MT7601USTA
+    cp RT2870STA.dat $INSTALL/lib/firmware/MT7601USTA/MT7601USTA.dat
+}

--- a/packages/linux-drivers/MT7601U/patches/MT7601U-001-sta_cfg.patch
+++ b/packages/linux-drivers/MT7601U/patches/MT7601U-001-sta_cfg.patch
@@ -1,0 +1,11 @@
+--- a/src/sta/sta_cfg.c	2014-09-18 18:04:41.000000000 +0400
++++ b/src/sta/sta_cfg.c	2014-09-21 04:57:21.037755895 +0400
+@@ -5763,7 +5763,7 @@
+             wrq->u.data.length = strlen(extra) + 1; /* 1: size of '\0' */
+             break;
+         case SHOW_DRVIER_VERION:
+-            snprintf(extra, size, "Driver version-%s, %s %s\n", STA_DRIVER_VERSION, __DATE__, __TIME__ );
++            //snprintf(extra, size, "Driver version-%s, %s %s\n", STA_DRIVER_VERSION, __DATE__, __TIME__ );
+             wrq->u.data.length = strlen(extra) + 1; /* 1: size of '\0' */
+             break;
+ #ifdef DOT11_N_SUPPORT

--- a/packages/linux-drivers/MT7601U/patches/MT7601U-002-rtmp_def.patch
+++ b/packages/linux-drivers/MT7601U/patches/MT7601U-002-rtmp_def.patch
@@ -1,0 +1,13 @@
+--- a/src/include/rtmp_def.h 2014-09-18 18:04:41.000000000 +0400
++++ b/src/include/rtmp_def.h 2014-09-21 05:45:32.977748765 +0400
+@@ -1601,8 +1601,8 @@
+ #define INF_MAIN_DEV_NAME		"wlan"
+ #define INF_MBSSID_DEV_NAME		"wlan"
+ #else
+-#define INF_MAIN_DEV_NAME		"ra"
+-#define INF_MBSSID_DEV_NAME		"ra"
++#define INF_MAIN_DEV_NAME		"wlan"
++#define INF_MBSSID_DEV_NAME		"wlan"
+ #endif /* ANDROID_SUPPORT */
+ #define INF_WDS_DEV_NAME		"wds"
+ #define INF_APCLI_DEV_NAME		"apcli"

--- a/packages/linux-drivers/MT7601U/patches/MT7601U-003-rt_drv.patch
+++ b/packages/linux-drivers/MT7601U/patches/MT7601U-003-rt_drv.patch
@@ -1,0 +1,11 @@
+--- a/src/include/os/rt_drv.h	2014-09-18 18:04:41.000000000 +0400
++++ b/src/include/os/rt_drv.h	2014-09-21 06:29:37.645742244 +0400
+@@ -56,7 +56,7 @@
+ #ifdef CONFIG_STA_SUPPORT
+ 
+ #ifdef RTMP_MAC_USB
+-#define STA_PROFILE_PATH			"/etc/Wireless/RT2870STA/RT2870STA.dat"
++#define STA_PROFILE_PATH			"/lib/firmware/MT7601USTA/MT7601USTA.dat"
+ #define STA_DRIVER_VERSION			"3.0.0.3"
+ #ifdef MULTIPLE_CARD_SUPPORT
+ #define CARD_INFO_PATH			"/etc/Wireless/RT2870STA/RT2870STACard.dat"

--- a/packages/linux-drivers/MT7601U/patches/MT7601U-004-rt_linux.patch
+++ b/packages/linux-drivers/MT7601U/patches/MT7601U-004-rt_linux.patch
@@ -1,0 +1,11 @@
+--- a/src/include/os/rt_linux.h	2014-09-18 18:04:41.000000000 +0400
++++ b/src/include/os/rt_linux.h	2014-09-21 06:27:26.741742567 +0400
+@@ -127,7 +127,7 @@
+ #ifdef CONFIG_STA_SUPPORT
+ 
+ #ifdef RTMP_MAC_USB
+-#define STA_PROFILE_PATH			"/etc/Wireless/RT2870STA/RT2870STA.dat"
++#define STA_PROFILE_PATH			"/lib/firmware/MT7601USTA/MT7601USTA.dat"
+ #define STA_DRIVER_VERSION			"3.0.0.3"
+ #ifdef MULTIPLE_CARD_SUPPORT
+ #define CARD_INFO_PATH			"/etc/Wireless/RT2870STA/RT2870STACard.dat"

--- a/projects/Generic/options
+++ b/projects/Generic/options
@@ -179,7 +179,7 @@
 # for a list of additinoal drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU RTL8812AU dvbhdhomerun"
+  ADDITIONAL_DRIVERS="MT7601U RTL8192CU RTL8192DU RTL8188EU RTL8812AU dvbhdhomerun"
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"

--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -180,7 +180,7 @@
 # for a list of additinoal drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU RTL8812AU dvbhdhomerun"
+  ADDITIONAL_DRIVERS="MT7601U RTL8192CU RTL8192DU RTL8188EU RTL8812AU dvbhdhomerun"
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"


### PR DESCRIPTION
This resolves #2524 and requests in the forums. It builds but I have no hardware to test with so do not merge unless there are some reports of success. nb: the MT7601USTA.dat file is not a true firmware (it’s a driver capabilities config file) but I figured /lib/firmware is tidier than the default /etc/Wireless location.