### PR TITLE
[SDL2] add patch for missing axes

### DIFF
--- a/packages/multimedia/SDL2/patches/SDL2-0001-fix-missing-axes.patch
+++ b/packages/multimedia/SDL2/patches/SDL2-0001-fix-missing-axes.patch
@@ -1,0 +1,22 @@
+--- a/src/joystick/linux/SDL_sysjoystick.c	2014-03-16 03:31:41.000000000 +0100
++++ b/src/joystick/linux/SDL_sysjoystick.c	2014-09-08 01:42:32.987502340 +0200
+@@ -500,7 +500,7 @@
+                 ++joystick->nbuttons;
+             }
+         }
+-        for (i = 0; i < ABS_MISC; ++i) {
++        for (i = 0; i < ABS_MAX; ++i) {
+             /* Skip hats */
+             if (i == ABS_HAT0X) {
+                 i = ABS_HAT3Y;
+@@ -761,10 +761,6 @@
+                 }
+                 break;
+             case EV_ABS:
+-                if (code >= ABS_MISC) {
+-                    break;
+-                }
+-
+                 switch (code) {
+                 case ABS_HAT0X:
+                 case ABS_HAT0Y:


### PR DESCRIPTION
Adds a patch that fixes a lot of buttons/triggers not showing up as SDL joystick axes. Most notably useful for PS3 and PS4 controllers.
