### PR TITLE
add vdr-plugin-epgfixer

### DIFF
--- a/packages/addons/service/multimedia/vdr-addon/package.mk
+++ b/packages/addons/service/multimedia/vdr-addon/package.mk
@@ -24,7 +24,7 @@ PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://www.openelec.tv"
 PKG_URL=""
-PKG_DEPENDS_TARGET="toolchain attr libcap vdr vdr-plugin-xvdr vdr-plugin-vnsiserver vdr-iptv vdr-wirbelscan vdr-wirbelscancontrol vdr-plugin-dvbapi vdr-plugin-streamdev vdr-live vdr-control vdr-epgsearch vdr-plugin-xmltv2vdr vdr-plugin-eepg vdr-dummydevice vdr-satip"
+PKG_DEPENDS_TARGET="toolchain attr libcap vdr vdr-plugin-xvdr vdr-plugin-vnsiserver vdr-iptv vdr-wirbelscan vdr-wirbelscancontrol vdr-plugin-dvbapi vdr-plugin-streamdev vdr-live vdr-control vdr-epgsearch vdr-plugin-xmltv2vdr vdr-plugin-eepg vdr-dummydevice vdr-satip vdr-plugin-epgfixer"
 PKG_PRIORITY="optional"
 PKG_SECTION="service.multimedia"
 PKG_SHORTDESC="vdr: A powerful DVB TV application"
