### PR TITLE
Add PKG_SOURCE_NAME option

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -33,8 +33,8 @@ if [ -n "$PKG_URL" ]; then
     PACKAGE="$SOURCES/$1/$SOURCE_NAME"
     PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
     [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-    [ "$PKG_SOURCE_NAME" != "" ] && OUTPUT_OPTION="-O $SOURCES/$1/$PKG_SOURCE_NAME"
-    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1 $OUTPUT_OPTION"
+    [ -n "$PKG_SOURCE_NAME" ]  && WGET_OUTPUT_OPTION="-O $SOURCES/$1/$PKG_SOURCE_NAME"
+    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1 $WGET_OUTPUT_OPTION"
 
     NBWGET="1"
 

--- a/scripts/get
+++ b/scripts/get
@@ -29,11 +29,12 @@ fi
 
 if [ -n "$PKG_URL" ]; then
   for i in $PKG_URL; do
-    SOURCE_NAME="`basename $i`"
+    SOURCE_NAME=${PKG_SOURCE_NAME:-`basename $i`}
     PACKAGE="$SOURCES/$1/$SOURCE_NAME"
     PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
     [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1"
+    [ "$PKG_SOURCE_NAME" != "" ] && OUTPUT_OPTION="-O $SOURCES/$1/$PKG_SOURCE_NAME"
+    WGET_CMD="wget --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1 $OUTPUT_OPTION"
 
     NBWGET="1"
 


### PR DESCRIPTION
This patch adds a PKG_SOURCE_NAME option to the package.mk file

This allows you to download a decorated url from the PKG_URL but not use the decoration, an example of this is:

PKG_URL="https://api.github.com/repos/FiveNinjas/Skin/tarball/$PKG_NAME-$PKG_VERSION?access_token=biglongapikeyyougetfromgithub"
PKG_SOURCE_NAME="$PKG_NAME-$PKG_VERSION.tar.gz"
 
unpack() {
  mkdir -p $BUILD/$PKG_NAME-$PKG_VERSION
  tar xfz sources/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz --directory $BUILD/$PKG_NAME-$PKG_VERSION
  mv $BUILD/$PKG_NAME-$PKG_VERSION/FiveNinjas*/* $BUILD/$PKG_NAME-$PKG_VERSION/
}


I had to insert the unpack because github doesn't name the enclosed directory in the right format