### PR TITLE
xbmc: make binary addons executable on ssh connection

### DIFF
--- a/packages/mediacenter/xbmc/profile.d/02-xbmc.conf
+++ b/packages/mediacenter/xbmc/profile.d/02-xbmc.conf
@@ -16,6 +16,9 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+# make addon-bins executable
+chmod +x /storage/.xbmc/addons/*/bin/*
+
 # PATH
 for addon in /storage/.xbmc/addons/*/bin /usr/lib/xbmc/addons/*/bin; do
   [ -d "$addon" ] && PATH="$PATH:$addon"


### PR DESCRIPTION
no need to restart the system to make addons executable