@@ -48,6 +48,7 @@ addon() {
   VDR_PLUGIN_VNSISERVER_DIR="$(get_build_dir vdr-plugin-vnsiserver)"
   VDR_PLUGIN_STREAMVEV_DIR="$(get_build_dir vdr-plugin-streamdev)"
   VDR_PLUGIN_XMLTV2VDR="$(get_build_dir vdr-plugin-xmltv2vdr)"
+  VDR_PLUGIN_EPGFIXER_DIR="$(get_build_dir vdr-plugin-epgfixer)"
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config
   cp $VDR_DIR/channels.conf $ADDON_BUILD/$PKG_ADDON_ID/config
@@ -84,6 +85,7 @@ addon() {
   cp -PR $VDR_PLUGIN_XMLTV2VDR/libvdr*.so.* $ADDON_BUILD/$PKG_ADDON_ID/plugin
   cp -PR $(get_build_dir vdr-dummydevice)/libvdr*.so.* $ADDON_BUILD/$PKG_ADDON_ID/plugin
   cp -PR $(get_build_dir vdr-satip)/libvdr*.so.* $ADDON_BUILD/$PKG_ADDON_ID/plugin
+  cp -PR $VDR_PLUGIN_EPGFIXER_DIR/libvdr*.so.* $ADDON_BUILD/$PKG_ADDON_ID/plugin
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config/plugins/eepg
 
@@ -103,4 +105,7 @@ addon() {
 
   mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config/plugins/streamdev-server
   cp -PR $VDR_PLUGIN_STREAMVEV_DIR/streamdev-server/streamdevhosts.conf $ADDON_BUILD/$PKG_ADDON_ID/config/plugins/streamdev-server
+
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/config/plugins/epgfixer
+  cp -PR $VDR_PLUGIN_EPGFIXER_DIR/epgfixer/*.conf $ADDON_BUILD/$PKG_ADDON_ID/config/plugins/epgfixer
 }

--- a/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
+++ b/packages/addons/service/multimedia/vdr-addon/source/bin/vdr.start
@@ -105,6 +105,9 @@ fi
 if [ "$ENABLE_EEPG" == "true" ] ; then
   VDR_ARG="$VDR_ARG -P eepg"
 fi
+if [ "$ENABLE_EPGFIXER" == "true" ] ; then
+  VDR_ARG="$VDR_ARG -P epgfixer"
+fi
 if [ "$ENABLE_EPGSEARCH" == "true" ] ; then
   VDR_ARG="$VDR_ARG -P epgsearch"
 fi

--- a/packages/addons/service/multimedia/vdr-addon/source/resources/language/English/strings.xml
+++ b/packages/addons/service/multimedia/vdr-addon/source/resources/language/English/strings.xml
@@ -24,6 +24,7 @@
 	<string id="1046">Enable plugin: extended EPG</string>
 	<string id="1047">Enable plugin: dummydevice</string>
 	<string id="1048">Enable plugin: satip</string>
+	<string id="1049">Enable plugin: epgfixer</string>
 	<string id="1051">VDR Configuration</string>
 	<string id="1052">VDR Video Dir</string>
 	<string id="1053">PVR plugin</string>

--- a/packages/addons/service/multimedia/vdr-addon/source/resources/settings.xml
+++ b/packages/addons/service/multimedia/vdr-addon/source/resources/settings.xml
@@ -35,6 +35,7 @@
 		<setting id="ENABLE_XMLTV2VDR" type="bool" label="1045" default="false" />
 		<setting id="ENABLE_DUMMYDEVICE" type="bool" label="1047" default="false" />
 		<setting id="ENABLE_SATIP" type="bool" label="1048" default="false" />
+		<setting id="ENABLE_EPGFIXER" type="bool" label="1049" default="false" />
 		<setting type="sep" />
 		<setting id="ENABLE_SOFTCAM" type="bool" label="1036" default="true" />
     </category>

--- a/packages/addons/service/multimedia/vdr-addon/source/settings-default.xml
+++ b/packages/addons/service/multimedia/vdr-addon/source/settings-default.xml
@@ -14,6 +14,7 @@
     <setting id="ENABLE_CONTROL" value="false" />
     <setting id="CONTROL_PORT" value="2002" />
     <setting id="ENABLE_EEPG" value="false" />
+    <setting id="ENABLE_EPGFIXER" value="false" />
     <setting id="ENABLE_EPGSEARCH" value="false" />
     <setting id="ENABLE_XMLTV2VDR" value="false" />
     <setting id="ENABLE_DUMMYDEVICE" value="false" />

--- a/packages/multimedia/vdr-plugin-epgfixer/package.mk
+++ b/packages/multimedia/vdr-plugin-epgfixer/package.mk
@@ -1,0 +1,52 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="vdr-plugin-epgfixer"
+PKG_VERSION="1ad4aaf"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://projects.vdr-developer.org/projects/plg-epgfixer"
+#PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="http://projects.vdr-developer.org/git/vdr-plugin-epgfixer.git/snapshot/vdr-plugin-epgfixer-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain vdr pcre"
+PKG_PRIORITY="optional"
+PKG_SECTION="multimedia"
+PKG_SHORTDESC="vdr-plugin-epgfixer"
+PKG_LONGDESC="Plugin for modifying EPG data using regular expressions."
+
+PKG_IS_ADDON="no"
+
+PKG_AUTORECONF="no"
+
+pre_configure_target() {
+  export CFLAGS="$CFLAGS -fPIC"
+  export CXXFLAGS="$CXXFLAGS -fPIC"
+  export LDFLAGS="$LDFLAGS -fPIC"
+}
+
+make_target() {
+  VDR_DIR=$(get_build_dir vdr)
+  make VDRDIR=$VDR_DIR \
+    LIBDIR="." \
+    LOCALEDIR="./locale"
+}
+
+makeinstall_target() {
+  : # installation not needed, done by create-addon script
+}

--- a/packages/multimedia/vdr-plugin-epgfixer/patches/vdr-plugin-epgfixer-01_makefile.patch
+++ b/packages/multimedia/vdr-plugin-epgfixer/patches/vdr-plugin-epgfixer-01_makefile.patch
@@ -1,0 +1,59 @@
+--- a/Makefile	2014-08-23 13:33:34.000000000 +0400
++++ b/Makefile	2014-12-25 06:10:10.903404927 +0300
+@@ -18,18 +18,12 @@
+ ### The directory environment:
+ 
+ # Use package data if installed...otherwise assume we're under the VDR source directory:
+-PKGCFG = $(if $(VDRDIR),$(shell pkg-config --variable=$(1) $(VDRDIR)/vdr.pc),$(shell pkg-config --variable=$(1) vdr || pkg-config --variable=$(1) ../../../vdr.pc))
+-CFGDIR = $(call PKGCFG,configdir)
+-LIBDIR = $(call PKGCFG,libdir)
+-LOCDIR = $(call PKGCFG,locdir)
+-PLGCFG = $(call PKGCFG,plgcfg)
+ #
+ TMPDIR ?= /tmp
+ 
+ ### The compiler options:
+ 
+-export CFLAGS   = $(call PKGCFG,cflags)
+-export CXXFLAGS = $(call PKGCFG,cxxflags)
++include $(VDRDIR)/Make.global
+ 
+ ### Regexp
+ ifeq (exists, $(shell pkg-config libpcre && echo exists))
+@@ -40,7 +34,7 @@
+ 
+ ### The version number of VDR's plugin API:
+ 
+-APIVERSION = $(call PKGCFG,apiversion)
++APIVERSION = $(shell sed -ne '/define APIVERSION/s/^.*"\(.*\)".*$$/\1/p' $(VDRDIR)/config.h)
+ 
+ ### Allow user defined options to overwrite defaults:
+ 
+@@ -57,7 +51,7 @@
+ 
+ ### Includes and Defines (add further entries here):
+ 
+-INCLUDES +=
++INCLUDES += -I$(VDRDIR)/include
+ 
+ DEFINES += -DPLUGIN_NAME_I18N='"$(PLUGIN)"'
+ 
+@@ -70,8 +64,8 @@
+ OBJS = $(PLUGIN).o blacklist.o charset.o config.o epgclone.o epghandler.o regexp.o setup_menu.o tools.o
+ 
+ ifeq ($(REGEXLIB), pcre)
+-LIBS += $(shell pcre-config --libs-posix)
+-INCLUDES += $(shell pcre-config --cflags)
++LIBS += $(shell pkg-config --libs libpcreposix libpcre)
++INCLUDES += $(shell pkg-config --cflags libpcre)
+ DEFINES += -DHAVE_PCREPOSIX
+ endif
+ 
+@@ -123,6 +117,7 @@
+ 
+ $(SOFILE): $(OBJS)
+ 	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $(OBJS) -o $@ $(LIBS)
++	@cp --remove-destination $@ $(LIBDIR)/$@.$(APIVERSION)
+ 
+ install-lib: $(SOFILE)
+ 	install -D $^ $(DESTDIR)$(LIBDIR)/$^.$(APIVERSION)

--- a/tools/mkpkg/mkpkg_vdr-plugin-epgfixer
+++ b/tools/mkpkg/mkpkg_vdr-plugin-epgfixer
@@ -1,0 +1,43 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+echo "getting sources..."
+  if [ ! -d vdr-plugin-epgfixer.git ]; then
+    git clone git://projects.vdr-developer.org/vdr-plugin-epgfixer.git vdr-plugin-epgfixer.git
+  fi
+
+  cd vdr-plugin-epgfixer.git
+    git pull
+    GIT_REV=`git log -n1 --format=%h`
+  cd ..
+
+echo "copying sources..."
+  rm -rf vdr-plugin-epgfixer-$GIT_REV
+  cp -R vdr-plugin-epgfixer.git vdr-plugin-epgfixer-$GIT_REV
+
+echo "cleaning sources..."
+  rm -rf vdr-plugin-epgfixer-$GIT_REV/.git
+
+echo "packing sources..."
+  tar cvJf vdr-plugin-epgfixer-$GIT_REV.tar.xz vdr-plugin-epgfixer-$GIT_REV
+
+echo "remove temporary sourcedir..."
+  rm -rf vdr-plugin-epgfixer-$GIT_REV


### PR DESCRIPTION
A very valuable plugin to deal with ugly epg data broadcasted by providers.
An example of that ugly epg:
an EIT event has short_text and description tags and both can be used as an event description.
But for some events only short_text is broadcasted, for some only description or the text is
splitted between them. It mostly depends on EIT table id type - present/following or schedule.
E.g "Champions League. Schalke - Real Madrid." may be shown in KODI for some events as 
"Schalke - Real Madrid." or  "Champions League." for other which is very annoying. This
particular issue can be fixed in a skin (all skins with PVR support) but there will still be
other epg errors - you never know, it depends on your provider. So, to my view, it's better to
give a user an opportunity to correct them with this plugin. It's small, depends only on
vdr and pcre and works fine for me.

Change PKG_URL in packages/multimedia/vdr-plugin-epgfixer/package.mk if you put it to http://sources.openelec.tv.
