### PR TITLE
linux: Use legacy turbo

### DIFF
--- a/packages/linux/patches/3.19.1/linux-999-i915-use-legacy-turbo.patch
+++ b/packages/linux/patches/3.19.1/linux-999-i915-use-legacy-turbo.patch
@@ -1,0 +1,30 @@
+From 89973c56cefd075a0209d63f87ecfbbe7245d100 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Fri, 6 Mar 2015 17:26:41 +0100
+Subject: [PATCH] i915_irq: enable legacy turbo
+
+---
+ drivers/gpu/drm/i915/i915_irq.c | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/drivers/gpu/drm/i915/i915_irq.c b/drivers/gpu/drm/i915/i915_irq.c
+index b051a23..5cceebf 100644
+--- a/drivers/gpu/drm/i915/i915_irq.c
++++ b/drivers/gpu/drm/i915/i915_irq.c
+@@ -4340,12 +4340,7 @@ void intel_irq_init(struct drm_i915_private *dev_priv)
+ 	INIT_WORK(&dev_priv->rps.work, gen6_pm_rps_work);
+ 	INIT_WORK(&dev_priv->l3_parity.error_work, ivybridge_parity_work);
+ 
+-	/* Let's track the enabled rps events */
+-	if (IS_VALLEYVIEW(dev_priv) && !IS_CHERRYVIEW(dev_priv))
+-		/* WaGsvRC0ResidencyMethod:vlv */
+-		dev_priv->pm_rps_events = GEN6_PM_RP_UP_EI_EXPIRED;
+-	else
+-		dev_priv->pm_rps_events = GEN6_PM_RPS_EVENTS;
++	dev_priv->pm_rps_events = GEN6_PM_RPS_EVENTS;
+ 
+ 	setup_timer(&dev_priv->gpu_error.hangcheck_timer,
+ 		    i915_hangcheck_elapsed,
+-- 
+1.9.1
+


### PR DESCRIPTION
This is the baytrail fix which was already pushed to 5.0 in the 3.19.x version, see: https://bugs.freedesktop.org/show_bug.cgi?id=88012