### PR TITLE
Add a package to support proprietary Mali-400MP OpenGL ES drivers found in Amlogic Meson6 SoCs

### DIFF
--- a/packages/graphics/opengl-meson6/package.mk
+++ b/packages/graphics/opengl-meson6/package.mk
@@ -1,0 +1,52 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2014 Alex Deryskyba (alex@codesnake.com)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="opengl-meson6"
+PKG_VERSION="r4p0-01-armhf"
+PKG_REV="1"
+PKG_ARCH="arm"
+PKG_LICENSE="nonfree"
+PKG_SITE="http://openlinux.amlogic.com:8000/download/ARM/filesystem/"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain"
+PKG_PRIORITY="optional"
+PKG_SECTION="graphics"
+PKG_SHORTDESC="opengl-meson6: OpenGL ES pre-compiled libraries for Mali 400 GPUs found in Amlogic Meson6 SoCs"
+PKG_LONGDESC="opengl-meson6: OpenGL ES pre-compiled libraries for Mali 400 GPUs found in Amlogic Meson6 SoCs. The libraries could be found in a Linux buildroot released by Amlogic at http://openlinux.amlogic.com:8000/download/ARM/filesystem/. See the opengl package."
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+make_target() {
+ : # nothing todo
+}
+
+makeinstall_target() {
+  mkdir -p $SYSROOT_PREFIX/usr/include
+    cp -PR usr/include/* $SYSROOT_PREFIX/usr/include
+
+  mkdir -p $SYSROOT_PREFIX/usr/lib
+    cp -PR usr/lib/*.so* $SYSROOT_PREFIX/usr/lib
+
+  mkdir -p $INSTALL/usr/lib
+    cp -PR usr/lib/*.so* $INSTALL/usr/lib
+}
+
+post_install() {
+  enable_service unbind-console.service
+}

--- a/packages/graphics/opengl-meson6/system.d/unbind-console.service
+++ b/packages/graphics/opengl-meson6/system.d/unbind-console.service
@@ -1,0 +1,11 @@
+[Unit]
+Description=Unbind framebuffer console
+
+ConditionPathExists=/sys/class/vtconsole/vtcon1/bind
+
+[Service]
+Type=oneshot
+ExecStart=/bin/sh -c 'echo 0 > /sys/class/vtconsole/vtcon1/bind'
+
+[Install]
+WantedBy=graphical.target


### PR DESCRIPTION
Add the opengl-meson6 package that is required to support the devices based on Amlogic Meson6 SoC.
