### PR TITLE
IMX: Disable deinterlace by default (user can enable it manually)

### DIFF
--- a/projects/imx6/patches/kodi/kodi-999.96-iMX6-disable-deinterlace-by-default.patch
+++ b/projects/imx6/patches/kodi/kodi-999.96-iMX6-disable-deinterlace-by-default.patch
@@ -1,0 +1,26 @@
+From 467c583ca00c3512d93745ae6bee7ae26ebcb13e Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sun, 21 Dec 2014 12:58:30 +0100
+Subject: [PATCH] IMX: Disable deinterlacing by default (user can enable it if
+ he wants)
+
+---
+ xbmc/settings/VideoSettings.cpp | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/xbmc/settings/VideoSettings.cpp b/xbmc/settings/VideoSettings.cpp
+index 65105e8..e61f49a 100644
+--- a/xbmc/settings/VideoSettings.cpp
++++ b/xbmc/settings/VideoSettings.cpp
+@@ -29,7 +29,7 @@
+ 
+ CVideoSettings::CVideoSettings()
+ {
+-  m_DeinterlaceMode = VS_DEINTERLACEMODE_AUTO;
++  m_DeinterlaceMode = VS_DEINTERLACEMODE_OFF;
+   m_InterlaceMethod = VS_INTERLACEMETHOD_AUTO;
+   m_ScalingMethod = VS_SCALINGMETHOD_LINEAR;
+   m_ViewMode = ViewModeNormal;
+-- 
+1.9.1
+


### PR DESCRIPTION
This sets the default of Deinterlacing to Off. As we still have some minor performance issues (arround 2 fps too slow on 1080i50 HD+ TV), user can enable that byself.
