### PR TITLE
Linux: Port fixes for gpu hang to 3.17

### DIFF
--- a/packages/linux/patches/linux-010-intel-flush-flags.patch
+++ b/packages/linux/patches/linux-010-intel-flush-flags.patch
@@ -1,0 +1,32 @@
+From aae8d9091ebefbb30c4e05f2c7d7c54c53a710e1 Mon Sep 17 00:00:00 2001
+From: root <root@localhost.localdomain>
+Date: Wed, 10 Dec 2014 13:46:30 +0000
+Subject: [PATCH 1/2] flush-flags
+
+---
+ drivers/gpu/drm/i915/intel_ringbuffer.c | 3 +++
+ 1 file changed, 3 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/intel_ringbuffer.c b/drivers/gpu/drm/i915/intel_ringbuffer.c
+index 47a126a..fec60de 100644
+--- a/drivers/gpu/drm/i915/intel_ringbuffer.c
++++ b/drivers/gpu/drm/i915/intel_ringbuffer.c
+@@ -351,12 +351,15 @@ gen7_render_ring_flush(struct intel_engine_cs *ring,
+ 		flags |= PIPE_CONTROL_VF_CACHE_INVALIDATE;
+ 		flags |= PIPE_CONTROL_CONST_CACHE_INVALIDATE;
+ 		flags |= PIPE_CONTROL_STATE_CACHE_INVALIDATE;
++		flags |= 1 << 16;
+ 		/*
+ 		 * TLB invalidate requires a post-sync write.
+ 		 */
+ 		flags |= PIPE_CONTROL_QW_WRITE;
+ 		flags |= PIPE_CONTROL_GLOBAL_GTT_IVB;
+ 
++		flags |= PIPE_CONTROL_STALL_AT_SCOREBOARD;
++
+ 		/* Workaround: we must issue a pipe_control with CS-stall bit
+ 		 * set before a pipe_control command that has the state cache
+ 		 * invalidate bit set. */
+-- 
+1.9.1
+

--- a/packages/linux/patches/linux-011-intel-pmsi-ctl-around-ctx.patch
+++ b/packages/linux/patches/linux-011-intel-pmsi-ctl-around-ctx.patch
@@ -1,0 +1,88 @@
+From 21feaa695380e86bc8e3301038374a3a65c05540 Mon Sep 17 00:00:00 2001
+From: root <root@localhost.localdomain>
+Date: Wed, 10 Dec 2014 13:47:00 +0000
+Subject: [PATCH 2/2] pmsi-ctl-around-ctx
+
+Conflicts:
+	drivers/gpu/drm/i915/i915_gem_context.c
+---
+ drivers/gpu/drm/i915/i915_gem_context.c | 25 +++++++++++++++++++++++--
+ drivers/gpu/drm/i915/i915_reg.h         |  2 ++
+ 2 files changed, 25 insertions(+), 2 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_gem_context.c b/drivers/gpu/drm/i915/i915_gem_context.c
+index 3b99390..9567ba6 100644
+--- a/drivers/gpu/drm/i915/i915_gem_context.c
++++ b/drivers/gpu/drm/i915/i915_gem_context.c
+@@ -563,7 +563,10 @@ mi_set_context(struct intel_engine_cs *ring,
+ 	       struct intel_context *new_context,
+ 	       u32 hw_flags)
+ {
+-	int ret;
++	u32 flags = hw_flags | MI_MM_SPACE_GTT;
++	struct intel_engine_cs *engine;
++	int num_rings;
++	int ret, i;
+ 
+ 	/* w/a: If Flush TLB Invalidation Mode is enabled, driver must do a TLB
+ 	 * invalidation prior to MI_SET_CONTEXT. On GEN6 we don't set the value
+@@ -576,10 +579,22 @@ mi_set_context(struct intel_engine_cs *ring,
+ 			return ret;
+ 	}
+ 
+-	ret = intel_ring_begin(ring, 6);
++	/* These flags are for resource streamer on HSW+ */
++	if (!IS_HASWELL(ring->dev) && INTEL_INFO(ring->dev)->gen < 8)
++		flags |= (MI_SAVE_EXT_STATE_EN | MI_RESTORE_EXT_STATE_EN);
++
++	num_rings = hweight32(INTEL_INFO(ring->dev)->ring_mask);
++
++	ret = intel_ring_begin(ring, 6 + 2*(num_rings*2 + 1));
+ 	if (ret)
+ 		return ret;
+ 
++	intel_ring_emit(ring, MI_LOAD_REGISTER_IMM(num_rings));
++	for_each_ring(engine, to_i915(ring->dev), i) {
++		intel_ring_emit(ring, RING_PSMI_CTL(engine->mmio_base));
++		intel_ring_emit(ring, _MASKED_BIT_ENABLE(GEN6_PSMI_SLEEP_MSG_DISABLE));
++	}
++
+ 	/* WaProgramMiArbOnOffAroundMiSetContext:ivb,vlv,hsw,bdw,chv */
+ 	if (INTEL_INFO(ring->dev)->gen >= 7)
+ 		intel_ring_emit(ring, MI_ARB_ON_OFF | MI_ARB_DISABLE);
+@@ -604,6 +619,12 @@ mi_set_context(struct intel_engine_cs *ring,
+ 	else
+ 		intel_ring_emit(ring, MI_NOOP);
+ 
++	intel_ring_emit(ring, MI_LOAD_REGISTER_IMM(num_rings));
++	for_each_ring(engine, to_i915(ring->dev), i) {
++		intel_ring_emit(ring, RING_PSMI_CTL(engine->mmio_base));
++		intel_ring_emit(ring, _MASKED_BIT_DISABLE(GEN6_PSMI_SLEEP_MSG_DISABLE));
++	}
++
+ 	intel_ring_advance(ring);
+ 
+ 	return ret;
+diff --git a/drivers/gpu/drm/i915/i915_reg.h b/drivers/gpu/drm/i915/i915_reg.h
+index f29b44c..df02a15 100644
+--- a/drivers/gpu/drm/i915/i915_reg.h
++++ b/drivers/gpu/drm/i915/i915_reg.h
+@@ -1029,6 +1029,7 @@ enum punit_power_well {
+ #define GEN6_VERSYNC	(RING_SYNC_1(VEBOX_RING_BASE))
+ #define GEN6_VEVSYNC	(RING_SYNC_2(VEBOX_RING_BASE))
+ #define GEN6_NOSYNC 0
++#define RING_PSMI_CTL(base)	((base)+0x50)
+ #define RING_MAX_IDLE(base)	((base)+0x54)
+ #define RING_HWS_PGA(base)	((base)+0x80)
+ #define RING_HWS_PGA_GEN6(base)	((base)+0x2080)
+@@ -1354,6 +1355,7 @@ enum punit_power_well {
+ #define   GEN6_BLITTER_FBC_NOTIFY			(1<<3)
+ 
+ #define GEN6_RC_SLEEP_PSMI_CONTROL	0x2050
++#define   GEN6_PSMI_SLEEP_MSG_DISABLE	(1 << 0)
+ #define   GEN8_RC_SEMA_IDLE_MSG_DISABLE	(1 << 12)
+ #define   GEN8_FF_DOP_CLOCK_GATE_DISABLE	(1<<10)
+ 
+-- 
+1.9.1
+


### PR DESCRIPTION
Those fixed were done by chris wilson here: https://bugs.freedesktop.org/show_bug.cgi?id=83677

This port does not pick the ringbuffer changes as they are not needed according to chris.

This PR needs testing, especially from the chromebox guys. If testing works, it should go into OE5
