### PR TITLE
Add support for executing project-specific initialization script from the init script

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -237,6 +237,11 @@ makeinstall_init() {
     touch $INSTALL/etc/fstab
     ln -sf /proc/self/mounts $INSTALL/etc/mtab
 
+  if [ -f $PROJECT_DIR/$PROJECT/initramfs/platform_init ]; then
+    cp $PROJECT_DIR/$PROJECT/initramfs/platform_init $INSTALL
+    chmod 755 $INSTALL/platform_init
+  fi
+
   cp $PKG_DIR/scripts/init $INSTALL
   chmod 755 $INSTALL/init
 }

--- a/packages/sysutils/busybox/scripts/init
+++ b/packages/sysutils/busybox/scripts/init
@@ -58,6 +58,11 @@
   # hide kernel log messages on console
   echo '1 4 1 7' > /proc/sys/kernel/printk
 
+  # run platform_init script if exists
+  if [ -f "./platform_init" ]; then
+    ./platform_init
+  fi
+
   # clear screen and hide cursor
   clear
   echo 0 > /sys/devices/virtual/graphics/fbcon/cursor_blink


### PR DESCRIPTION
Some platforms/projects require specific initialization that cannot be placed into main init script. This pull request makes possible to run the platform_init script if it will be found alongside the init script.
The platform_init script can be added at the project level.
