### PR TITLE
kodi: revert upstream commit b6bec7a

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.02-revert-b6bec7a.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.02-revert-b6bec7a.patch
@@ -1,0 +1,35 @@
+From d4d83054ad9096c31d3c91bcbbf1919de1aa76f0 Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sun, 29 Jun 2014 22:59:00 +0300
+Subject: [PATCH] revert b6bec7a
+
+this reverts upstream commit b6bec7a (part of xbmc/pull/4761):
+
+> From b6bec7a44fec728c28aa0cedc96288539a71e324 Mon Sep 17 00:00:00 2001
+> From: Trent Nelson <trent.nelson@pivosgroup.com>
+> Date: Wed, 21 May 2014 17:16:54 +0800
+> Subject: [PATCH] [PVR] Make sure client addons are disabled first time we see
+>  them.
+
+pvr client addons should NOT be disabled after pvr database reset
+---
+ xbmc/pvr/addons/PVRClients.cpp | 3 +--
+ 1 file changed, 1 insertion(+), 2 deletions(-)
+
+diff --git a/xbmc/pvr/addons/PVRClients.cpp b/xbmc/pvr/addons/PVRClients.cpp
+index b403fd6..809c244 100644
+--- a/xbmc/pvr/addons/PVRClients.cpp
++++ b/xbmc/pvr/addons/PVRClients.cpp
+@@ -1126,8 +1126,7 @@ bool CPVRClients::UpdateAddons(void)
+   for (unsigned iClientPtr = 0; iClientPtr < m_addons.size(); iClientPtr++)
+   {
+     const AddonPtr clientAddon = m_addons.at(iClientPtr);
+-    bool newRegistration = false;
+-    if (RegisterClient(clientAddon, &newRegistration) < 0 || newRegistration)
++    if (RegisterClient(clientAddon) < 0)
+     {
+       CAddonMgr::Get().DisableAddon(clientAddon->ID(), true);
+       usableClients--;
+-- 
+1.9.1
+


### PR DESCRIPTION
this fixes a long standing bug with "reset pvr database" where
all pvr client addons are disabled and user must re-enable manualy

as it wont be fixed upstream before kodi final release, I am PRing it here for OE

beware, this re-introduces a very old bug. newly added PVR addons are ENABLED by default.. I cannot fix the old bug, but I still care for new regressions.

ref: https://github.com/xbmc/xbmc/pull/4761#issuecomment-52103319

if you agree to merge. I will take care to remove this patch as soon the bug is fixed upstream in I***
if not, it's fine. not too much big deal, but bug reports started to appear on kodi trac. soon or later those will start to appear here too. feel free to redirect reporters to this PR.

//cc @fritsch what you think?
