### PR TITLE
New upstream version requires change of makefile patch

### DIFF
--- a/packages/multimedia/vdr-plugin-restfulapi/package.mk
+++ b/packages/multimedia/vdr-plugin-restfulapi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="vdr-plugin-restfulapi"
-PKG_VERSION="20150114180413unstable"
+PKG_VERSION="20150115225816unstable"
 PKG_REV="0yavdr0~trusty"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -42,11 +42,6 @@ pre_configure_target() {
 pre_make_target() {
   # dont build parallel
   MAKEFLAGS=-j1
-}
-
-pre_build_target() {                                                                                                                                                                                               
-  WIRBELSCAN_DIR=$(get_build_dir vdr-wirbelscan)
-  ln -sf $WIRBELSCAN_DIR/wirbelscan_services.h $PKG_BUILD
 }
 
 make_target() {

--- a/packages/multimedia/vdr-plugin-restfulapi/patches/vdr-plugin-restfulapi-01_makefile.patch
+++ b/packages/multimedia/vdr-plugin-restfulapi/patches/vdr-plugin-restfulapi-01_makefile.patch
@@ -1,5 +1,4 @@
-diff -Nur vdr-plugin-restfulapi.orig/Makefile vdr-plugin-restfulapi/Makefile
---- vdr-plugin-restfulapi.orig/Makefile	2015-01-14 17:56:59.017916074 +0100
+--- vdr-plugin-restfulapi.orig/Makefile	2015-01-15 22:13:47.000000000 +0100
 +++ vdr-plugin-restfulapi/Makefile	2015-01-14 23:04:43.361230469 +0100
 @@ -16,21 +16,16 @@
  ### The directory environment:
@@ -25,13 +24,12 @@ diff -Nur vdr-plugin-restfulapi.orig/Makefile vdr-plugin-restfulapi/Makefile
  
  ### Allow user defined options to overwrite defaults:
  
-@@ -47,11 +42,11 @@
+@@ -47,9 +42,11 @@
  
  ### Includes and Defines (add further entries here):
  
--INCLUDES += -I/usr/include/vdr/plugins/wirbelscan
 +INCLUDES += -I$(VDRDIR)/include
- 
++
  DEFINES += -DPLUGIN_NAME_I18N='"$(PLUGIN)"'
  
 -LIBS    += $(shell cxxtools-config --libs) -lcxxtools-http
@@ -39,7 +37,7 @@ diff -Nur vdr-plugin-restfulapi.orig/Makefile vdr-plugin-restfulapi/Makefile
  CONFDIR  = $(call PKGCFG,configdir)
  PLGCONFDIR = $(CONFDIR)/plugins/$(PLUGIN)
  
-@@ -108,6 +103,7 @@
+@@ -106,6 +103,7 @@
  
  $(SOFILE): $(OBJS)
  	$(CXX) $(CXXFLAGS) $(LDFLAGS) -shared $(OBJS) -o $@ -Wl,--no-whole-archive $(LIBS)


### PR DESCRIPTION
New upstream version has now Documentation for the wirbelscan extension and feature complete.
At least for now ;)