### PR TITLE
imx6: Add coherent_pool=1M to boot options - fixes some dvb cards

### DIFF
--- a/projects/imx6/bootloader/uEnv.txt
+++ b/projects/imx6/bootloader/uEnv.txt
@@ -1,3 +1,3 @@
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3'
+mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 coherent_pool=1M'


### PR DESCRIPTION
This fixes some DVB devices, by increasing the dma pool for atomic dma operations. It seems some firmware of DVB devices forces that.

Btw. the uEnv.txt forces the video to 1920x1080@60 - do we have reports of users that don't have a picture at bootup?
