### PR TITLE
kodi: setup default skin

### DIFF
--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -398,6 +398,7 @@ make_target() {
 
 # setup default skin inside the sources
   sed -i -e "s|skin.confluence|$SKIN_DIR|g" $ROOT/$PKG_BUILD/xbmc/settings/Settings.h
+  sed -i -e "s|skin.confluence|$SKIN_DIR|g" $ROOT/$PKG_BUILD/system/settings/settings.xml
 
   make externals
   make kodi.bin


### PR DESCRIPTION
Default skin must be also set in settings.xml file. Not an issue for Confluence only if some other skin is set at build time.
