### PR TITLE
Enable binary patching

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -143,7 +143,11 @@ for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
 
   if [ -f "$i" ]; then
     printf "%${BUILD_INDENT}c ${boldgreen}APPLY PATCH${endcolor} ${boldwhite}${PATCH_DESC}${endcolor}   $i\n" ' '>&$SILENT_OUT
-    cat $i | patch -d `echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 >&$VERBOSE_OUT
+    if [ -n "$(grep -E '^GIT binary patch$' $i)" ]; then
+      cat $i | git apply --directory=`echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 --verbose --whitespace=nowarn >&$VERBOSE_OUT
+    else
+      cat $i | patch -d `echo "$PKG_BUILD" | cut -f1 -d\ ` -p1 >&$VERBOSE_OUT
+    fi
   fi
 done
 


### PR DESCRIPTION
This pull request allows binary patches to be applied during the OpenELEC build process.

As one example, pull request [PR6201](https://github.com/xbmc/xbmc/pull/6201) contains a binary patch (image file, test.png, in commit [8438b740](https://github.com/Montellese/xbmc/commit/8438b740f24cd3085b711c8e85f4204001f67ff9)) that would otherwise not be possible to apply on top of OpenELEC without repackaging kodi..