### PR TITLE
Wetekfixes

### DIFF
--- a/projects/WeTek_Play/patches/linux/100-fix-23hzpixelclock.patch
+++ b/projects/WeTek_Play/patches/linux/100-fix-23hzpixelclock.patch
@@ -1,0 +1,11 @@
+--- a/drivers/amlogic/display/vout/tvconf.c.orig	2015-01-14 22:43:43.861634189 +0100
++++ b/drivers/amlogic/display/vout/tvconf.c	2015-01-14 22:46:45.289865564 +0100
+@@ -390,7 +390,7 @@
+ 		.aspect_ratio_den  = 9,
+ 		.sync_duration_num = 2397,
+ 		.sync_duration_den = 100,
+-		.video_clk		   = 74250000,
++		.video_clk		   = 74176000,//74250000,
+ 	},
+ #endif
+     { /* VMODE_4K2K_30HZ */

--- a/projects/WeTek_Play/patches/linux/30-g18dtd.patch
+++ b/projects/WeTek_Play/patches/linux/30-g18dtd.patch
@@ -67,7 +67,7 @@ diff -Naur a/arch/arm/boot/dts/amlogic/meson6_g18.dtd b/arch/arm/boot/dts/amlogi
 +	#address-cells = <1>;
 +	#size-cells = <1>;
 +       chosen {
-+           bootargs = "root=/dev/ram0 rdinit=/init boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 BOOT_IMAGE=kernel.img console=tty0 consoleblank=0 scaling_governor=hotplug scaling_min_freq=200000 scaling_max_freq=1500000 systemd.show_status=auto";
++           bootargs = "root=/dev/ram0 rdinit=/init boot=/dev/mmcblk0p1 disk=/dev/mmcblk0p2 BOOT_IMAGE=kernel.img console=tty0 consoleblank=0 scaling_governor=hotplug scaling_min_freq=200000 scaling_max_freq=1512000 systemd.show_status=auto";
 +       };
 +
 +/// ***************************************************************************************
@@ -1236,7 +1236,7 @@ diff -Naur a/arch/arm/boot/dts/amlogic/meson6_g18.dtd b/arch/arm/boot/dts/amlogi
 +                1080000             1220000     1220000
 +                1200000             1240000     1240000
 +                1320000             1320000     1320000
-+                1500000             1320000     1320000
++                1512000             1320000     1320000
 +            >;
 +	};
 +    };

--- a/projects/WeTek_Play/patches/linux/30-g18dtd.patch
+++ b/projects/WeTek_Play/patches/linux/30-g18dtd.patch
@@ -2690,3 +2690,26 @@ diff -Naur a/arch/arm/boot/dts/amlogic/meson6_g18.dtd b/arch/arm/boot/dts/amlogi
 +	};
 +}; /* end of / */
 +
+--- a/arch/arm/boot/dts/amlogic/meson6_g18.dtd	2015-01-12 00:19:11.729405484 +0100
++++ b/arch/arm/boot/dts/amlogic/meson6_g18.dtd	2015-01-12 00:23:29.396031497 +0100
+@@ -1396,5 +1396,20 @@
+ 		fe1_ts = <0>;
+ 		fe1_dev = <1>;
+ 	};
++
++/// ***************************************************************************************
++///	-	DISP&MM-A/V Amvideocap
++//$$ MODULE = "DISP&MM-Amvideocap"
++//$$ DEVICE="amvideocap"
++//$$ L2 PROP_STR = "status"
++//$$ L3 PROP_U32 4 ="reg"
++ amvideocap{
++ compatible = "amlogic,amvideocap";
++ dev_name = "amvideocap.0";
++ status = "okay";
++ reserve-memory = <0x00a00000>; // 1920 * 1088 * 4 = 8,355,840
++ reserve-iomap = "true";
++ };
++
+ }; /* end of / */
+ 

