### PR TITLE
lirc: fixed ir blasting

### DIFF
--- a/packages/sysutils/lirc/scripts/lircd_helper
+++ b/packages/sysutils/lirc/scripts/lircd_helper
@@ -45,10 +45,10 @@ case "$ACTION" in
         elif [ -e "/etc/lirc/$CONFIG" ]; then
           LIRCD_CONFIG="$LIRCD_CONFIG /etc/lirc/$CONFIG"
         else
-          exit 1
+          exit 0
         fi
       else
-        exit 1
+        exit 0
       fi
 
       exec $LIRCD $LIRCD_CONFIG

--- a/packages/sysutils/lirc/udev.d/98-lircd.rules
+++ b/packages/sysutils/lirc/udev.d/98-lircd.rules
@@ -18,9 +18,9 @@ LABEL="begin"
 # Ask lircd_helper to lirc devices.
 #-------------------------------------------------------------------------------
 
-#SUBSYSTEM=="lirc", \
-#  ENV{lircd_driver}="default", \
-#  ENV{lircd_conf}="lircd.conf"
+SUBSYSTEM=="lirc", \
+  ENV{lircd_driver}="default", \
+  ENV{lircd_conf}="lircd.conf"
 
 ### Microsoft Xbox DVD dongle
 SUBSYSTEM=="lirc", DRIVERS=="lirc_xbox", \


### PR DESCRIPTION
Hi,

This fixes ir blasting and the possibility to use custom .config/lircd.conf for any remote.

This has been broken for a long time but the wiki guides still refers to this method.

