### PR TITLE
Enable use of systemd-journal-gatewayd

### DIFF
--- a/packages/web/libmicrohttpd/package.mk
+++ b/packages/web/libmicrohttpd/package.mk
@@ -32,8 +32,8 @@ PKG_LONGDESC="GNU libmicrohttpd is a small C library that is supposed to make it
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
-                           --enable-static \
+PKG_CONFIGURE_OPTS_TARGET="--enable-shared \
+                           --disable-static \
                            --disable-curl \
                            --disable-https \
                            --with-libgcrypt-prefix=$SYSROOT_PREFIX/usr"


### PR DESCRIPTION
I'm not sure of how practical this will be or if it will be more of just a "cool" thing

systemd-journal-gatewayd allows viewing the journal from a remote host using http. ie,
```
http://<openelec-ip>:19531
```

This allows you to browse the entire journal or journal entries from specific units.

You can also format the url to get specific information
```
http://<openelec-ip>:19531/entries?boot&PRIORITY=3
```
This will get journal entries for the current boot that are log priority 3

This uses socket activation via systemd-journal-gatewayd.socket so systemd-journal-gatewayd does not run until the specific port is requested.

see, http://www.freedesktop.org/software/systemd/man/systemd-journal-gatewayd.html
and, http://www.freedesktop.org/software/systemd/man/systemd.journal-fields.html