### PR TITLE
Intel: Fix EDID overriding (makes audio work)

### DIFF
--- a/packages/linux/patches/3.19.2/linux-999-11-EDID-Fix-edid-override-and-no-audio-thx-Jani-Nikula.patch
+++ b/packages/linux/patches/3.19.2/linux-999-11-EDID-Fix-edid-override-and-no-audio-thx-Jani-Nikula.patch
@@ -1,0 +1,51 @@
+From 0c60dddcf8a3439f498a2ededbee66005e4ead58 Mon Sep 17 00:00:00 2001
+From: Jani Nikula <jani.nikula@intel.com>
+Date: Thu, 26 Mar 2015 10:42:00 +0200
+Subject: [PATCH] drm/edid: set ELD for firmware and debugfs override EDIDs
+
+If the user supplies EDID through firmware or debugfs override, the
+driver callbacks are bypassed and the connector ELD does not get
+updated, and audio fails. Set ELD for firmware and debugfs EDIDs too.
+
+There should be no harm in gratuitously doing this for non HDMI/DP
+connectors, as it's still up to the driver to use the ELD, if any.
+
+Bugzilla: https://bugs.freedesktop.org/show_bug.cgi?id=82349
+Reference: https://bugs.freedesktop.org/show_bug.cgi?id=80691
+Reported-by: Emil <emilsvennesson@gmail.com>
+Reported-by: Rob Engle <grenoble@gmail.com>
+Tested-by: Jolan Luff <jolan@gormsby.com>
+Cc: stable@vger.kernel.org
+Signed-off-by: Jani Nikula <jani.nikula@intel.com>
+---
+ drivers/gpu/drm/drm_edid_load.c    | 1 +
+ drivers/gpu/drm/drm_probe_helper.c | 1 +
+ 2 files changed, 2 insertions(+)
+
+diff --git a/drivers/gpu/drm/drm_edid_load.c b/drivers/gpu/drm/drm_edid_load.c
+index 732cb6f..4c0aa97 100644
+--- a/drivers/gpu/drm/drm_edid_load.c
++++ b/drivers/gpu/drm/drm_edid_load.c
+@@ -287,6 +287,7 @@ int drm_load_edid_firmware(struct drm_connector *connector)
+ 
+ 	drm_mode_connector_update_edid_property(connector, edid);
+ 	ret = drm_add_edid_modes(connector, edid);
++	drm_edid_to_eld(connector, edid);
+ 	kfree(edid);
+ 
+ 	return ret;
+diff --git a/drivers/gpu/drm/drm_probe_helper.c b/drivers/gpu/drm/drm_probe_helper.c
+index 7483a47..9bca854 100644
+--- a/drivers/gpu/drm/drm_probe_helper.c
++++ b/drivers/gpu/drm/drm_probe_helper.c
+@@ -152,6 +152,7 @@ static int drm_helper_probe_single_connector_modes_merge_bits(struct drm_connect
+ 			struct edid *edid = (struct edid *) connector->edid_blob_ptr->data;
+ 
+ 			count = drm_add_edid_modes(connector, edid);
++			drm_edid_to_eld(connector, edid);
+ 		} else
+ 			count = (*connector_funcs->get_modes)(connector);
+ 	}
+-- 
+1.9.1
+


### PR DESCRIPTION
This should fix a long standing issue when users want to boot with their AVRs disabled or resume from suspend and end without audio. 

It's perhaps worth to integrate a working EDID file into OE for easy usage. Was only verified with kms_helper for now.

Edid (Full HD + All bitstream audio codecs): https://dl.dropboxusercontent.com/u/55728161/edid-samsung-marantz.bin