### PR TITLE
Update 98-eventlircd.rules (PS3 BD remote hardware Version #2)

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -208,6 +208,10 @@ ATTRS{name}=="Nintendo Wii Remote", \
 ATTRS{name}=="BD Remote Control", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="ps3remote.evmap"
+#PS3 BD Remote Version 2 (Bluetooth AND infrared 3 in 1 remote)
+ATTRS{name}=="Sony Computer Entertainment Inc BD Remote Control", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="ps3remote.evmap"
 
 LABEL="end-bluetooth"
 


### PR DESCRIPTION
Tweak to support the newer PS3 BD (with IR) remote which identifies differently. 
```
Version 1
[  142.524200] input: BD Remote Control as /devices/platform/bcm2708_usb/usb1/1-1/1-1.3/1-1.3:1.0/bluetooth/hci0/hci0:43/0005:054C:0306.0001/input/i$
[  142.533894] sony 0005:054C:0306.0001: input,hidraw0: BLUETOOTH HID v1.00 Gamepad [BD Remote Control] on 00:00:00:00:00:00
-------------
Version 2
[ 7476.763657] input: Sony Computer Entertainment Inc BD Remote Control as /devices/platform/bcm2708_usb/usb1/1-1/1-1.3/1-1.3.3/1-1.3.3:1.0/bluetooth/hci0/hci0:11/0005:054C:0306.000A/input/input9
[ 7476.764266] sony 0005:054C:0306.000A: input,hidraw4: BLUETOOTH HID v1.10 Gamepad [Sony Computer Entertainment Inc BD Remote Control] on 00:00:00:00:00:00
```
