### PR TITLE
[uefi] enable 32bit uefi support

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -337,6 +337,8 @@ do_install_quick() {
         cp $TMPDIR/part1/syslinux.cfg $TMPDIR/part1/EFI/BOOT
         cp /usr/share/syslinux/bootx64.efi $TMPDIR/part1/EFI/BOOT
         cp /usr/share/syslinux/ldlinux.e64 $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/syslinux/bootx32.efi $TMPDIR/part1/EFI/BOOT
+        cp /usr/share/syslinux/ldlinux.e32 $TMPDIR/part1/EFI/BOOT
       fi
       sync
 

--- a/packages/tools/syslinux/package.mk
+++ b/packages/tools/syslinux/package.mk
@@ -81,6 +81,8 @@ makeinstall_host() {
     cp bios/mbr/gptmbr.bin $ROOT/$TOOLCHAIN/share/syslinux
     cp efi64/efi/syslinux.efi $ROOT/$TOOLCHAIN/share/syslinux/bootx64.efi
     cp efi64/com32/elflink/ldlinux/ldlinux.e64  $ROOT/$TOOLCHAIN/share/syslinux
+    cp efi32/efi/syslinux.efi $ROOT/$TOOLCHAIN/share/syslinux/bootx32.efi
+    cp efi32/com32/elflink/ldlinux/ldlinux.e32  $ROOT/$TOOLCHAIN/share/syslinux
 }
 
 makeinstall_target() {
@@ -96,4 +98,6 @@ makeinstall_target() {
     cp bios/mbr/gptmbr.bin $INSTALL/usr/share/syslinux
     cp efi64/efi/syslinux.efi $INSTALL/usr/share/syslinux/bootx64.efi
     cp efi64/com32/elflink/ldlinux/ldlinux.e64  $INSTALL/usr/share/syslinux
+    cp efi32/efi/syslinux.efi $INSTALL/usr/share/syslinux/bootx32.efi
+    cp efi32/com32/elflink/ldlinux/ldlinux.e32  $INSTALL/usr/share/syslinux
 }

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -204,6 +204,8 @@ EOF
       mkdir -p "$OE_TMP/EFI/BOOT"
       cp $ROOT/$TOOLCHAIN/share/syslinux/bootx64.efi "$OE_TMP/EFI/BOOT"
       cp $ROOT/$TOOLCHAIN/share/syslinux/ldlinux.e64 "$OE_TMP/EFI/BOOT"
+      cp $ROOT/$TOOLCHAIN/share/syslinux/bootx32.efi "$OE_TMP/EFI/BOOT"
+      cp $ROOT/$TOOLCHAIN/share/syslinux/ldlinux.e32 "$OE_TMP/EFI/BOOT"
       cat << EOF > "$OE_TMP"/EFI/BOOT/syslinux.cfg
 DEFAULT installer
 


### PR DESCRIPTION
we already have CONFIG_EFI_MIXED=y so kernel part should be fine
build passed. not runtime tested (no hardware here..)

thanks @klojum and @fritsch for pointing out that such broken (and argh released in late 2014) hardware exists.

ref http://liliputing.com/2014/10/run-ubuntu-zotac-zbox-pico-mini-pc-kinda.html

EDIT: this is also a potential fix for some intel boards that fail to boot in uefi mode (do some nucs require 32bit uefi bootloader?)
