### PR TITLE
[build] Do not strip shared libs if devtools shall be installed.

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -339,7 +339,7 @@ if [ ! -f $STAMP ]; then
 
           find $INSTALL -type d -exec rmdir -p "{}" ";" 2>/dev/null || true
 
-          if [ ! "$DEBUG" = yes ]; then
+          if [ ! "$DEVTOOLS" = yes ]; then
             $STRIP `find $INSTALL -name "*.so" 2>/dev/null` 2>/dev/null || :
             $STRIP `find $INSTALL -name "*.so.[0-9]*" 2>/dev/null` 2>/dev/null || :
           fi


### PR DESCRIPTION
Stripping has some bad side effects for dev tools. For example, stripping libpthread.so.0 (and libthread_db.so.1 ?) breaks gdb's ability to debug  threads.

GDB output (with "set debug libthread-db 1"):

Trying host libthread_db library: libthread_db.so.1.
Host libthread_db.so.1 resolved to: /lib/libthread_db.so.1.
td_ta_new failed: application not linked with libthread
Trying host libthread_db library: /lib/libthread_db.so.1.
td_ta_new failed: application not linked with libthread
thread_db_load_search returning 0
warning: Unable to find libthread_db matching inferior's thread library, thread debugging will not be available.
