### PR TITLE
Add support for Fujitsu Siemens Scaleo E lcd

### DIFF
--- a/packages/sysutils/lcdproc/patches/lcdproc-fujitsu_siemens_scaleo_e.patch
+++ b/packages/sysutils/lcdproc/patches/lcdproc-fujitsu_siemens_scaleo_e.patch
@@ -1,0 +1,56 @@
+diff -Naur lcdproc-0.5.7-cvs20140217/server/drivers/dm140.c lcdproc-0.5.7-cvs20140217.patch/server/drivers/dm140.c
+--- lcdproc-0.5.7-cvs20140217/server/drivers/dm140.c	2014-12-24 01:37:27.439628078 +0100
++++ lcdproc-0.5.7-cvs20140217.patch/server/drivers/dm140.c	2014-12-24 01:41:34.556853466 +0100
+@@ -81,10 +81,17 @@
+ 	    return -1;
+         }
+ 	
+-	if((p->fd = OpenHID(drvthis))< 0)
++	if ((p->fd = OpenHID(drvthis)) < 0)
+ 	{
+-		report(RPT_INFO, "Device for Vendor[%s] Product[%s] was not found, exiting\n", p->pszVendor, p->pszProduct);
+-		return -1;
++		report(RPT_INFO, "Device for Vendor[%s] Product[%s] was not found\n", p->pszVendor, p->pszProduct);
++		p->pszVendor = "1509";
++		p->pszProduct = "925d";
++		if ((p->fd = OpenHID(drvthis)) < 0)
++		{
++			report(RPT_INFO, "Device for Vendor[%s] Product[%s] was not found\n", p->pszVendor, p->pszProduct);
++			report(RPT_INFO, "No dm140 device found, exiting\n");
++			return -1;
++		}
+ 	}
+ 
+ 	//******************************************************
+diff -Naur lcdproc-0.5.7-cvs20140217/server/drivers/led.c lcdproc-0.5.7-cvs20140217.patch/server/drivers/led.c
+--- lcdproc-0.5.7-cvs20140217/server/drivers/led.c	2014-12-24 01:37:27.439628078 +0100
++++ lcdproc-0.5.7-cvs20140217.patch/server/drivers/led.c	2014-12-24 01:49:38.519253308 +0100
+@@ -95,21 +95,21 @@
+ //**************************************************************
+ // FUNCTION: Compare
+ //
+-// INPUT: 
++// INPUT:
+ //  const char *pszValue - string to compare
+-//  short sValue - numberic value to compare
++//  short sOtherValue - numeric value to compare
+ //
+ // OUTPUT:
+ //   int - Boolean value, 0 on non match, 1 on success.
+ //
+-// DESCRIPTION: Compare a character value to a numeric value.
++// DESCRIPTION: Compare a hex value in a string to a numeric value.
+ //**************************************************************
+-int Compare(const char *pszValue, short sValue)
++int Compare(const char *pszValue, short sOtherValue)
+ {
+-  int iValue;
++  short sValue;
+   // convert the pszValue to a number
+-  sscanf( pszValue, "%4x", &iValue);
+-  return( iValue == sValue );
++  sscanf( pszValue, "%4hx", &sValue );
++  return( sValue == sOtherValue );
+ }
+ 
+ 


### PR DESCRIPTION
The Fujitsu Siemens Scaleo E HTPC has a dm140 lcd with a different USB vendor/device id than currently supported by the dm140 driver, so add support for this "new" USB device id.

Function Compare didn't work with USB vendor/device ids >= 2^15 (ie 0x925d) because the value read from the string was not converted to a signed short.

These problems have previously been mentioned here: 
http://www.mythtv.org/wiki/futaba

![Fujitsu Siemens Scaleo E with working lcd](https://cloud.githubusercontent.com/assets/4707486/5559935/4517493c-8d64-11e4-8844-b1ae55ce4ed8.jpg)
