### PR TITLE
libva: x11: dri2: fix double Unlocks/SyncHandle

### DIFF
--- a/packages/multimedia/libva/patches/libva-0001-x11-dri2-fix-double-Unlocks-SyncHandle.patch
+++ b/packages/multimedia/libva/patches/libva-0001-x11-dri2-fix-double-Unlocks-SyncHandle.patch
@@ -1,0 +1,35 @@
+From dd4fe20c87143533224520bd42fd23b116d58edc Mon Sep 17 00:00:00 2001
+From: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+Date: Tue, 3 Mar 2015 22:19:45 +0000
+Subject: [PATCH] x11: dri2: fix double Unlocks/SyncHandle
+
+Signed-off-by: Lionel Landwerlin <lionel.g.landwerlin@intel.com>
+---
+ va/x11/va_dri2.c | 4 ----
+ 1 file changed, 4 deletions(-)
+
+diff --git a/va/x11/va_dri2.c b/va/x11/va_dri2.c
+index b4a4398..a395260 100644
+--- a/va/x11/va_dri2.c
++++ b/va/x11/va_dri2.c
+@@ -308,8 +308,6 @@ VA_DRI2Buffer *VA_DRI2GetBuffers_internal(XExtDisplayInfo *info,
+ 	p[i] = attachments[i];
+ 
+     if (!_XReply(dpy, (xReply *)&rep, 0, xFalse)) {
+-	UnlockDisplay(dpy);
+-	SyncHandle();
+ 	return NULL;
+     }
+ 
+@@ -323,8 +321,6 @@ VA_DRI2Buffer *VA_DRI2GetBuffers_internal(XExtDisplayInfo *info,
+     buffers = Xmalloc(rep.count * sizeof buffers[0]);
+     if (buffers == NULL) {
+ 	_XEatData(dpy, rep.count * sizeof repBuffer);
+-	UnlockDisplay(dpy);
+-	SyncHandle();
+ 	return NULL;
+     }
+ 
+-- 
+2.1.4
+


### PR DESCRIPTION
See: http://lists.freedesktop.org/archives/libva/2015-March/003217.html

Master PR of  https://github.com/OpenELEC/OpenELEC.tv/pull/3976