### PR TITLE
u-boot: Do not build u-boot if $UBOOT_VERSION is not specified

### DIFF
--- a/packages/tools/u-boot/package.mk
+++ b/packages/tools/u-boot/package.mk
@@ -25,6 +25,8 @@ elif [ "$UBOOT_VERSION" = "imx6-cuboxi" ]; then
   PKG_VERSION="imx6-a06fada"
   PKG_SITE="http://imx.solid-run.com/wiki/index.php?title=Building_the_kernel_and_u-boot_for_the_CuBox-i_and_the_HummingBoard"
   PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+else
+  exit 0
 fi
 PKG_REV="1"
 PKG_ARCH="arm"


### PR DESCRIPTION
This is especially useful for WeTek Play, which uses U-Boot bootloader,
but currently doesn't build it as a part of OpenELEC.