--- a/projects/WeTek_Play/patches/linux/70-remove-amvideocap-spam.patch
+++ b/projects/WeTek_Play/patches/linux/70-remove-amvideocap-spam.patch
@@ -1,0 +1,141 @@
+--- a/drivers/amlogic/amports/amvideocap.c	2015-01-12 19:17:17.003191369 +0100
++++ b/drivers/amlogic/amports/amvideocap.c	2015-01-12 19:20:50.855003956 +0100
+@@ -163,13 +163,13 @@
+     //printk("vf->type:0x%x\n", vf->type);
+ 
+     if ((vf->type & VIDTYPE_VIU_422) == VIDTYPE_VIU_422) {
+-        printk("********************Into VIDTYPE_VIU_422*********************\n");
++        //printk("********************Into VIDTYPE_VIU_422*********************\n");
+         format =  GE2D_FORMAT_S16_YUV422;
+     } else if ((vf->type & VIDTYPE_VIU_444) == VIDTYPE_VIU_444) {
+-        printk("********************Into VIDTYPE_VIU_444*********************\n");
++        //printk("********************Into VIDTYPE_VIU_444*********************\n");
+         format = GE2D_FORMAT_S24_YUV444;
+     } else if((vf->type & VIDTYPE_VIU_NV21) == VIDTYPE_VIU_NV21){
+-        printk("********************Into VIDTYPE_VIU_NV21*********************\n");
++        //printk("********************Into VIDTYPE_VIU_NV21*********************\n");
+         format= GE2D_FORMAT_M24_NV21;
+     }
+     return format;
+@@ -195,13 +195,13 @@
+         printk("%s: failed to alloc y addr\n", __FUNCTION__);
+         return -1;
+     }
+-    printk("RGB_phy_addr:%x\n", (unsigned int)priv->phyaddr);
++    //printk("RGB_phy_addr:%x\n", (unsigned int)priv->phyaddr);
+     RGB_addr = (unsigned long)priv->vaddr;
+     if (!RGB_addr) {
+         printk("%s: failed to remap y addr\n", __FUNCTION__);
+         return -1;
+     }
+-    printk("RGB_addr:%x\n",  (unsigned int)RGB_addr);
++    //printk("RGB_addr:%x\n",  (unsigned int)RGB_addr);
+ 
+     if(vf == NULL) {
+         printk("%s: vf is NULL\n", __FUNCTION__);
+@@ -250,7 +250,7 @@
+     canvas_read(y_index, &cs0);
+     canvas_read(u_index, &cs1);
+     canvas_read(v_index, &cs2);
+-    printk("y_index=[0x%x]  u_index=[0x%x] cur_index:%x\n", y_index, u_index, cur_index);
++    //printk("y_index=[0x%x]  u_index=[0x%x] cur_index:%x\n", y_index, u_index, cur_index);
+     ge2d_config.src_planes[0].addr = cs0.addr;
+     ge2d_config.src_planes[0].w = cs0.width;
+     ge2d_config.src_planes[0].h = cs0.height;
+@@ -260,7 +260,7 @@
+     ge2d_config.src_planes[2].addr = cs2.addr;
+     ge2d_config.src_planes[2].w = cs2.width;
+     ge2d_config.src_planes[2].h = cs2.height;
+-    printk("w=%d-height=%d cur_index:%x\n", cs0.width, cs0.height, cur_index);
++    //printk("w=%d-height=%d cur_index:%x\n", cs0.width, cs0.height, cur_index);
+ 
+     ge2d_config.src_key.key_enable = 0;
+     ge2d_config.src_key.key_mask = 0;
+@@ -282,7 +282,7 @@
+ 
+ 
+     canvas_read(canvas_idx, &cd);
+-    printk("cd.addr:%x\n", (unsigned int)cd.addr);
++    //printk("cd.addr:%x\n", (unsigned int)cd.addr);
+     ge2d_config.dst_planes[0].addr = cd.addr;
+     ge2d_config.dst_planes[0].w = cd.width;
+     ge2d_config.dst_planes[0].h = cd.height;
+@@ -349,7 +349,7 @@
+     int curindex;
+     vframe_t *vf = vfput;
+     int ret = 0;
+-    printk("%s:start vf=%p,index=%x\n", __func__,vf,index);
++    //printk("%s:start vf=%p,index=%x\n", __func__,vf,index);
+     if (!vf) {
+         ret = amvideocap_capture_get_frame(priv, &vf, &curindex);
+     }else{
+@@ -358,7 +358,7 @@
+     if (ret < 0 || !vf) {
+         return -EAGAIN;
+     }
+-    printk("%s: get vf type=%x\n", __func__,vf->type);
++    //printk("%s: get vf type=%x\n", __func__,vf->type);
+ 
+ 
+ #define CHECK_AND_SETVAL(val,want,def) (val)=(want)>0?(want):(def)
+@@ -374,7 +374,7 @@
+     amvideocap_capture_put_frame(priv, vf);
+ 
+     if (!ret) {
+-        printk("%s: capture ok priv->want.fmt=%d\n", __func__,priv->want.fmt);
++        //printk("%s: capture ok priv->want.fmt=%d\n", __func__,priv->want.fmt);
+         priv->state = AMVIDEOCAP_STATE_FINISHED_CAPTURE;
+         priv->src.width=vf->width;
+         priv->src.height=vf->height;
+@@ -387,7 +387,7 @@
+     }else{
+         priv->state = AMVIDEOCAP_STATE_ERROR;
+     }
+-    printk("amvideocap_capture_one_frame priv->state=%d\n", priv->state);
++    //printk("amvideocap_capture_one_frame priv->state=%d\n", priv->state);
+     return ret;
+ }
+ static int amvideocap_capture_one_frame_callback(unsigned long data, vframe_t *vfput, int index)
+@@ -427,7 +427,7 @@
+             }
+         } else {
+             ret = amvideocap_capture_one_frame(priv, NULL, 0);
+-            printk("amvideocap_capture_one_frame_wait ret=%d\n", ret);
++            //printk("amvideocap_capture_one_frame_wait ret=%d\n", ret);
+         }
+     } while (ret == -EAGAIN && time_before(jiffies, timeout));
+     ext_register_end_frame_callback(NULL);/*del req*/
+@@ -606,7 +606,7 @@
+         printk("set_cached: failed remap_pfn_range\n");
+         return -EAGAIN;
+     }
+-    printk("amvideocap_mmap ok\n");
++    //printk("amvideocap_mmap ok\n");
+     return 0;
+ }
+ static ssize_t amvideocap_read(struct file *file, char __user *buf, size_t count, loff_t * ppos)
+@@ -626,12 +626,12 @@
+             waitdelay=file->f_flags & O_NONBLOCK ? HZ/100  : HZ * 10;
+     }
+     if(!pos){/*trigger a new capture,*/
+-        printk("start amvideocap_read waitdelay=%d\n",waitdelay);
++        //printk("start amvideocap_read waitdelay=%d\n",waitdelay);
+         ret = amvideocap_capture_one_frame_wait(priv,waitdelay);
+-        printk("amvideocap_read=%d,priv->state=%d,priv->vaddr=%p\n", ret,priv->state,priv->vaddr);
++        //printk("amvideocap_read=%d,priv->state=%d,priv->vaddr=%p\n", ret,priv->state,priv->vaddr);
+         if ((ret == 0) && (priv->state==AMVIDEOCAP_STATE_FINISHED_CAPTURE) && (priv->vaddr != NULL)) {
+             int size = min((int)count, (priv->out.byte_per_pix * priv->out.width_aligned* priv->out.height));
+-            printk("priv->out_width=%d priv->out_height=%d priv->outfmt_byteppix=%d, size=%d\n", priv->out.width,priv->out.height,priv->out.byte_per_pix,size);
++            //printk("priv->out_width=%d priv->out_height=%d priv->outfmt_byteppix=%d, size=%d\n", priv->out.width,priv->out.height,priv->out.byte_per_pix,size);
+             copied=copy_to_user(buf, priv->vaddr, size);
+             if(copied){
+                 printk("amvideocap_read %d copy_to_user failed \n",size);
+@@ -646,7 +646,7 @@
+             int maxsize = priv->out.byte_per_pix * priv->out.width_aligned* priv->out.height;
+             if(pos<maxsize){
+                 int rsize=min((int)count,(maxsize-(int)pos));
+-                ///printk("amvideocap_read11 try copy %d,pos=%d\n",rsize,pos);
++                //printk("amvideocap_read11 try copy %d,pos=%d\n",rsize,pos);
+                 copied=copy_to_user(buf, priv->vaddr+pos, rsize);
+                 if(copied){
+                     printk("amvideocap_read11 %d copy_to_user failed \n",rsize);

--- a/projects/WeTek_Play/patches/linux/80-ge2d-fix-ge2d_state-race.patch
+++ b/projects/WeTek_Play/patches/linux/80-ge2d-fix-ge2d_state-race.patch
@@ -1,0 +1,53 @@
+--- a/include/linux/amlogic/ge2d/ge2d_wq.h	2015-01-14 00:46:24.916408987 +0100
++++ b/include/linux/amlogic/ge2d/ge2d_wq.h	2015-01-14 00:45:24.233715480 +0100
+@@ -81,6 +81,7 @@
+    ge2d_event_t			event ;
+    int		 			irq_num;
+    int 		 			ge2d_state;
++   spinlock_t	 			state_lock;  //for sync access to ge2d_state
+    int					process_queue_state;
+ }ge2d_manager_t ;
+ 
+--- a/drivers/amlogic/display/ge2d/ge2d_wq.c	2015-01-14 00:59:18.775744127 +0100
++++ b/drivers/amlogic/display/ge2d/ge2d_wq.c	2015-01-14 00:58:59.440160948 +0100
+@@ -144,9 +144,11 @@
+ 	}while(pos!=head);
+ 	ge2d_manager.last_wq=wq;
+ exit:
++	spin_lock(&ge2d_manager.state_lock);
+ 	if(ge2d_manager.ge2d_state==GE2D_STATE_REMOVING_WQ)
+-	complete(&ge2d_manager.event.process_complete);
++	    complete(&ge2d_manager.event.process_complete);
+ 	ge2d_manager.ge2d_state=GE2D_STATE_IDLE;
++	spin_unlock(&ge2d_manager.state_lock);
+ 	return ret;	
+ }
+ 
+@@ -854,8 +856,17 @@
+ 		spin_unlock(&ge2d_manager.event.sem_lock);
+ 		if((ge2d_manager.current_wq==ge2d_work_queue)&&(ge2d_manager.ge2d_state== GE2D_STATE_RUNNING))
+ 		{
+-			ge2d_manager.ge2d_state=GE2D_STATE_REMOVING_WQ;
+-			wait_for_completion(&ge2d_manager.event.process_complete);
++		        // check again with lock
++		        int wasRunning = 0;
++		        spin_lock(&ge2d_manager.state_lock);
++		        if (ge2d_manager.ge2d_state== GE2D_STATE_RUNNING)
++		        {
++			  ge2d_manager.ge2d_state=GE2D_STATE_REMOVING_WQ;
++			  wasRunning = 1;
++			}
++			spin_unlock(&ge2d_manager.state_lock);
++			if (wasRunning)
++			    wait_for_completion(&ge2d_manager.event.process_complete);
+ 			ge2d_manager.last_wq=NULL;  //condition so complex ,simplify it .
+ 		}//else we can delete it safely.
+ 		
+@@ -902,6 +913,7 @@
+ 	//prepare bottom half		
+ 	
+ 	spin_lock_init(&ge2d_manager.event.sem_lock);
++	spin_lock_init(&ge2d_manager.state_lock);
+ 	sema_init (&ge2d_manager.event.cmd_in_sem,1); 
+ 	init_waitqueue_head (&ge2d_manager.event.cmd_complete);
+ 	init_completion(&ge2d_manager.event.process_complete);

--- a/projects/WeTek_Play/patches/linux/90-meson6-maxclock-unclamp.patch
+++ b/projects/WeTek_Play/patches/linux/90-meson6-maxclock-unclamp.patch
@@ -1,0 +1,11 @@
+--- a/arch/arm/mach-meson6/clock.c.orig	2015-01-14 18:04:05.216364113 +0100
++++ b/arch/arm/mach-meson6/clock.c	2015-01-14 18:04:22.807966326 +0100
+@@ -1419,7 +1419,7 @@
+ #endif /* CONFIG_SMP */
+ 	int error = 0;
+ 
+-	int cpu_freq_limit = 1200000000;
++	int cpu_freq_limit = 1512000000;
+ 	if (rate < 1000)
+ 		rate *= 1000000;
+ 

--- a/projects/WeTek_Play/patches/linux/95-meson6-fixhdmitx-audiolock-1080p24.patch
+++ b/projects/WeTek_Play/patches/linux/95-meson6-fixhdmitx-audiolock-1080p24.patch
@@ -1,0 +1,36 @@
+--- a/arch/arm/mach-meson6/hdmi_tx_hw/hdmi_tx_hw.c.orig	2015-01-15 22:15:55.446965413 +0100
++++ b/arch/arm/mach-meson6/hdmi_tx_hw/hdmi_tx_hw.c	2015-01-15 22:16:13.378517737 +0100
+@@ -1999,6 +1999,7 @@
+ {
+     unsigned int audio_N_para = 6272;
+     unsigned int audio_N_tolerance = 3;
++    unsigned int multiplier = 1;
+ //    unsigned int audio_CTS = 30000;
+     
+     hdmi_print(INF, AUD "audio channel num is %d\n", hdmitx_device->cur_audio_param.channel_num);
+@@ -2122,15 +2123,22 @@
+     hdmi_print(INF, AUD "reset audio N para\n");
+     switch(audio_param->sample_rate){
+         case FS_44K1:
+-            audio_N_para = 6272 * 2;
+-            break;
+         case FS_48K:
+-            audio_N_para = 6144 * 2;
++            multiplier = 2;
+             break;
+         default:
+             break;
+     }
+ 
++    //1080p24hz mode is a special case - at least for yamaha amps
++    //it needs 3 times the normal npara to get a stable audio lock
++    if((hdmitx_device->cur_VIC == HDMI_1080p24))
++    {
++      multiplier = 3;
++    }
++
++    audio_N_para *= multiplier;
++
+     //TODO. Different audio type, maybe have different settings
+     switch(audio_param->type){
+         case CT_PCM:


### PR DESCRIPTION
Those contain the following fixes for the wetek.play - this is all kernel related:
1.  pixelclock for 23.976Hz mode was wrong
2. yamaha amp (and maybe others) couldn't lock audio in 1080p24 mode (tried it with 44k1, 48k and 96k - none worked before - all work with my patch)
3. allow 1.5ghz for the meson6 cpu (there was still a clamp to 12000 internally)
4. fix race condition in ge2d (which made boblight-aml stuck after some time of usage)
5. add the amvideocap device to the devicetree (needed for boblight-aml).