### PR TITLE
linux: enable firmware loading from /storage/.config/firmware/

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -216,5 +216,7 @@ post_install() {
   mkdir -p $INSTALL/etc/modprobe.d
     cp $PKG_DIR/modprobe.d/*.conf $INSTALL/etc/modprobe.d
 
+  ln -sf /storage/.config/firmware/ $INSTALL/lib/firmware/updates
+
   enable_service cpufreq-threshold.service
 }


### PR DESCRIPTION
as the feature is gone in systemd now, I re-enable it for in-kernel firmware loader. details in commit description
tested on 3.17 but no reason to fail on 3.16 or older
