### PR TITLE
GCC 4.9 has support for armv7ve

### DIFF
--- a/config/arch.arm
+++ b/config/arch.arm
@@ -32,12 +32,9 @@
       SIMD_SUPPORT="no"
       ;;
     cortex-a7|cortex-a15)
-      TARGET_SUBARCH=armv7-a
+      TARGET_SUBARCH=armv7ve
       TARGET_ABI=eabi
-      # It's not currently possible to specify the exact architecture variant (-mcpu)
-      # that A7/A15 supports in the command line so use -mtune here.
-      # see http://gcc.gnu.org/bugzilla/show_bug.cgi?id=57907
-      TARGET_EXTRA_FLAGS="-mtune=$TARGET_CPU"
+      TARGET_EXTRA_FLAGS="-mcpu=$TARGET_CPU"
       TARGET_FPU_FLAGS="-mfloat-abi=$TARGET_FLOAT -mfpu=$TARGET_FPU"
       SIMD_SUPPORT="yes"
       ;;


### PR DESCRIPTION
GCC 4.9 added support for armv7ve, use it for cortex-a7 and cortex-a15