### PR TITLE
ntfs-3g_ntfsprogs: fix gcrypt check in autoreconf

### DIFF
--- a/packages/sysutils/ntfs-3g_ntfsprogs/patches/ntfs-3g_ntfsprogs-01-meh-gcrypt.patch
+++ b/packages/sysutils/ntfs-3g_ntfsprogs/patches/ntfs-3g_ntfsprogs-01-meh-gcrypt.patch
@@ -1,0 +1,21 @@
+diff --git a/configure.ac b/configure.ac
+index 830c5fb..e0d3bac 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -318,6 +318,7 @@ fi
+ compile_crypto=false
+ if test "$enable_crypto" != "no"; then
+ 	have_libgcrypt=false
++	m4_ifdef([AM_PATH_LIBGCRYPT],
+ 	AM_PATH_LIBGCRYPT(1.2.2, [ have_libgcrypt=true ],
+ 	[
+ 		if test "$enable_crypto" = "yes"; then
+@@ -325,7 +326,7 @@ if test "$enable_crypto" != "no"; then
+ 		else
+ 			AC_MSG_WARN([ntfsprogs crypto code requires the gcrypt library.])
+ 		fi
+-	])
++	]),[have_libgcrypt=false])
+ 	have_libgnutls=false
+ 	PKG_CHECK_MODULES(GNUTLS, gnutls >= 1.4.4, [ have_libgnutls=true ],
+ 		if test "$enable_crypto" = "yes"; then


### PR DESCRIPTION
AM_PATH_LIBGCRYPT is undefined if libgcrypt is not (yet)
built, and we dont depend on gcrypt...