### PR TITLE
scripts/checkdeps: allow project specific deps

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -48,6 +48,14 @@ case $1 in
     ;;
 esac
 
+# project specific dependencies
+if [ -n "$EXTRA_DEPS" ] ; then
+  deps="$deps $EXTRA_DEPS"
+fi
+if [ -n "$EXTRA_DEPS_PKG" ] ; then
+  deps_pkg="$deps_pkg $EXTRA_DEPS_PKG"
+fi
+
 getarg() {
   eval echo \${$(($1+2))}
 }


### PR DESCRIPTION
projects can define EXTRA_DEPS and EXTRA_DEPS_PKG in projects/xxx/options

//cc @codesnake

example:
```
  # extra build dependeices
    EXTRA_DEPS="mkimage"
    EXTRA_DEPS_PKG="u-boot-tools"
```
