### PR TITLE
bcm_sta: add patch for 3.17.x kernels

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/6.20.155.1/bcm_sta-013-add-support-for-Linux-3.17.patch
+++ b/packages/linux-drivers/bcm_sta/patches/6.20.155.1/bcm_sta-013-add-support-for-Linux-3.17.patch
@@ -1,0 +1,38 @@
+diff --git bcm_sta-6.20.155.1/x86-32/src/wl/sys/wl_linux.c bcm_sta-6.20.155.1/x86-32/src/wl/sys/wl_linux.c
+index 3a5e46b..6384e58 100644
+--- bcm_sta-6.20.155.1/x86-32/src/wl/sys/wl_linux.c
++++ bcm_sta-6.20.155.1/x86-32/src/wl/sys/wl_linux.c
+@@ -1351,7 +1351,12 @@
+ 	dev->priv = priv_link;
+ #else
+ 
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0))
+ 	dev = alloc_netdev(sizeof(priv_link_t), intf_name, ether_setup);
++#else
++	dev = alloc_netdev(sizeof(priv_link_t), intf_name, NET_NAME_UNKNOWN,
++			   ether_setup);
++#endif
+ 	if (!dev) {
+ 		WL_ERROR(("wl%d: %s: alloc_netdev failed\n",
+ 			(wl->pub)?wl->pub->unit:wlif->subunit, __FUNCTION__));
+diff --git bcm_sta-6.20.155.1/x86-64/src/wl/sys/wl_linux.c bcm_sta-6.20.155.1/x86-64/src/wl/sys/wl_linux.c
+index 3a5e46b..6384e58 100644
+--- bcm_sta-6.20.155.1/x86-64/src/wl/sys/wl_linux.c
++++ bcm_sta-6.20.155.1/x86-64/src/wl/sys/wl_linux.c
+@@ -1351,7 +1351,12 @@
+        dev->priv = priv_link;
+ #else
+
++#if (LINUX_VERSION_CODE < KERNEL_VERSION(3, 17, 0))
+        dev = alloc_netdev(sizeof(priv_link_t), intf_name, ether_setup);
++#else
++       dev = alloc_netdev(sizeof(priv_link_t), intf_name, NET_NAME_UNKNOWN,
++                          ether_setup);
++#endif
+        if (!dev) {
+                WL_ERROR(("wl%d: %s: alloc_netdev failed\n",
+                        (wl->pub)?wl->pub->unit:wlif->subunit, __FUNCTION__));
+
+-- 
+1.9.1
+


### PR DESCRIPTION
based on a user build-failure report in the forums but not tested as I am travelling; a patch is required to build the sta driver on 3.17.x kernels: https://bugs.launchpad.net/ubuntu/+source/bcmwl/+bug/1358966
