### PR TITLE
imx6: increase coherent pool to 1M

### DIFF
--- a/projects/imx6/bootloader/uEnv.txt
+++ b/projects/imx6/bootloader/uEnv.txt
@@ -1,3 +1,3 @@
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3'
+mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=32 dmfc=3 coherent_pool=1M'


### PR DESCRIPTION
this allows some dvb sticks (at least dvb_usb_it913x) to load
their firmware

[    5.240055] ERROR: 256 KiB atomic DMA coherent pool is too small!
[    5.240055] Please increase it with coherent_pool= kernel parameter!
[    5.241779] dvb_usb_it913x: probe of 1-1:1.0 failed with error -12
