### PR TITLE
linux: re-add still needed patch

### DIFF
--- a/packages/linux/patches/3.18.3/linux-999.04-revert-xhci-Set-scatter-gather-limit.patch
+++ b/packages/linux/patches/3.18.3/linux-999.04-revert-xhci-Set-scatter-gather-limit.patch
@@ -1,0 +1,43 @@
+From b6d7efd33fd2843fbafe2b2d4b8119b217779a6a Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sat, 3 May 2014 00:08:24 +0200
+Subject: [PATCH] Revert "Revert "xhci: Set scatter-gather limit to avoid
+ failed block writes.""
+
+This reverts commit 47f467ac740ebf0475a5176ddb1741acba6aad4e.
+---
+ drivers/usb/host/xhci.c | 4 ++--
+ drivers/usb/host/xhci.h | 2 +-
+ 2 files changed, 3 insertions(+), 3 deletions(-)
+
+diff --git a/drivers/usb/host/xhci.c b/drivers/usb/host/xhci.c
+index 5a646a6..cfa5995 100644
+--- a/drivers/usb/host/xhci.c
++++ b/drivers/usb/host/xhci.c
+@@ -4716,8 +4716,8 @@ int xhci_gen_setup(struct usb_hcd *hcd, xhci_get_quirks_t get_quirks)
+ 	struct device		*dev = hcd->self.controller;
+ 	int			retval;
+ 
+-	/* Accept arbitrarily long scatter-gather lists */
+-	hcd->self.sg_tablesize = ~0;
++	/* Limit the block layer scatter-gather lists to half a segment. */
++	hcd->self.sg_tablesize = TRBS_PER_SEGMENT / 2;
+ 
+ 	/* support to build packet from discontinuous buffers */
+ 	hcd->self.no_sg_constraint = 1;
+diff --git a/drivers/usb/host/xhci.h b/drivers/usb/host/xhci.h
+index 03c74b7..c283cf1 100644
+--- a/drivers/usb/host/xhci.h
++++ b/drivers/usb/host/xhci.h
+@@ -1260,7 +1260,7 @@ union xhci_trb {
+  * since the command ring is 64-byte aligned.
+  * It must also be greater than 16.
+  */
+-#define TRBS_PER_SEGMENT	64
++#define TRBS_PER_SEGMENT	256
+ /* Allow two commands + a link TRB, along with any reserved command TRBs */
+ #define MAX_RSVD_CMD_TRBS	(TRBS_PER_SEGMENT - 3)
+ #define TRB_SEGMENT_SIZE	(TRBS_PER_SEGMENT*16)
+-- 
+1.9.1
+


### PR DESCRIPTION
this fixes some usb tv tuners on usb3 ports

should fix #3833
and maybe #3795
