### PR TITLE
added possibility to save fetched file into different name

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -100,6 +100,16 @@ tolower(){
   echo "$@" | tr ABCDEFGHIJKLMNOPQRSTUVWXYZ abcdefghijklmnopqrstuvwxyz
 }
 
+url_toname() {
+    if [ "${1##*|}" == "$1" ]; then
+        # return "basename $1" if there is no pipe char
+        echo ${1##*/}
+    else
+        # return the name after pipe char otherwise
+        echo ${1##*|}
+    fi
+}
+
 require_eglibc() {
   if [ "$TARGET_LIBC" != eglibc ]; then
     echo "$1 requires eglibc, aborting."

--- a/scripts/extract
+++ b/scripts/extract
@@ -29,7 +29,7 @@ fi
 [ ! -d "$SOURCES/$1" -o ! -d "$3" ] && exit 1
 
 for i in $PKG_URL; do
-  FILE="`basename $i`"
+  FILE=$(url_toname $i)
 
   case $FILE in
   $2)

--- a/scripts/get
+++ b/scripts/get
@@ -29,11 +29,13 @@ fi
 
 if [ -n "$PKG_URL" ]; then
   for i in $PKG_URL; do
-    SOURCE_NAME="`basename $i`"
+    SOURCE_NAME=$(url_toname $i)
+    URL=${i%%|*}
+
     PACKAGE="$SOURCES/$1/$SOURCE_NAME"
     PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
     [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1"
+    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -O ${PACKAGE} -P $SOURCES/$1"
 
     NBWGET="1"
 
@@ -54,7 +56,7 @@ if [ -n "$PKG_URL" ]; then
     printf "%${BUILD_INDENT}c ${boldcyan}GET${endcolor}      $1\n" ' '>&$SILENT_OUT
     export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
-    until [ -f "$STAMP" ] || $WGET_CMD $i || $WGET_CMD $PACKAGE_MIRROR; do
+    until [ -f "$STAMP" ] || $WGET_CMD $URL || $WGET_CMD $PACKAGE_MIRROR; do
       NBWGET=$(($NBWGET+1))
       if [ "$NBWGET" -gt "10" ]; then
         echo -e "\nCant't get $1 sources : $i\n Try later !!"


### PR DESCRIPTION
Sometimes when you're getting the file from the website the filename doesn't match the PKG_NAME schema, this patch allows you to add the correct filename in the PKG_URL after the pipe char.

Without pipe char delimiter fetching works like before.

E.g.:
Setting: `PKG_URL="http://some.url/and/path/to/file|${PKG_NAME}-${PKG_VERSION}.tar.gz"`

Will save the contents of the `http://some.url/and/path/to/file` to file named `${PKG_NAME}-${PKG_VERSION}.tar.gz"`
