### PR TITLE
[rbp] Update create_sdcard script so that it creates a 256MiB system partition

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/create_sdcard
+++ b/packages/tools/bcm2835-bootloader/files/create_sdcard
@@ -195,10 +195,10 @@ echo "#########################################################"
 
 # create a single partition
   echo "creating partitions on $DISK..."
-  parted -s "$DISK" unit cyl mkpart primary fat32 -- 0 16
-# align the partition on 4mb boundary, starting at 132mb (132 % 4 == 0), which
+  parted -s "$DISK" mkpart primary fat32 -- 0 256MiB 
+# align the partition on 4mb boundary, starting at 260mb (260 % 4 == 0), which
 # is right after the first partition
-  parted -s "$DISK" mkpart primary ext2 -- 132MiB -2cyl
+  parted -s "$DISK" mkpart primary ext2 -- 260MiB -2cyl
 
 # make partition active (bootable)
   echo "marking partition active..."


### PR DESCRIPTION
In addition to increasing the partition sizes, I've used consistent MiB units when creating both partitions - I think it is confusing to use cyclinders when creating the FAT partition, then switch to MiB while creating the ext4 partition.

Before (partitions created with existing create_sdcard):

```
Model: UDISK PDU09_8G AAI2.0 (scsi)
Disk /dev/sdd: 7702MiB
Sector size (logical/physical): 512B/512B
Partition Table: msdos

Number  Start    End      Size     Type     File system  Flags
 1      1.00MiB  126MiB   125MiB   primary  fat16        boot, lba
 2      132MiB   7686MiB  7554MiB  primary  ext4
```

After (partitions created with updated create_sdcard):

```
Model: UDISK PDU09_8G AAI2.0 (scsi)
Disk /dev/sdd: 7702MiB
Sector size (logical/physical): 512B/512B
Partition Table: msdos

Number  Start    End      Size     Type     File system  Flags
 1      0.00MiB  256MiB   256MiB   primary  fat16        boot, lba
 2      260MiB   7686MiB  7426MiB  primary  ext4
```
