### PR TITLE
use default imageres and remove busydialogdelayms

### DIFF
--- a/projects/RPi/kodi/advancedsettings.xml
+++ b/projects/RPi/kodi/advancedsettings.xml
@@ -3,11 +3,7 @@
   <showexitbutton>false</showexitbutton>
 
   <fanartres>720</fanartres>
-  <imageres>540</imageres>
-
-  <video>
-    <busydialogdelayms>750</busydialogdelayms>
-  </video>
+  <imageres>720</imageres>
 
   <samba>
     <clienttimeout>30</clienttimeout>


### PR DESCRIPTION
the default for imageres is 720, I suggest we increase to this res, should still be ok for 256mb Pi (really buy a new one for 2015...)
remove busydialogdelayms as it was removed since Gotham
http://kodi.wiki/view/Advancedsettings.xml#Recently_removed_tags