### PR TITLE
[rfc] init: warn on obvious KERNEL/SYSTEM mismatch

### DIFF
--- a/packages/sysutils/busybox/config/busybox-init.conf
+++ b/packages/sysutils/busybox/config/busybox-init.conf
@@ -1,7 +1,7 @@
 #
 # Automatically generated make config: don't edit
 # Busybox version: 1.22.1
-# Thu Apr 24 17:06:16 2014
+# Sun Nov 23 18:41:18 2014
 #
 CONFIG_HAVE_DOT_CONFIG=y
 
@@ -286,7 +286,7 @@ CONFIG_FEATURE_FANCY_TAIL=y
 # CONFIG_FEATURE_TEE_USE_BLOCK_IO is not set
 # CONFIG_TRUE is not set
 # CONFIG_TTY is not set
-# CONFIG_UNAME is not set
+CONFIG_UNAME=y
 # CONFIG_UNEXPAND is not set
 # CONFIG_FEATURE_UNEXPAND_LONG_OPTIONS is not set
 # CONFIG_UNIQ is not set

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -599,6 +599,18 @@
       mount --move /storage /sysroot/storage
     fi
 
+    if [ ! -d "/sysroot/lib/modules/$(uname -r)/" -a -f "/sysroot/usr/lib/systemd/systemd" ]; then
+      echo ""
+      echo "NEVER TOUCH boot= in extlinux.conf / cmdline.txt"
+      echo "if you dont know what you are doing"
+      echo ""
+      echo "your installation is now broken"
+      echo ""
+      echo "normal boot in 60s..."
+      usleep 60000000
+    fi
+
+
     [ -f "/sysroot/usr/lib/systemd/systemd" ] || error "final_check" "Could not find system."
   }
 


### PR DESCRIPTION
... because rpi / netboot users still cant get it

and I am tired of reports like [this](http://openelec.tv/forum/71-pvr-live-tv/73856-tvheadend-unreachable#123133) and to explain it [again](http://openelec.tv/forum/71-pvr-live-tv/73856-tvheadend-unreachable#123144) and [again](http://openelec.tv/forum/124-raspberry-pi/46413-howto-install-openelec-on-raspberry-pi-on-a-tiny-sd-and-a-1gb-usb-drive?start=15#123141) (and countless of times so far in irc)

quick and ditry. needs runtime testing. I am not going to. and arguments like "we want evenmoresilent boot" are invalid, so please dont.
