### PR TITLE
fix compile for Linux 3.18

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-005-CFG80211_BSS_FTYPE_UNKNOWN-linux-3.18.0.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-005-CFG80211_BSS_FTYPE_UNKNOWN-linux-3.18.0.patch
@@ -1,0 +1,38 @@
+diff -ur bcm_sta-6.30.223.248.ori/x86-32/src/wl/sys/wl_cfg80211_hybrid.c bcm_sta-6.30.223.248/x86-32/src/wl/sys/wl_cfg80211_hybrid.c
+--- bcm_sta-6.30.223.248.ori/x86-32/src/wl/sys/wl_cfg80211_hybrid.c	2015-01-14 07:28:39.000000000 +0100
++++ bcm_sta-6.30.223.248/x86-32/src/wl/sys/wl_cfg80211_hybrid.c	2015-01-14 07:32:16.000000000 +0100
+@@ -2010,9 +2010,15 @@
+ 
+ 	notify_ie = (u8 *)bi + le16_to_cpu(bi->ie_offset);
+ 	notify_ielen = le32_to_cpu(bi->ie_length);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
++	cbss = cfg80211_inform_bss(wiphy, channel, CFG80211_BSS_FTYPE_UNKNOWN, (const u8 *)(bi->BSSID.octet),
++                0, beacon_proberesp->capab_info, beacon_proberesp->beacon_int,
++                (const u8 *)notify_ie, notify_ielen, signal, GFP_KERNEL);
++#else
+ 	cbss = cfg80211_inform_bss(wiphy, channel, (const u8 *)(bi->BSSID.octet),
+ 		0, beacon_proberesp->capab_info, beacon_proberesp->beacon_int,
+ 		(const u8 *)notify_ie, notify_ielen, signal, GFP_KERNEL);
++#endif
+ 
+ 	if (unlikely(!cbss))
+ 		return -ENOMEM;
+diff -ur bcm_sta-6.30.223.248.ori/x86-64/src/wl/sys/wl_cfg80211_hybrid.c bcm_sta-6.30.223.248/x86-64/src/wl/sys/wl_cfg80211_hybrid.c
+--- bcm_sta-6.30.223.248.ori/x86-64/src/wl/sys/wl_cfg80211_hybrid.c	2015-01-14 07:28:39.000000000 +0100
++++ bcm_sta-6.30.223.248/x86-64/src/wl/sys/wl_cfg80211_hybrid.c	2015-01-14 07:33:35.000000000 +0100
+@@ -2010,9 +2010,15 @@
+ 
+ 	notify_ie = (u8 *)bi + le16_to_cpu(bi->ie_offset);
+ 	notify_ielen = le32_to_cpu(bi->ie_length);
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(3, 18, 0)
++	cbss = cfg80211_inform_bss(wiphy, channel,CFG80211_BSS_FTYPE_UNKNOWN, (const u8 *)(bi->BSSID.octet),
++                0, beacon_proberesp->capab_info, beacon_proberesp->beacon_int,
++                (const u8 *)notify_ie, notify_ielen, signal, GFP_KERNEL);
++#else
+ 	cbss = cfg80211_inform_bss(wiphy, channel, (const u8 *)(bi->BSSID.octet),
+ 		0, beacon_proberesp->capab_info, beacon_proberesp->beacon_int,
+ 		(const u8 *)notify_ie, notify_ielen, signal, GFP_KERNEL);
++#endif
+ 
+ 	if (unlikely(!cbss))
+ 		return -ENOMEM;


### PR DESCRIPTION
Fixes following compile error:

/var/lib/hudson/jobs/OpenELEC/workspace/build.OpenELEC-Generic.x86_64-devel/bcm_sta-6.30.223.248/x86-64/src/wl/sys/wl_cfg80211_hybrid.c:2013:9: error: too few arguments to function 'cfg80211_inform_bss'
  cbss = cfg80211_inform_bss(wiphy, channel, (const u8 *)(bi->BSSID.octet),

