### PR TITLE
IMX: fix menu animation speed regression

### DIFF
--- a/projects/imx6/patches/kodi/kodi-17-fix-frametime-for-active-vsync.patch
+++ b/projects/imx6/patches/kodi/kodi-17-fix-frametime-for-active-vsync.patch
@@ -1,0 +1,116 @@
+From 07a17ab720e13d56d8438aa460b0052aa9c02060 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Fri, 20 Mar 2015 10:25:48 +0100
+Subject: [PATCH] fix frametime for active vsync
+
+---
+ xbmc/Application.cpp     | 11 ++++++++++-
+ xbmc/utils/TimeUtils.cpp | 23 +++++++++++++++++++----
+ xbmc/utils/TimeUtils.h   |  2 +-
+ 3 files changed, 30 insertions(+), 6 deletions(-)
+
+diff --git a/xbmc/Application.cpp b/xbmc/Application.cpp
+index a79c7dd..eef7f02 100644
+--- a/xbmc/Application.cpp
++++ b/xbmc/Application.cpp
+@@ -2216,6 +2216,7 @@ void CApplication::Render()
+   bool hasRendered = false;
+   bool limitFrames = false;
+   unsigned int singleFrameTime = 10; // default limit 100 fps
++  bool vsync = true;
+ 
+   // Whether externalplayer is playing and we're unfocused
+   bool extPlayerActive = m_pPlayer->GetCurrentPlayer() == EPC_EXTPLAYER && m_pPlayer->IsPlaying() && !m_AppFocused;
+@@ -2228,6 +2229,8 @@ void CApplication::Render()
+     if (!extPlayerActive && g_graphicsContext.IsFullScreenVideo() && !m_pPlayer->IsPausedPlayback())
+     {
+       m_bPresentFrame = g_renderManager.HasFrame();
++      if (vsync_mode == VSYNC_DISABLED)
++        vsync = false;
+     }
+     else
+     {
+@@ -2236,9 +2239,15 @@ void CApplication::Render()
+       // DXMERGE - we checked for g_videoConfig.GetVSyncMode() before this
+       //           perhaps allowing it to be set differently than the UI option??
+       if (vsync_mode == VSYNC_DISABLED || vsync_mode == VSYNC_VIDEO)
++      {
+         limitFrames = true; // not using vsync.
++        vsync = false;
++      }
+       else if ((g_infoManager.GetFPS() > g_graphicsContext.GetFPS() + 10) && g_infoManager.GetFPS() > 1000 / singleFrameTime)
++      {
+         limitFrames = true; // using vsync, but it isn't working.
++        vsync = false;
++      }
+ 
+       if (limitFrames)
+       {
+@@ -2334,7 +2343,7 @@ void CApplication::Render()
+   }
+ 
+   m_lastFrameTime = XbmcThreads::SystemClockMillis();
+-  CTimeUtils::UpdateFrameTime(flip);
++  CTimeUtils::UpdateFrameTime(flip, vsync);
+ 
+   g_renderManager.UpdateResolution();
+   g_renderManager.ManageCaptures();
+diff --git a/xbmc/utils/TimeUtils.cpp b/xbmc/utils/TimeUtils.cpp
+index 9f2e135..57e5e90 100644
+--- a/xbmc/utils/TimeUtils.cpp
++++ b/xbmc/utils/TimeUtils.cpp
+@@ -21,6 +21,7 @@
+ #include "TimeUtils.h"
+ #include "XBDateTime.h"
+ #include "threads/SystemClock.h"
++#include "guilib/GraphicContext.h"
+ 
+ #if (defined HAVE_CONFIG_H) && (!defined TARGET_WINDOWS)
+   #include "config.h"
+@@ -72,12 +73,26 @@ int64_t CurrentHostFrequency(void)
+ CTimeSmoother CTimeUtils::frameTimer;
+ unsigned int CTimeUtils::frameTime = 0;
+ 
+-void CTimeUtils::UpdateFrameTime(bool flip)
++void CTimeUtils::UpdateFrameTime(bool flip, bool vsync)
+ {
+   unsigned int currentTime = XbmcThreads::SystemClockMillis();
+-  if (flip)
+-    frameTimer.AddTimeStamp(currentTime);
+-  frameTime = frameTimer.GetNextFrameTime(currentTime);
++  if (vsync)
++  {
++    unsigned int last = frameTime;
++    while (frameTime < currentTime)
++    {
++      frameTime += (unsigned int)(1000 / g_graphicsContext.GetFPS());
++      // observe wrap around
++      if (frameTime < last)
++        break;
++    }
++  }
++  else
++  {
++    if (flip)
++      frameTimer.AddTimeStamp(currentTime);
++    frameTime = frameTimer.GetNextFrameTime(currentTime);
++  }
+ }
+ 
+ unsigned int CTimeUtils::GetFrameTime()
+diff --git a/xbmc/utils/TimeUtils.h b/xbmc/utils/TimeUtils.h
+index f8796d5..e07540f 100644
+--- a/xbmc/utils/TimeUtils.h
++++ b/xbmc/utils/TimeUtils.h
+@@ -32,7 +32,7 @@ int64_t CurrentHostFrequency(void);
+ class CTimeUtils
+ {
+ public:
+-  static void UpdateFrameTime(bool flip); ///< update the frame time.  Not threadsafe
++  static void UpdateFrameTime(bool flip, bool vsync); ///< update the frame time.  Not threadsafe
+   static unsigned int GetFrameTime(); ///< returns the frame time in MS.  Not threadsafe
+   static CDateTime GetLocalTime(time_t time);
+ 
+-- 
+1.9.1
+

--- a/projects/imx6/patches/kodi/kodi-18-guilib-only-update-scrollinfo-if-frametime-did-chang.patch
+++ b/projects/imx6/patches/kodi/kodi-18-guilib-only-update-scrollinfo-if-frametime-did-chang.patch
@@ -1,0 +1,26 @@
+From 68428562758adbcb597cadc05ba124a6bde97291 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Fri, 13 Mar 2015 20:57:17 +0100
+Subject: [PATCH] guilib: only update scrollinfo if frametime did change
+
+---
+ xbmc/guilib/GUIFont.cpp | 3 ++-
+ 1 file changed, 2 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/guilib/GUIFont.cpp b/xbmc/guilib/GUIFont.cpp
+index a7ee668..06232cb 100644
+--- a/xbmc/guilib/GUIFont.cpp
++++ b/xbmc/guilib/GUIFont.cpp
+@@ -52,7 +52,8 @@ float CScrollInfo::GetPixelsPerFrame()
+     delta = 100; // assume a minimum of 10 fps
+   m_lastFrameTime = currentTime;
+   // do an exponential moving average of the frame time
+-  m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
++  if (delta)
++    m_averageFrameTime = m_averageFrameTime + (delta - m_averageFrameTime) * alphaEMA;
+   // and multiply by pixel speed (per ms) to get number of pixels to move this frame
+   return pixelSpeed * m_averageFrameTime;
+ }
+-- 
+1.9.1
+


### PR DESCRIPTION
After you pushed the Dirty Region fullscreen rework, these two patches are needed to fix the animation speed regression. Testbuild for IMX users, here: https://dl.dropboxusercontent.com/u/55728161/OpenELEC-imx6.arm-5.0.7-fritschgui.tar

Would be nice if some imx users could test that, it should also help a lot on wetek boxes.