### PR TITLE
Add sleep before  creating filesystem

### DIFF
--- a/packages/tools/u-boot/files/create_sdcard
+++ b/packages/tools/u-boot/files/create_sdcard
@@ -207,7 +207,8 @@ echo "#########################################################"
 # tell kernel we have a new partition table
   echo "telling kernel we have a new partition table..."
   partprobe "$DISK"
-
+  sleep 1
+  
 # create filesystem
   echo "creating filesystem on $PART1..."
   mkfs.vfat "$PART1" -I -n System


### PR DESCRIPTION
In some computers mkfs try to creating filesystem, before kernel update partition table.