### PR TITLE
wetek_play: avl6211: let userspace knows we support dvbs2

### DIFF
--- a/projects/WeTek_Play/patches/linux/20-wetek_dvb_code.patch
+++ b/projects/WeTek_Play/patches/linux/20-wetek_dvb_code.patch
@@ -1977,7 +1977,7 @@ diff -Naur a/drivers/amlogic/wetek/avl6211.c b/drivers/amlogic/wetek/avl6211.c
 +			FE_CAN_FEC_1_2 | FE_CAN_FEC_2_3 | FE_CAN_FEC_3_4 |
 +			FE_CAN_FEC_4_5 | FE_CAN_FEC_5_6 | FE_CAN_FEC_6_7 |
 +			FE_CAN_FEC_7_8 | FE_CAN_FEC_8_9 | FE_CAN_FEC_AUTO |
-+			FE_CAN_QPSK    | FE_CAN_RECOVER
++			FE_CAN_QPSK    | FE_CAN_RECOVER | FE_CAN_2G_MODULATION
 +	},
 +
 +	.init = avl6211_init,


### PR DESCRIPTION
... at least vdr/wirbelscan is confused and thinks there is no dvb-s2 support