### PR TITLE
Intel: Fixes for HSW GT1

### DIFF
--- a/packages/graphics/Mesa/patches/Mesa-001-upstream.patch
+++ b/packages/graphics/Mesa/patches/Mesa-001-upstream.patch
@@ -1,0 +1,24 @@
+From eb3441214e993b0e219f02177eef29529b49594f Mon Sep 17 00:00:00 2001
+From: Ben Widawsky <benjamin.widawsky@intel.com>
+Date: Tue, 23 Dec 2014 11:47:14 -0800
+Subject: [PATCH] i965/hsw: Limit max WM threads to physical limit
+
+---
+ src/mesa/drivers/dri/i965/brw_device_info.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/mesa/drivers/dri/i965/brw_device_info.c b/src/mesa/drivers/dri/i965/brw_device_info.c
+index 65942c2..82e4024 100644
+--- a/src/mesa/drivers/dri/i965/brw_device_info.c
++++ b/src/mesa/drivers/dri/i965/brw_device_info.c
+@@ -156,7 +156,7 @@ static const struct brw_device_info brw_device_info_hsw_gt1 = {
+    GEN7_FEATURES, .is_haswell = true, .gt = 1,
+    .max_vs_threads = 70,
+    .max_gs_threads = 70,
+-   .max_wm_threads = 102,
++   .max_wm_threads = 70,
+    .urb = {
+       .size = 128,
+       .min_vs_entries = 32,
+-- 
+2.2.1

--- a/packages/graphics/Mesa/patches/Mesa-002-upstream.patch
+++ b/packages/graphics/Mesa/patches/Mesa-002-upstream.patch
@@ -1,0 +1,21 @@
+From 372aab5291dc65789f596cb849925c1f535741d5 Mon Sep 17 00:00:00 2001
+From: Ben Widawsky <benjamin.widawsky@intel.com>
+Date: Thu, 18 Dec 2014 15:24:48 -0800
+Subject: workaround flush
+
+
+diff --git a/src/mesa/drivers/dri/i965/gen7_vs_state.c b/src/mesa/drivers/dri/i965/gen7_vs_state.c
+index 404dd20..de1853a 100644
+--- a/src/mesa/drivers/dri/i965/gen7_vs_state.c
++++ b/src/mesa/drivers/dri/i965/gen7_vs_state.c
+@@ -71,7 +71,7 @@ upload_vs_state(struct brw_context *brw)
+    const int max_threads_shift = brw->is_haswell ?
+       HSW_VS_MAX_THREADS_SHIFT : GEN6_VS_MAX_THREADS_SHIFT;
+ 
+-   if (!brw->is_haswell && !brw->is_baytrail)
++   if (!brw->is_baytrail)
+       gen7_emit_vs_workaround_flush(brw);
+ 
+    if (brw->vs.prog_data->base.base.use_alt_mode)
+-- 
+cgit v0.10.2

--- a/packages/linux/patches/3.17.7/linux-012-improve-hsw-gt1-hang.patch
+++ b/packages/linux/patches/3.17.7/linux-012-improve-hsw-gt1-hang.patch
@@ -1,0 +1,66 @@
+From 06ca5f69871464eb098c6fbbbd744799c1eba951 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Wed, 24 Dec 2014 14:34:46 +0100
+Subject: [PATCH] DRM: Port http://patchwork.freedesktop.org/patch/39363/ to
+ 3.17 by Ben Widawsky <ben@bwidawsk.net>
+
+---
+ drivers/gpu/drm/i915/i915_drv.h | 2 ++
+ drivers/gpu/drm/i915/i915_reg.h | 7 +++++++
+ drivers/gpu/drm/i915/intel_pm.c | 9 +++++++++
+ 3 files changed, 18 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/i915_drv.h b/drivers/gpu/drm/i915/i915_drv.h
+index 3524306..0f8488b 100644
+--- a/drivers/gpu/drm/i915/i915_drv.h
++++ b/drivers/gpu/drm/i915/i915_drv.h
+@@ -2011,6 +2011,8 @@ struct drm_i915_cmd_table {
+ #define IS_HSW_ULT(dev)		(IS_HASWELL(dev) && \
+ 				 ((dev)->pdev->device & 0xFF00) == 0x0A00)
+ #define IS_ULT(dev)		(IS_HSW_ULT(dev) || IS_BDW_ULT(dev))
++#define IS_HSW_GT1(dev)         (IS_HASWELL(dev) && \
++                                ((dev)->pdev->device & 0x00F0) == 0x0)
+ #define IS_HSW_GT3(dev)		(IS_HASWELL(dev) && \
+ 				 ((dev)->pdev->device & 0x00F0) == 0x0020)
+ /* ULX machines are also considered ULT. */
+diff --git a/drivers/gpu/drm/i915/i915_reg.h b/drivers/gpu/drm/i915/i915_reg.h
+index df02a15..86fc6ee 100644
+--- a/drivers/gpu/drm/i915/i915_reg.h
++++ b/drivers/gpu/drm/i915/i915_reg.h
+@@ -1110,6 +1110,13 @@ enum punit_power_well {
+ #define RING_DMA_FADD_UDW(base)	((base)+0x60) /* gen8+ */
+ #define RING_INSTPM(base)	((base)+0xc0)
+ #define RING_MI_MODE(base)	((base)+0x9c)
++#define RING_WAIT_FOR_RC6_EXIT(base)	((base)+0xcc)
++#define   RING_RC6_SEL_WRITE_ADDR_MASK		(0x7 << 4)
++#define   RING_RC6_SEL_WRITE_ADDR_MULTICAST	(0x0 << 4)
++#define   RING_RC6_SEL_WRITE_ADDR_UPPER_LEFT	(0x4 << 4)
++#define   RING_RC6_SEL_WRITE_ADDR_UPPER_RIGHT	(0x5 << 4)
++#define   RING_RC6_SEL_WRITE_ADDR_LOWER_LEFT	(0x6 << 4)
++#define   RING_RC6_SEL_WRITE_ADDR_LOWER_RIGHT	(0x7 << 4)
+ #define INSTPS		0x02070 /* 965+ only */
+ #define INSTDONE1	0x0207c /* 965+ only */
+ #define ACTHD_I965	0x02074
+diff --git a/drivers/gpu/drm/i915/intel_pm.c b/drivers/gpu/drm/i915/intel_pm.c
+index 1924b56..d225b38 100644
+--- a/drivers/gpu/drm/i915/intel_pm.c
++++ b/drivers/gpu/drm/i915/intel_pm.c
+@@ -3704,6 +3704,15 @@ static void gen6_enable_rps(struct drm_device *dev)
+ 			DRM_ERROR("Couldn't fix incorrect rc6 voltage\n");
+ 	}
+ 
++	/* HSW GT1: "This field must be always [be] programmed to “100” , this
++	 * is required to address know [sic] HW issue." */
++	if (IS_HSW_GT1(dev)) {
++		for_each_ring(ring, dev_priv, i) {
++			I915_WRITE(RING_WAIT_FOR_RC6_EXIT(ring->mmio_base),
++				   _MASKED_FIELD(RING_RC6_SEL_WRITE_ADDR_MASK,
++						 RING_RC6_SEL_WRITE_ADDR_UPPER_LEFT));
++		}
++	}
+ 	gen6_gt_force_wake_put(dev_priv, FORCEWAKE_ALL);
+ }
+ 
+-- 
+1.9.1
+

