### PR TITLE
ffmpeg: double --disable-small

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -56,7 +56,7 @@ else
 fi
 
 if [ "$OPTIMIZATIONS" = size ]; then
-  FFMPEG_OPTIM="--disable-small"
+  FFMPEG_OPTIM="--enable-small"
 else
   FFMPEG_OPTIM="--disable-small"
 fi


### PR DESCRIPTION
should be enable-small or if not in use maybe removed :)?
