### PR TITLE
lcdproc: don't build parallel

### DIFF
--- a/packages/sysutils/lcdproc/package.mk
+++ b/packages/sysutils/lcdproc/package.mk
@@ -39,6 +39,11 @@ fi
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-libusb --enable-drivers=$LCD_DRIVER,!curses,!svga --enable-seamless-hbars"
 
+pre_make_target() {
+  # dont build parallel
+    MAKEFLAGS=-j1
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/etc/lcd*.conf
   rm -rf $INSTALL/usr/bin


### PR DESCRIPTION
Builds sometimes fail trying to cp files that don't yet exist when using more than -j1.