### PR TITLE
connman: permanently disable ipv6

### DIFF
--- a/packages/network/connman/sysctl.d/ipv6.conf
+++ b/packages/network/connman/sysctl.d/ipv6.conf
@@ -1,0 +1,1 @@
+net.ipv6.conf.all.disable_ipv6=1


### PR DESCRIPTION
closes #3746

users who want to re-enable it, can override via .config/sysctl.d/

for OE 6.0 ipv6 should be permanently removed from kernel and OE settings addon.