### PR TITLE
Radeon: disable RADEON_GEM_GTT_WC for Kabini and Aruba

### DIFF
--- a/packages/linux/patches/3.17.7/linux-999.06-radeon-upstream-fixes.patch
+++ b/packages/linux/patches/3.17.7/linux-999.06-radeon-upstream-fixes.patch
@@ -1,0 +1,21 @@
+commit 108aa376ae52e634f6465424554fa9319c0a7a61
+Author: Michel Dänzer <michel.daenzer@amd.com>
+Date:   Fri Oct 10 18:01:18 2014 +0900
+
+    drm/radeon: Ignore RADEON_GEM_GTT_WC on Kabini and Aruba
+
+diff --git a/drivers/gpu/drm/radeon/radeon_object.c b/drivers/gpu/drm/radeon/radeon_object.c
+index 7f3b1e1..aea7c6e 100644
+--- a/drivers/gpu/drm/radeon/radeon_object.c
++++ b/drivers/gpu/drm/radeon/radeon_object.c
+@@ -235,6 +235,10 @@ int radeon_bo_create(struct radeon_device *rdev,
+ 	if (!(rdev->flags & RADEON_IS_PCIE))
+ 		bo->flags &= ~(RADEON_GEM_GTT_WC | RADEON_GEM_GTT_UC);
+ 
++	/* XXX: Write-combined CPU mappings of GTT seem broken on Kabini and Aruba */
++	if (rdev->family == CHIP_KABINI || rdev->family == CHIP_ARUBA)
++		bo->flags &= ~RADEON_GEM_GTT_WC;
++
+ 	radeon_ttm_placement_from_domain(bo, domain);
+ 	/* Kernel allocation are uninterruptible */
+ 	down_read(&rdev->pm.mclk_lock);


### PR DESCRIPTION
Backport of https://github.com/OpenELEC/OpenELEC.tv/pull/3822 for 3.17.7