### PR TITLE
mkimage enhancements

### DIFF
--- a/projects/RPi/options
+++ b/projects/RPi/options
@@ -147,3 +147,6 @@
 
   # build and install 'FishBMC' Visualization (yes / no)
     KODI_VIS_FISHBMC="no"
+
+  # kernel image name
+    KERNEL_NAME="kernel.img"

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -160,3 +160,6 @@
   # extra build dependeices
     EXTRA_DEPS="mkimage"
     EXTRA_DEPS_PKG="u-boot-tools"
+
+  # kernel image name
+    KERNEL_NAME="kernel.img"

--- a/scripts/image
+++ b/scripts/image
@@ -294,7 +294,7 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
         echo "mkimage: see scripts/image and scripts/mkimage if you dont trust us :)"
         # variables used in image script must be passed
         sudo env \
-          PATH="$PATH" \
+          PATH="$PATH:/sbin" \
           ROOT="$ROOT" \
           TOOLCHAIN="$TOOLCHAIN" \
           TARGET_IMG="$TARGET_IMG" \

--- a/scripts/image
+++ b/scripts/image
@@ -290,6 +290,10 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
         if [ "$2" == "efi" ] ; then
           UEFI=yes
         fi
+        # projects can set KERNEL_NAME (kernel.img)
+        if [ -z "$KERNEL_NAME" ] ; then
+          KERNEL_NAME="KERNEL"
+        fi
         echo "mkimage: boo. now root access (sudo) is required..."
         echo "mkimage: see scripts/image and scripts/mkimage if you dont trust us :)"
         # variables used in image script must be passed
@@ -300,6 +304,7 @@ IMAGE_NAME="$DISTRONAME-$TARGET_VERSION"
           TARGET_IMG="$TARGET_IMG" \
           IMAGE_NAME="$IMAGE_NAME" \
           BOOTLOADER="$BOOTLOADER" \
+          KERNEL_NAME="$KERNEL_NAME" \
           RELEASE_DIR="$RELEASE_DIR" \
           UUID_SYSTEM="$(uuidgen)" \
           UUID_STORAGE="$(uuidgen)" \

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -242,10 +242,14 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
     echo "image: copying files to part1..."
     cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/KERNEL"
     cp $TARGET_IMG/$IMAGE_NAME.system "$OE_TMP/SYSTEM"
-    cp $RELEASE_DIR/3rdparty/bootloader/u-boot.img "$OE_TMP"
+    if [ -f $RELEASE_DIR/3rdparty/bootloader/u-boot.img ] ; then
+      cp $RELEASE_DIR/3rdparty/bootloader/u-boot.img "$OE_TMP"
+    fi
 
-    for dtb in $(ls $RELEASE_DIR/3rdparty/bootloader/*.dtb) ; do
-      cp "$dtb" "$OE_TMP"
+    for dtb in $RELEASE_DIR/3rdparty/bootloader/*.dtb ; do
+      if [ -f $dtb ] ; then
+        cp "$dtb" "$OE_TMP"
+      fi
     done
 fi # bootloader
 

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -171,12 +171,12 @@ MENU COLOR tabmsg       31;40   #ff868787 #00000000 std
 
 LABEL installer
   MENU LABEL Run $DISTRONAME Installer
-  KERNEL /KERNEL
+  KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM installer quiet tty vga=current
 
 LABEL live
   MENU LABEL Run $DISTRONAME Live
-  KERNEL /KERNEL
+  KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE quiet vga=current
 EOF
 
@@ -190,7 +190,7 @@ EOF
 
   # copy files
     echo "image: copying files to part1..."
-    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/KERNEL"
+    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/$KERNEL_NAME"
     cp $TARGET_IMG/$IMAGE_NAME.system "$OE_TMP/SYSTEM"
     cp $RELEASE_DIR/splash.png "$OE_TMP"
     cp $ROOT/$TOOLCHAIN/share/syslinux/vesamenu.c32 "$OE_TMP"
@@ -204,7 +204,7 @@ EOF
 DEFAULT installer
 
 LABEL installer
-  KERNEL /KERNEL
+  KERNEL /$KERNEL_NAME
   APPEND boot=UUID=$UUID_SYSTEM installer quiet tty vga=current
 EOF
     fi
@@ -217,7 +217,7 @@ EOF
 
   # copy files
     echo "image: copying files to part1..."
-    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/kernel.img"
+    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/$KERNEL_NAME"
     cp $TARGET_IMG/$IMAGE_NAME.system "$OE_TMP/SYSTEM"
     cp $RELEASE_DIR/3rdparty/bootloader/bootcode.bin "$OE_TMP"
     cp $RELEASE_DIR/3rdparty/bootloader/fixup.dat "$OE_TMP"
@@ -240,7 +240,7 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
     fi
 
     echo "image: copying files to part1..."
-    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/KERNEL"
+    cp $TARGET_IMG/$IMAGE_NAME.kernel "$OE_TMP/$KERNEL_NAME"
     cp $TARGET_IMG/$IMAGE_NAME.system "$OE_TMP/SYSTEM"
     if [ -f $RELEASE_DIR/3rdparty/bootloader/u-boot.img ] ; then
       cp $RELEASE_DIR/3rdparty/bootloader/u-boot.img "$OE_TMP"


### PR DESCRIPTION
- projects are allowed to set name for target kernel (RPi/WeTek_Play use kernel.img)
- minors

@sraue @MilhouseVH could you confirm this still produces valid images for RPi/x86, just in case ?
