### PR TITLE
Use neon-vfpv4 fpu on RPi2

### DIFF
--- a/projects/RPi2/options
+++ b/projects/RPi2/options
@@ -30,7 +30,7 @@
         # fpa fpe2 fpe3 maverick vfp vfpv3 vfpv3-fp16 vfpv3-d16 vfpv3-d16-fp16
         # vfpv3xd vfpv3xd-fp16 neon neon-fp16 vfpv4 vfpv4-d16 fpv4-sp-d16
         # neon-vfpv4.
-        TARGET_FPU="neon"
+        TARGET_FPU="neon-vfpv4"
         ;;
     esac
 


### PR DESCRIPTION
RPi2 supports vfpv4 and the use of neon-vfpv4 produces a working build
Not sure if one is better then the other