### PR TITLE
systemd service ordering fixes

### DIFF
--- a/packages/mediacenter/kodi/system.d/kodi-cleanlogs.service
+++ b/packages/mediacenter/kodi/system.d/kodi-cleanlogs.service
@@ -2,7 +2,7 @@
 Description=Kodi clean debug logs
 ConditionKernelCommandLine=!debugging
 ConditionPathExists=!/storage/.cache/debug.openelec
-DefaultDependencies=no
+Before=kodi.service
 
 [Service]
 Type=oneshot
@@ -10,4 +10,4 @@ ExecStart=-/bin/sh -c 'rm -rf /storage/.kodi/userdata/addon_data/*/*.log /storag
 RemainAfterExit=yes
 
 [Install]
-WantedBy=sysinit.target
+WantedBy=kodi.service

--- a/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
+++ b/packages/mediacenter/kodi/system.d/kodi-waitonnetwork.service
@@ -1,8 +1,7 @@
 [Unit]
 Description=Wait on network
 After=connman.service
-Before=xorg.service fbset.service
-
+Before=kodi-autostart.service kodi.service
 ConditionPathExists=/storage/.cache/openelec/network_wait
 
 [Service]

--- a/packages/network/connman/system.d/connman.service
+++ b/packages/network/connman/system.d/connman.service
@@ -1,7 +1,6 @@
 [Unit]
 Description=Connection service
 Requires=dbus.socket
-After=debugconfig.service
 After=dbus.socket
 Before=network.target
 Wants=network.target

--- a/packages/sysutils/busybox/system.d/var-log-debug.service
+++ b/packages/sysutils/busybox/system.d/var-log-debug.service
@@ -1,9 +1,8 @@
 [Unit]
 Description=Debug /var/log relink
 DefaultDependencies=false
-After=systemd-tmpfiles-setup.service var.mount
+After=var.mount
 Before=systemd-journal-flush.service
-
 ConditionKernelCommandLine=!installer
 ConditionKernelCommandLine=|debugging
 ConditionPathExists=|/storage/.cache/debug.openelec

--- a/packages/sysutils/systemd/system.d/debugconfig.service
+++ b/packages/sysutils/systemd/system.d/debugconfig.service
@@ -1,15 +1,14 @@
 [Unit]
 Description=Setup debug config
 DefaultDependencies=no
-Before=local-fs.target shutdown.target
-Conflicts=shutdown.target
-
+After=systemd-tmpfiles-setup.service
 ConditionKernelCommandLine=|debugging
 ConditionPathExists=|/storage/.cache/debug.openelec
 
 [Service]
 Type=oneshot
-ExecStart=/bin/sh -c 'mkdir -p /run/openelec/debug; cp /usr/share/debugconf/*.conf /run/openelec/debug'
+ExecStart=/bin/sh -c 'cp /usr/share/debugconf/*.conf /run/openelec/debug'
+RemainAfterExit=yes
 
 [Install]
-WantedBy=local-fs.target
+WantedBy=sysinit.target

--- a/packages/sysutils/systemd/system.d/userconfig.service
+++ b/packages/sysutils/systemd/system.d/userconfig.service
@@ -1,6 +1,7 @@
 [Unit]
 Description=Setup User config dir
 DefaultDependencies=no
+After=systemd-tmpfiles-setup.service
 
 [Service]
 Type=oneshot


### PR DESCRIPTION
those are systemd service ordering fixes backported from master

needs testing.

should probably fix sshd issue reported on forums (and other random services that depend on tmpfiles) not started due to tmpfiles-setup failing