### PR TITLE
Make default sources accessible from remotes

### DIFF
--- a/packages/mediacenter/xbmc/scripts/xbmc-sources
+++ b/packages/mediacenter/xbmc/scripts/xbmc-sources
@@ -35,10 +35,12 @@
         <source>
             <name>Videos</name>
             <path pathversion="1">$HOME/videos/</path>
+            <allowsharing>true</allowsharing>
         </source>
         <source>
             <name>TV Shows</name>
             <path pathversion="1">$HOME/tvshows/</path>
+            <allowsharing>true</allowsharing>
         </source>
     </video>
     <music>
@@ -46,6 +48,7 @@
         <source>
             <name>Music</name>
             <path pathversion="1">$HOME/music/</path>
+            <allowsharing>true</allowsharing>
         </source>
     </music>
     <pictures>
@@ -53,6 +56,7 @@
         <source>
             <name>Pictures</name>
             <path pathversion="1">$HOME/pictures/</path>
+            <allowsharing>true</allowsharing>
         </source>
     </pictures>
   </sources>


### PR DESCRIPTION
Since Gotham there's a limitation on access to sources. It's by default true when added from the GUI but not from Openelec install script.
Leading users to no easy way to give access unless removing the sources and adding it back again starting a slow full scrape after.
