### PR TITLE
Update patch due errors when looking for libpci

### DIFF
--- a/packages/sysutils/pciutils/patches/pciutils-01-fix-pkgconf.patch
+++ b/packages/sysutils/pciutils/patches/pciutils-01-fix-pkgconf.patch
@@ -17,6 +17,7 @@ index 9d7e8a0..38827ba 100644
 -libdir=@LIBDIR@
 -idsdir=@IDSDIR@
 +includedir=${prefix}/include
++exec_prefix=${prefix}
 +libdir=${exec_prefix}/lib
 +idsdir=${prefix}/share
  


### PR DESCRIPTION
it appear when i try to compile some 3rd part apps

Variable 'exec_prefix' not defined in '/home/cs/devel/OpenELEC.tv/build.OpenELEC-Generic.x86_64-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/lib/pkgconfig/libpci.pc'

Call to 'pkg-config --libs-only-l libpci' returned exit status 1.

another bug observed regarding pciutils is described here:
https://gcc.gnu.org/bugzilla/show_bug.cgi?id=48200

maybe not related to our static build but it appears when building it as shared