### PR TITLE
[RFC] allow addons to ship profile.d scripts

### DIFF
--- a/packages/mediacenter/kodi/profile.d/00-addons.conf
+++ b/packages/mediacenter/kodi/profile.d/00-addons.conf
@@ -16,6 +16,13 @@
 #  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
 ################################################################################
 
+# addons profile.d/*.profile
+for config in /storage/.kodi/addons/*/profile.d/*.profile; do
+  if [ -f "$config" ] ; then
+    . $config
+  fi
+done
+
 oe_setup_addon() {
   if [ ! -z $1 ] ; then
     DEF="/storage/.kodi/addons/$1/settings-default.xml"


### PR DESCRIPTION
this was requested by @ksooo

most of the potential issues I can think of are fixed already in bf42102

addons are not allowed to override anything that is already set via system profile.d/ scripts.

however, a rogue addon could "sleep 100000" thus effectively preventing stuff sourcing /etc/profile from starting. but addons can do other bad things as well, anyway. if one does such sh** he should be beaten.

pls dont merge. lets discuss it first and then decide if we want it.