### PR TITLE
vdr-satip: update to vdr-satip-1.0.0

### DIFF
--- a/packages/multimedia/vdr-satip/package.mk
+++ b/packages/multimedia/vdr-satip/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="vdr-satip"
-PKG_VERSION="0.3.3"
+PKG_VERSION="1.0.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- update to vdr-satip-1.0.0
- this is a major update of the plugin and the first real usable version for every hardware besides the Octopus Net