### PR TITLE
imx6: fixup reboot

### DIFF
--- a/projects/imx6/patches/kodi/kodi-999.95-iMX6-powermanager.patch
+++ b/projects/imx6/patches/kodi/kodi-999.95-iMX6-powermanager.patch
@@ -1,12 +1,13 @@
-From fa31c513986f8429f8e8e4b1ca39455769cd0a1c Mon Sep 17 00:00:00 2001
+From fc4ab34876077a012c4d0749b872703f46546255 Mon Sep 17 00:00:00 2001
 From: fritsch <peter.fruehberger@gmail.com>
 Date: Sat, 13 Dec 2014 18:36:00 +0100
-Subject: [PATCH] IMX: PowerManager - do nothing besides rebooting
+Subject: [PATCH] IMX: PowerManager - do nothing besides rebooting (wrap
+ Login1)
 
 ---
- xbmc/powermanagement/PowerManager.cpp         |  4 +++
- xbmc/powermanagement/linux/CIMXPowerSyscall.h | 40 +++++++++++++++++++++++++++
- 2 files changed, 44 insertions(+)
+ xbmc/powermanagement/PowerManager.cpp         |  4 ++
+ xbmc/powermanagement/linux/CIMXPowerSyscall.h | 70 +++++++++++++++++++++++++++
+ 2 files changed, 74 insertions(+)
  create mode 100644 xbmc/powermanagement/linux/CIMXPowerSyscall.h
 
 diff --git a/xbmc/powermanagement/PowerManager.cpp b/xbmc/powermanagement/PowerManager.cpp
@@ -33,10 +34,10 @@ index 5900f98..f669894 100644
    if (CConsoleUPowerSyscall::HasConsoleKitAndUPower())
 diff --git a/xbmc/powermanagement/linux/CIMXPowerSyscall.h b/xbmc/powermanagement/linux/CIMXPowerSyscall.h
 new file mode 100644
-index 0000000..27e644e
+index 0000000..2bf428e
 --- /dev/null
 +++ b/xbmc/powermanagement/linux/CIMXPowerSyscall.h
-@@ -0,0 +1,40 @@
+@@ -0,0 +1,70 @@
 +/*
 + *      Copyright (C) 2005-2013 Team XBMC
 + *      http://xbmc.org
@@ -60,22 +61,50 @@ index 0000000..27e644e
 +#pragma once
 +#include "powermanagement/IPowerSyscall.h"
 +#include "system.h"
-+#if defined(TARGET_POSIX)
++#if defined(TARGET_POSIX) && defined(HAS_DBUS)
++#include "powermanagement/linux/LogindUPowerSyscall.h"
++#endif
 +
 +class CIMXPowerSyscall : public CPowerSyscallWithoutEvents
 +{
 +public:
++  CIMXPowerSyscall()
++  {
++      m_instance = NULL;
++      #if defined(TARGET_POSIX) && defined(HAS_DBUS)
++      if (CLogindUPowerSyscall::HasLogind())
++      {
++        m_instance = new CLogindUPowerSyscall();
++      }
++      #endif
++  }
++  ~CIMXPowerSyscall()
++  {
++    delete m_instance;
++  }
 +  virtual bool Powerdown() {return false; }
 +  virtual bool Suspend() {return false; }
 +  virtual bool Hibernate() {return false; }
-+  virtual bool Reboot() {return true; }
++  virtual bool Reboot()
++  {
++    if (m_instance)
++      return m_instance->Reboot();
++    else
++      return false;
++  }
 +
 +  virtual bool CanPowerdown() {return false; }
 +  virtual bool CanSuspend() {return false; }
-+  virtual bool CanHibernate() {return false; }
-+  virtual bool CanReboot() {return true; }
-+  virtual int  BatteryLevel() {return 0; }
++  virtual bool CanHibernate() {return false;}
++  virtual bool CanReboot()
++  {
++   if (m_instance)
++     return m_instance->CanReboot();
++   else
++     return false;
++  }
++  virtual int BatteryLevel() {return 0; }
++
++private:
++  IPowerSyscall * m_instance;
 +};
-+#endif
--- 
-1.9.1


### PR DESCRIPTION
A more sane follow up of the older patch you picked.

Btw. shutdown is not possible, but it at least syncs the fs and stops some apps. Therefore I think I would drop that change entirely?
