### PR TITLE
linux: eMMC: Don't initialize partitions on RPMB flagged areas.

### DIFF
--- a/packages/linux/patches/3.19.2/linux-999.05-eMMC-Don-t-initialize-partitions-on-RPMB-flagged-are.patch
+++ b/packages/linux/patches/3.19.2/linux-999.05-eMMC-Don-t-initialize-partitions-on-RPMB-flagged-are.patch
@@ -1,0 +1,26 @@
+From 57f0b99ca9a2db948fa70988c447553683368be1 Mon Sep 17 00:00:00 2001
+From: Nell Hardcastle <nell@dev-nell.com>
+Date: Thu, 29 May 2014 22:06:50 -0700
+Subject: [PATCH] eMMC: Don't initialize partitions on RPMB flagged areas.
+
+Prevents a lot of pointless hanging at boot on some devices.
+---
+ drivers/mmc/card/block.c |    2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/drivers/mmc/card/block.c b/drivers/mmc/card/block.c
+index 4409d79..56df902 100644
+--- a/drivers/mmc/card/block.c
++++ b/drivers/mmc/card/block.c
+@@ -2254,7 +2254,7 @@ static int mmc_blk_alloc_parts(struct mmc_card *card, struct mmc_blk_data *md)
+ 		return 0;
+ 
+ 	for (idx = 0; idx < card->nr_parts; idx++) {
+-		if (card->part[idx].size) {
++		if (card->part[idx].size && !(card->part[idx].area_type & MMC_BLK_DATA_AREA_RPMB)) {
+ 			ret = mmc_blk_alloc_part(card, md,
+ 				card->part[idx].part_cfg,
+ 				card->part[idx].size >> 9,
+-- 
+1.7.10.4
+


### PR DESCRIPTION
this fixes an issue on some baytrail boxes with integrated emmc, where installer hangs / wont detect the target drive.

on that hardware parted and blkid would hang for minute or two, trying to access /dev/rpmb
tested by me and @fritsch on an "wintel" box.

would be nice if RPi dev can check if this doesnt break something.

//cc @MilhouseVH 

EDIT: @MilhouseVH I dont know if RPi/2 has/needs /dev/rpmb. but if it boots with this patch, all fine.