### PR TITLE
IMX: Revisit coherent_pool

### DIFF
--- a/projects/imx6/bootloader/uEnv.txt
+++ b/projects/imx6/bootloader/uEnv.txt
@@ -1,3 +1,3 @@
 zImage=/KERNEL
 bootfile=/KERNEL
-mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=16 dmfc=3'
+mmcargs=setenv bootargs 'boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 quiet video=mxcfb0:dev=hdmi,1920x1080M@60,if=RGB24,bpp=16 dmfc=3 coherent_pool=2M'

--- a/projects/imx6/linux/linux.arm.conf
+++ b/projects/imx6/linux/linux.arm.conf
@@ -524,7 +524,7 @@ CONFIG_ATAGS=y
 CONFIG_ZBOOT_ROM_TEXT=0
 CONFIG_ZBOOT_ROM_BSS=0
 # CONFIG_ARM_APPENDED_DTB is not set
-CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init noram usbcore.autosuspend=-1 coherent_pool=1M"
+CONFIG_CMDLINE="root=/dev/ram0 rdinit=/init noram usbcore.autosuspend=-1"
 # CONFIG_CMDLINE_FROM_BOOTLOADER is not set
 CONFIG_CMDLINE_EXTEND=y
 # CONFIG_CMDLINE_FORCE is not set


### PR DESCRIPTION
- This should go to 5.0
- The bump is again needed for usb dual tv tuner card - Evolve Venus

Btw. it's not good to nail such values into the kernel config, cause they are not overwritten properly by user supplied argument.