### PR TITLE
linux: Build $KERNEL_UBOOT_EXTRA_TARGET before kernel image

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -140,13 +140,13 @@ make_target() {
     $SCRIPTS/install initramfs
   )
 
-  LDFLAGS="" make $KERNEL_IMAGE $KERNEL_MAKE_EXTRACMD
-
   if [ "$BOOTLOADER" = "u-boot" -a -n "$KERNEL_UBOOT_EXTRA_TARGET" ]; then
     for extra_target in "$KERNEL_UBOOT_EXTRA_TARGET"; do
       LDFLAGS="" make $extra_target
     done
   fi
+
+  LDFLAGS="" make $KERNEL_IMAGE $KERNEL_MAKE_EXTRACMD
 
   if [ "$PERF_SUPPORT" = "yes" -a "$DEVTOOLS" = "yes" ]; then
     ( cd tools/perf


### PR DESCRIPTION
When there is a need to build the kernel with appended device tree for compatibility with older bootloaders,
$KERNEL_UBOOT_EXTRA_TARGET, which usually is a list of device tree source files, needs to be built
before the kernel, making device tree binaries available for appending to the kernel image.
