### PR TITLE
Fix a "No such file or directory" error when $BOOTLOADER = "u-boot"

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -180,7 +180,7 @@ makeinstall_target() {
   if [ "$BOOTLOADER" = "u-boot" ]; then
     mkdir -p $INSTALL/usr/share/bootloader
     for dtb in arch/arm/boot/dts/*.dtb; do
-      cp $dtb $INSTALL/usr/share/bootloader
+      cp $dtb $INSTALL/usr/share/bootloader 2>/dev/null || :
     done
   fi
 

--- a/packages/tools/u-boot/release
+++ b/packages/tools/u-boot/release
@@ -44,7 +44,7 @@ mkdir -p $RELEASE_DIR/3rdparty/bootloader
   fi
 
   for dtb in $BUILD/linux-*/arch/arm/boot/dts/*.dtb; do
-    cp -PR $dtb $RELEASE_DIR/3rdparty/bootloader
+    cp -PR $dtb $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
   done
 
   if [ -f "$PROJECT_DIR/$PROJECT/bootloader/uEnv.txt" ]; then


### PR DESCRIPTION
Fix a "No such file or directory" error when $BOOTLOADER = "u-boot" and there are no arch/arm/boot/dts/*.dtb files in Linux kernel build directory
