### PR TITLE
Fix divide by zero crash

### DIFF
--- a/packages/linux/patches/3.18.4/linux-227-ds3000-invalid-symbol-rate.patch
+++ b/packages/linux/patches/3.18.4/linux-227-ds3000-invalid-symbol-rate.patch
@@ -1,0 +1,18 @@
+diff -rupN a/drivers/media/dvb-frontends/ds3000.c b/drivers/media/dvb-frontends/ds3000.c
+--- a/drivers/media/dvb-frontends/ds3000.c	2015-01-28 23:24:59.000000000 +0100
++++ b/drivers/media/dvb-frontends/ds3000.c	2015-01-29 21:57:56.000000000 +0100
+@@ -958,6 +958,14 @@ static int ds3000_set_frontend(struct dv
+ 	/* enable ac coupling */
+ 	ds3000_writereg(state, 0x25, 0x8a);
+ 
++	dprintk("%s() frequency:%u symbol_rate:%u\n", __func__, c->frequency, c->symbol_rate);
++
++	if (c->symbol_rate < ds3000_ops.info.symbol_rate_min || c->symbol_rate > ds3000_ops.info.symbol_rate_max ) {
++		dprintk("%s() symbol_rate %u out of range (%u ... %u)\n", __func__, c->symbol_rate, 
++			ds3000_ops.info.symbol_rate_min, ds3000_ops.info.symbol_rate_max);
++		return 1;
++	}
++
+ 	/* enhance symbol rate performance */
+ 	if ((c->symbol_rate / 1000) <= 5000) {
+ 		value = 29777 / (c->symbol_rate / 1000) + 1;


### PR DESCRIPTION
When ds3000_set_frontend is called with 0 symbol rate the module would crash with a divide by
zero error.
Added simple symbol rate validation.
Tvheadend was triggering this bug and crashing openelec.