### PR TITLE
linux: Clear media states on flush

### DIFF
--- a/packages/linux/patches/3.17.7/linux-012-intel-fix-ivb-stall.patch
+++ b/packages/linux/patches/3.17.7/linux-012-intel-fix-ivb-stall.patch
@@ -1,0 +1,49 @@
+From 32431fd81d65259d490e53e3cfc7e1a2ad781fe3 Mon Sep 17 00:00:00 2001
+From: Chris Wilson <chris@chris-wilson.co.uk>
+Date: Tue, 16 Dec 2014 08:44:31 +0000
+Subject: [PATCH] drm/i915: Invalidate media caches on gen7
+MIME-Version: 1.0
+Content-Type: text/plain; charset=UTF-8
+Content-Transfer-Encoding: 8bit
+
+In the gen7 pipe control there is an extra bit to flush the media
+caches, so let's set it during cache invalidation flushes.
+
+v2: Rename to MEDIA_STATE_CLEAR to be more inline with spec.
+
+Cc: Simon Farnsworth <simon@farnz.org.uk>
+Cc: Ville Syrjälä <ville.syrjala@linux.intel.com>
+Cc: Daniel Vetter <daniel.vetter@ffwll.ch>
+Signed-off-by: Chris Wilson <chris@chris-wilson.co.uk>
+Reviewed-by: Daniel Vetter <daniel.vetter@ffwll.ch>
+Cc: stable@vger.kernel.org
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+---
+ drivers/gpu/drm/i915/i915_reg.h         | 1 +
+ drivers/gpu/drm/i915/intel_ringbuffer.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/i915/i915_reg.h b/drivers/gpu/drm/i915/i915_reg.h
+index c01e5f3..d9780e2 100644
+--- a/drivers/gpu/drm/i915/i915_reg.h
++++ b/drivers/gpu/drm/i915/i915_reg.h
+@@ -370,6 +370,7 @@
+ #define   PIPE_CONTROL_STORE_DATA_INDEX			(1<<21)
+ #define   PIPE_CONTROL_CS_STALL				(1<<20)
+ #define   PIPE_CONTROL_TLB_INVALIDATE			(1<<18)
++#define   PIPE_CONTROL_MEDIA_STATE_CLEAR		(1<<16)
+ #define   PIPE_CONTROL_QW_WRITE				(1<<14)
+ #define   PIPE_CONTROL_POST_SYNC_OP_MASK                (3<<14)
+ #define   PIPE_CONTROL_DEPTH_STALL			(1<<13)
+diff --git a/drivers/gpu/drm/i915/intel_ringbuffer.c b/drivers/gpu/drm/i915/intel_ringbuffer.c
+index 0a80e41..b02cf69 100644
+--- a/drivers/gpu/drm/i915/intel_ringbuffer.c
++++ b/drivers/gpu/drm/i915/intel_ringbuffer.c
+@@ -362,6 +362,7 @@ gen7_render_ring_flush(struct intel_engine_cs *ring,
+ 		flags |= PIPE_CONTROL_VF_CACHE_INVALIDATE;
+ 		flags |= PIPE_CONTROL_CONST_CACHE_INVALIDATE;
+ 		flags |= PIPE_CONTROL_STATE_CACHE_INVALIDATE;
++		flags |= PIPE_CONTROL_MEDIA_STATE_CLEAR;
+ 		/*
+ 		 * TLB invalidate requires a post-sync write.
+ 		 */


### PR DESCRIPTION
This should cope with some instabilities on IVB (therefore also Baytrail). 

It needs regression testing on:
- Chromebox 2955U
- Pike's SNB (@pike2k)
- An IVB System from the forum (older nuc)
- Some NUC with core hsw gpu

@sraue Can you provide a testbuild?
