### PR TITLE
xf86-video-intel: Downgrade to version 910

### DIFF
--- a/packages/x11/driver/xf86-video-intel/package.mk
+++ b/packages/x11/driver/xf86-video-intel/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xf86-video-intel"
-PKG_VERSION="2.99.916"
+PKG_VERSION="2.99.910"
 PKG_REV="1"
 PKG_ARCH="i386 x86_64"
 PKG_LICENSE="OSS"
@@ -46,7 +46,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-backlight \
                            --enable-sna \
                            --enable-uxa \
                            --disable-xvmc \
-                           --enable-glamor \
+                           --disable-glamor \
                            --disable-xaa \
                            --disable-dga \
                            --disable-tear-free \


### PR DESCRIPTION
This makes menus going fluent again. 911+ and later have a problem with syncing correctly to the display.

Verified by @mkortstiege while scrolling the menus. 916 would hang now and then.
