### PR TITLE
Fix multiple installations in NOOBS

### DIFF
--- a/config/noobs/partitions.json
+++ b/config/noobs/partitions.json
@@ -1,7 +1,7 @@
 {
   "partitions": [
     {
-      "label":                     "System",
+      "label":                     "@DISTRONAME@System",
       "filesystem_type":           "FAT",
       "partition_size_nominal":    160,
       "want_maximised":            false,
@@ -9,7 +9,7 @@
       "mkfs_options":              ""
     },
     {
-      "label":                     "Storage",
+      "label":                     "@DISTRONAME@Storage",
       "filesystem_type":           "ext4",
       "partition_size_nominal":    864,
       "want_maximised":            true,

--- a/scripts/image
+++ b/scripts/image
@@ -333,6 +333,9 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
           -e "s%@DESCRIPTION@%$DESCRIPTION%g" \
           -i $RELEASE_DIR/os.json
 
+      sed -e "s%@DISTRONAME@%$DISTRONAME%g" \
+          -i $RELEASE_DIR/partitions.json
+
     # create System dir
       mkdir -p $RELEASE_DIR/System
 
@@ -366,12 +369,12 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
       mkdir -p $RELEASE_DIR/Storage
 
     # remove an previous created release tarball
-      rm -rf $RELEASE_DIR/System.tar.xz
-      rm -rf $RELEASE_DIR/Storage.tar.xz
+      rm -rf $RELEASE_DIR/${DISTRONAME}System.tar.xz
+      rm -rf $RELEASE_DIR/${DISTRONAME}Storage.tar.xz
 
     # create filesystem tarballs
-      tar cJf $RELEASE_DIR/System.tar.xz -C $RELEASE_DIR/System/ .
-      tar cJf $RELEASE_DIR/Storage.tar.xz -C $RELEASE_DIR/Storage/ .
+      tar cJf $RELEASE_DIR/${DISTRONAME}System.tar.xz -C $RELEASE_DIR/System/ .
+      tar cJf $RELEASE_DIR/${DISTRONAME}Storage.tar.xz -C $RELEASE_DIR/Storage/ .
 
     # remove an filesystem dirs
       rm -rf $RELEASE_DIR/System


### PR DESCRIPTION
When installing two OpenELEC based distro with NOOBS, the labels of the SYSTEM partitions conflict. This fix address that problem by prefixing the names of these partitions by the DISTRONAME.

If you think there is a better way to fix this bug, tell me how and I will send another PR.