### PR TITLE
linux: fix TechnoTrend CT2-4400v2 clock for RPi2

### DIFF
--- a/packages/linux/patches/3.18.8/linux-228-fix-tt-ct2-4400v2.patch
+++ b/packages/linux/patches/3.18.8/linux-228-fix-tt-ct2-4400v2.patch
@@ -1,0 +1,17 @@
+diff -urN a/drivers/media/usb/dvb-usb/cxusb.c b/drivers/media/usb/dvb-usb/cxusb.c
+--- a/drivers/media/usb/dvb-usb/cxusb.c      2015-03-03 22:16:42.000000000 +0200
++++ b/drivers/media/usb/dvb-usb/cxusb.c 2015-03-03 22:21:25.408692492 +0200
+@@ -1510,6 +1510,12 @@
+	si2168_config.i2c_adapter = &adapter;
+	si2168_config.fe = &adap->fe_adap[0].fe;
+	si2168_config.ts_mode = SI2168_TS_PARALLEL;
++
++	/* CT2-4400v2 TS gets corrupted without this */
++	if (d->udev->descriptor.idProduct ==
++		USB_PID_TECHNOTREND_TVSTICK_CT2_4400)
++		si2168_config.ts_mode |= 0x40;
++
+	memset(&info, 0, sizeof(struct i2c_board_info));
+	strlcpy(info.type, "si2168", I2C_NAME_SIZE);
+	info.addr = 0x64;
+


### PR DESCRIPTION
RPi2 was still having no support for TechnoTrend CT2-4400v2 (which was introduced in kernel 3.19). This small patch enables gapped clock for CT2-4400 and CT2-4400v2, so that both of them work properly.