### PR TITLE
Tvheadend: update to 3.9.1838, enable hdhomerun

### DIFF
--- a/packages/addons/service/multimedia/tvheadend/changelog.txt
+++ b/packages/addons/service/multimedia/tvheadend/changelog.txt
@@ -1,3 +1,7 @@
+4.3.1
+- update to tvheadend-3.9.1838
+- tvheadend now has native support for hdhomerun devices
+
 4.3.0
 - rebuild for addon api bump
 - update to tvheadend-3.9.1083

--- a/packages/addons/service/multimedia/tvheadend/package.mk
+++ b/packages/addons/service/multimedia/tvheadend/package.mk
@@ -17,14 +17,14 @@
 ################################################################################
 
 PKG_NAME="tvheadend"
-PKG_VERSION="3.9.1083"
-PKG_REV="0"
+PKG_VERSION="3.9.1838"
+PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.lonelycoder.com/hts/tvheadend_overview.html"
 #PKG_URL="https://github.com/downloads/tvheadend/tvheadend/${PKG_NAME}-${PKG_VERSION}.tar.gz"
 PKG_URL="$DISTRO_SRC/${PKG_NAME}-${PKG_VERSION}.tar.gz"
-PKG_DEPENDS_TARGET="toolchain libressl curl"
+PKG_DEPENDS_TARGET="toolchain libressl curl libhdhomerun"
 PKG_PRIORITY="optional"
 PKG_SECTION="service/multimedia"
 PKG_SHORTDESC="tvheadend (Version: $PKG_VERSION): a TV streaming server for Linux supporting DVB-S, DVB-S2, DVB-C, DVB-T, ATSC, IPTV, and Analog video (V4L) as input sources."
@@ -48,7 +48,8 @@ configure_target() {
             --disable-avahi \
             --python=$ROOT/$TOOLCHAIN/bin/python \
             --disable-uriparser \
-            --enable-bundle
+            --enable-bundle \
+			--enable-hdhomerun_client
 }
 
 post_make_target() {

--- a/packages/multimedia/libhdhomerun/package.mk
+++ b/packages/multimedia/libhdhomerun/package.mk
@@ -42,3 +42,8 @@ makeinstall_target() {
   mkdir -p $INSTALL/usr/lib/
     cp -PR libhdhomerun.so $INSTALL/usr/lib/
 }
+post_make_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/include/libhdhomerun
+  cp hdhomerun*.h $SYSROOT_PREFIX/usr/include/libhdhomerun
+  cp libhdhomerun.so $SYSROOT_PREFIX/usr/lib
+}


### PR DESCRIPTION
Tvheadend now has native support for hdhomerun devices. To enable this,
libhdhomerun needs to be added to the toolchain and be used as a
dependency for tvheadend.
