### PR TITLE
xf86-video-nvidia*: add nvidia-xconfig

### DIFF
--- a/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
@@ -73,6 +73,7 @@ makeinstall_target() {
 
   mkdir -p $INSTALL/usr/bin
     cp nvidia-smi $INSTALL/usr/bin
+    cp nvidia-xconfig $INSTALL/usr/bin
 
   mkdir -p $INSTALL/usr/lib/vdpau
     cp libvdpau_nvidia.so* $INSTALL/usr/lib/vdpau/libvdpau_nvidia.so.1

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -73,6 +73,7 @@ makeinstall_target() {
 
   mkdir -p $INSTALL/usr/bin
     cp nvidia-smi $INSTALL/usr/bin
+    cp nvidia-xconfig $INSTALL/usr/bin
 
   mkdir -p $INSTALL/usr/lib/vdpau
     cp libvdpau_nvidia.so* $INSTALL/usr/lib/vdpau/libvdpau_nvidia.so.1


### PR DESCRIPTION
useful for creating edid.bin files from nvidia debug logs, adds only 165k to the image