--- a/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-002-upstream.patch
+++ b/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-002-upstream.patch
@@ -1,0 +1,24 @@
+From 79cc0c15bd67f5bc329d33718c1fb45362d8602c Mon Sep 17 00:00:00 2001
+From: Ben Widawsky <ben@bwidawsk.net>
+Date: Tue, 23 Dec 2014 11:35:10 -0800
+Subject: [PATCH] limit PS to max physical threads
+
+---
+ src/i965_device_info.c | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/src/i965_device_info.c b/src/i965_device_info.c
+index 50bb78d..b4db94d 100644
+--- a/src/i965_device_info.c
++++ b/src/i965_device_info.c
+@@ -434,7 +434,7 @@ static const struct intel_device_info hsw_gt1_device_info = {
+     .gt = 1,
+ 
+     .urb_size = 4096,
+-    .max_wm_threads = 102,
++    .max_wm_threads = 70,
+ 
+     .is_haswell = 1,
+ };
+-- 
+2.2.1

--- a/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-003-batchbuffer-flush.patch
+++ b/packages/multimedia/libva-intel-driver/patches/libva-intel-driver-003-batchbuffer-flush.patch
@@ -1,0 +1,60 @@
+
+m d8effa37c2b0619a479bcd3306d8c7b2ba781c9c Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Thu, 25 Dec 2014 22:34:01 +0100
+Subject: [PATCH] Batchbuffer: Correctly flush
+
+---
+ src/intel_batchbuffer.c | 30 ++++++++++++++++++++++++++++++
+ 1 file changed, 30 insertions(+)
+
+diff --git a/src/intel_batchbuffer.c b/src/intel_batchbuffer.c
+index 60178c6..23c8bcd 100644
+--- a/src/intel_batchbuffer.c
++++ b/src/intel_batchbuffer.c
+@@ -190,6 +190,35 @@ intel_batchbuffer_data(struct intel_batchbuffer *batch,
+     batch->ptr += size;
+ }
+ 
++void hsw_test_flush(struct intel_batchbuffer *batch)
++{
++	/* PIPECONTROL with RO Cache Invalidation: Prior to programming a
++	 * PIPECONTROL command with any of the RO cache invalidation bit set,
++	 * program a PIPECONTROL flush command with "stall" bit and "HDC 
++	 * Flush" bit set.
++	 *
++	 * For HSW the follow are RO caches:
++	 * Depth Stall
++	 * Render Target Cache Flush
++	 * Depth Cache Flush
++	 *
++	 * FIXME: At this time, I don't know how to set HDC flush, but we can
++	 * just try cs stall for now.
++	 */
++
++	int flags = CMD_PIPE_CONTROL_NOWRITE |
++                    CMD_PIPE_CONTROL_CS_STALL |
++		    CMD_PIPE_CONTROL_STALL_AT_SCOREBOARD;
++
++	BEGIN_BATCH(batch, 5);
++	OUT_BATCH(batch, (CMD_PIPE_CONTROL | (5 - 2)));
++	OUT_BATCH(batch, flags);
++	OUT_BATCH(batch, 0);
++	OUT_BATCH(batch, 0);
++	OUT_BATCH(batch, 0);
++	ADVANCE_BATCH(batch);
++}
++
+ void
+ intel_batchbuffer_emit_mi_flush(struct intel_batchbuffer *batch)
+ {
+@@ -249,6 +278,7 @@ intel_batchbuffer_emit_mi_flush(struct intel_batchbuffer *batch)
+                 OUT_BATCH(batch, 0); /* write data */
+                 ADVANCE_BATCH(batch);
+             } else {
++		hsw_test_flush(batch);
+                 BEGIN_BATCH(batch, 4);
+                 OUT_BATCH(batch, CMD_PIPE_CONTROL | (4 - 2));
+ 
+-- 
+1.9.1


### PR DESCRIPTION
It seems the HSW GT1 (Pentium 3230 and so on) have a physical limit concerning the number of wm threads, which causes Render hang and media hangs.

Those patches need testing and should go into OE 5.1 first or 5.0.1 if we find some testfolks for this.

I have tracked those down with OpenELEC user zeeeh and the intel dev bwidawsky. Without those patches the system of zeeh crashes within some minutes.

PS: As I am not able to build anything here, please someone could verify that I created the Mesa patches directory, etc. correctly.

History: https://bugs.freedesktop.org/show_bug.cgi?id=87564