### PR TITLE
Change the default settings level to "advanced"

### DIFF
--- a/packages/mediacenter/kodi/config/guisettings.xml
+++ b/packages/mediacenter/kodi/config/guisettings.xml
@@ -2,4 +2,7 @@
   <debug>
     <screenshotpath pathversion="1">$HOME/screenshots/</screenshotpath>
   </debug>
+  <general>
+    <settinglevel>2</settinglevel>
+  </general>
 </settings>


### PR DESCRIPTION
OpenELEC is designed as a living room appliance and most user use it as such. This means that most of the users will be using HDMI audio and passthrough.

This allows the passthrough options to be available immediately and avoid people from asking stupid questions about how to enable passthrough audio.