### PR TITLE
linux: Update saa716x PCIe interface chipset patch

### DIFF
--- a/packages/linux/patches/3.19/linux-950-saa716x_PCIe_interface_chipset.patch
+++ b/packages/linux/patches/3.19/linux-950-saa716x_PCIe_interface_chipset.patch
@@ -1383,10 +1383,10 @@ index 0000000..6b52fc1
 +		break;
 +	}
 +
-+	err = stv090x_set_gpio(fe, 2, 0, en, 0);
++	err = skystar2_stv090x_config.set_gpio(fe, 2, 0, en, 0);
 +	if (err < 0)
 +		goto exit;
-+	err = stv090x_set_gpio(fe, 3, 0, sel, 0);
++	err = skystar2_stv090x_config.set_gpio(fe, 3, 0, sel, 0);
 +	if (err < 0)
 +		goto exit;
 +
@@ -1405,7 +1405,7 @@ index 0000000..6b52fc1
 +	else
 +		value = 0;
 +
-+	err = stv090x_set_gpio(fe, 4, 0, value, 0);
++	err = skystar2_stv090x_config.set_gpio(fe, 4, 0, value, 0);
 +	if (err < 0)
 +		goto exit;
 +


### PR DESCRIPTION
(driver support for TechniSat SkyStar 2 eXpress)

based on https://git.kernel.org/cgit/linux/kernel/git/torvalds/linux.git/commit/?id=a2ea5561173f5c2c14e6050b261d225acd99fa08