### PR TITLE
Tweaks for setting make's -j option 

### DIFF
--- a/config/options
+++ b/config/options
@@ -66,7 +66,10 @@ LINUX_DEPENDS="$PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf $ROOT/package
 #  Try value 1 (default) to 4 on single CPU computer, or more on
 #  multi-processor computer (like hyperthreading SMP CPU)
   if test -z "${CONCURRENCY_MAKE_LEVEL}"; then
-    CONCURRENCY_MAKE_LEVEL=`cat /proc/cpuinfo | grep -c '^processor[[:cntrl:]]*:'`
+    if test -z "${CONCURRENCY_MAKE_FACTOR}"; then
+      CONCURRENCY_MAKE_FACTOR=1.0
+    fi
+    CONCURRENCY_MAKE_LEVEL=`echo "$(grep -c '^processor[[:cntrl:]]*:' /proc/cpuinfo) * ${CONCURRENCY_MAKE_FACTOR}" | bc | cut -d'.' -f1`
   fi
 
 # cache size for ccache


### PR DESCRIPTION
1) Allow -j to be directly set by developer without modifying versioned files
2) Introduce a "factor" variable to the automatic -j calculation.  It is multiplied by the number of detected CPUs.
