### PR TITLE
[rfc] addons: allow building addons with type different than xbmc.python.scrip...

### DIFF
--- a/config/addon/xbmc.python.module.xml
+++ b/config/addon/xbmc.python.module.xml
@@ -8,8 +8,7 @@
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>
-  <extension point="@PKG_ADDON_TYPE@"
-             library="lib/">
+  <extension point="xbmc.python.module" library="lib/">
   </extension>
   <extension point="xbmc.addon.metadata">
     <summary>@PKG_SHORTDESC@</summary>

--- a/config/addon/xbmc.python.script.xml
+++ b/config/addon/xbmc.python.script.xml
@@ -8,9 +8,8 @@
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>
-  <extension point="@PKG_ADDON_TYPE@"
-             library="default.py">
-        <provides>executable</provides>
+  <extension point="xbmc.python.script" library="default.py">
+    <provides>executable</provides>
   </extension>
 @EXTENSIONS@
   <extension point="xbmc.addon.metadata">

--- a/config/addon/xbmc.service.xml
+++ b/config/addon/xbmc.service.xml
@@ -8,9 +8,8 @@
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>
-  <extension point="@PKG_ADDON_TYPE@"
-             library="default.py">
-        <provides>executable</provides>
+  <extension point="xbmc.service" library="default.py">
+    <provides>executable</provides>
   </extension>
 @EXTENSIONS@
   <extension point="xbmc.addon.metadata">

--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -81,7 +81,6 @@ if [ "$PKG_IS_ADDON" = "yes" ] ; then
     $SED -e "s|@PKG_ADDON_ID@|$PKG_ADDON_ID|g" \
          -e "s|@PKG_NAME@|$PKG_NAME|g" \
          -e "s|@ADDON_VERSION@|$CUST_ADDON_VERSION|g" \
-         -e "s|@PKG_ADDON_TYPE@|$PKG_ADDON_TYPE|g" \
          -e "s|@REQUIRES@|$REQUIRES|g" \
          -e "s|@PKG_SHORTDESC@|$PKG_SHORTDESC|g" \
          -e "s|@OS_VERSION@|$OS_VERSION|g" \


### PR DESCRIPTION
this will allow us to build not only 'xbmc.python.script' addons but also 'xbmc.python.module', or whatever is supported by kodi - just drop an "addon template" in config/addons if you want new type of addon..

I have tested already converting Cheetah package (in unofficial) to a module. a test addon that requires Cheetah works fine

```
openelec:~/.kodi/addons/test.test # cat addon.xml
<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
<addon id="test.test"
       name="test"
       version="4.3.2"
       provider-name="poof">
  <requires>
    <import addon="os.openelec.tv" version="5.0"/>
    <import addon="xbmc.python" version="2.1.0"/>
    <import addon="script.module.openelec.Cheetah" version="0.0.0"/>

  </requires>
  <extension point="xbmc.python.script"
             library="default.py">
        <provides>executable</provides>
  </extension>

  <extension point="xbmc.addon.metadata">
    <summary>test</summary>
    <description>test</description>
    <platform>all</platform>
  </extension>
</addon>
openelec:~/.kodi/addons/test.test # cat default.py
from Cheetah.Template import Template

templateDef = """$contents"""
nameSpace = {'contents': 'Hello World!'}
t = Template(templateDef, searchList=[nameSpace])
print t

openelec:~/.kodi/addons/test.test # ls ../script.module.openelec.Cheetah/
addon.xml  lib
openelec:~/.kodi/addons/test.test # ls ../script.module.openelec.Cheetah/lib/Cheetah/
CacheRegion.pyo                  Servlet.pyo
CacheStore.pyo                   SettingsManager.pyo
CheetahWrapper.pyo               SourceReader.pyo
.......
```

thoughts?
