### PR TITLE
New script - scripts/uninstall

### DIFF
--- a/scripts/uninstall
+++ b/scripts/uninstall
@@ -1,0 +1,105 @@
+#!/bin/bash
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+. config/options $1
+
+if [ -z "$1" ]; then
+  echo "usage: $0 package_name[:<host|target|init|bootstrap>]"
+  exit 1
+fi
+
+  PACKAGE_NAME=$(echo $1 | awk -F : '{print $1}')
+  TARGET=$(echo $1 | awk -F : '{print $2}')
+  if [ -z "$TARGET" ]; then
+    TARGET="target"
+  fi
+
+if [ -n "$PKG_ARCH" -a ! "$PKG_ARCH" = "any" ]; then
+  echo "$PKG_ARCH" | grep -q "$TARGET_ARCH" || exit 0
+  echo "$PKG_ARCH" | grep -q "\-$TARGET_ARCH" && exit 0
+fi
+
+STAMP=$STAMPS/$PACKAGE_NAME/build_$TARGET
+
+if [ -f $STAMP ]; then
+
+    # include buildfile
+    . $PKG_DIR/package.mk
+
+    # virtual packages dont must be build, they only contains dependencies, so dont go further here
+    if [ ! "$PKG_SECTION" = "virtual" ]; then
+
+      # setup configure script
+      if [ -z "$PKG_CONFIGURE_SCRIPT" ]; then
+        PKG_CONFIGURE_SCRIPT="$ROOT/$PKG_BUILD/configure"
+      else
+        PKG_CONFIGURE_SCRIPT="$ROOT/$PKG_BUILD/$PKG_CONFIGURE_SCRIPT"
+      fi
+      if [ -z "$PKG_CMAKE_SCRIPT" ]; then
+        PKG_CMAKE_SCRIPT="$ROOT/$PKG_BUILD/CMakeLists.txt"
+      else
+        PKG_CMAKE_SCRIPT="$ROOT/$PKG_BUILD/$PKG_CMAKE_SCRIPT"
+      fi
+
+      # ensure $PKG_BUILD is there. (installer? PKG_URL="")
+      if [ ! -d $PKG_BUILD ] ; then
+        exit 0
+      fi
+
+      cd $PKG_BUILD
+
+      if [ "$TARGET" = "target" ]; then
+        if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" ]; then
+          cd .$TARGET_NAME
+        fi
+      elif [ "$TARGET" = "host" ]; then
+        if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" ]; then
+          cd .$HOST_NAME
+        fi
+      elif [ "$TARGET" = "init" ]; then
+        if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" ]; then
+          cd .$TARGET_NAME-init
+        fi
+      elif [ "$TARGET" = "bootstrap" ]; then
+        if [ -f "$PKG_CONFIGURE_SCRIPT" -o -f "$PKG_CMAKE_SCRIPT" ]; then
+          cd .$TARGET_NAME-bootstrap
+        fi
+      fi
+
+      MAKEUNINSTALL="$ROOT/$TOOLCHAIN/bin/make -j1 DESTDIR=$SYSROOT_PREFIX uninstall"
+
+      if [ "$TARGET" = "target" ]; then
+        $MAKEUNINSTALL $PKG_MAKEINSTALL_OPTS_TARGET
+      elif [ "$TARGET" = "host" ]; then
+        make uninstall $PKG_MAKEINSTALL_OPTS_HOST
+      elif [ "$TARGET" = "init" ]; then
+        make uninstall DESTDIR=$INSTALL $PKG_MAKEINSTALL_OPTS_INIT
+      elif [ "$TARGET" = "bootstrap" ]; then
+        $MAKEUNINSTALL $PKG_MAKEINSTALL_OPTS_BOOTSTRAP
+      fi
+
+      cd $ROOT
+    fi  # ! "$PKG_SECTION" = "virtual"
+
+    if [ -f "$STAMP" ]; then
+      rm -f $STAMP
+    fi
+
+fi


### PR DESCRIPTION
Just thought I would share this.

It's helpful when building new packages to test different config options (shared, static). It allows easy removal of packages from the toolchain and sysroot.

Basically just scripts/build but opposite. Not sure why this doesn't exist already but maybe I'm just missing something.

```
PROJECT=RPi ARCH=arm ./scripts/uninstall parted
```
```
PROJECT=RPi ARCH=arm ./scripts/uninstall parted:host
```