### PR TITLE
add 2sf audio decoder addon

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.2sf/package.mk
@@ -1,0 +1,48 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="audiodecoder.2sf"
+PKG_VERSION="014b430"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/notspiff/audiodecoder.2sf"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform"
+PKG_PRIORITY="optional"
+PKG_SECTION=""
+PKG_SHORTDESC="audiodecoder.2sf"
+PKG_LONGDESC="audiodecoder.2sf"
+PKG_AUTORECONF="no"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="kodi.audiodecoder"
+
+configure_target() {
+  cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_MODULE_PATH=$SYSROOT_PREFIX/usr/lib/kodi \
+        -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
+        ..
+}
+
+addon() {
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
+  cp -PR $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/
+  cp -PL $PKG_BUILD/.install_pkg/usr/lib/kodi/addons/$PKG_NAME/*.so $ADDON_BUILD/$PKG_ADDON_ID/
+}

--- a/tools/mkpkg/mkpkg_audiodecoder.2sf
+++ b/tools/mkpkg/mkpkg_audiodecoder.2sf
@@ -1,0 +1,43 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+echo "getting sources..."
+  if [ ! -d audiodecoder.2sf.git ]; then
+    git clone https://github.com/notspiff/audiodecoder.2sf.git audiodecoder.2sf.git
+  fi
+
+  cd audiodecoder.2sf.git
+    git pull
+    GIT_REV=`git log -n1 --format=%h`
+  cd ..
+
+echo "copying sources..."
+  rm -rf audiodecoder.2sf-$GIT_REV
+  cp -R audiodecoder.2sf.git audiodecoder.2sf-$GIT_REV
+
+echo "cleaning sources..."
+  rm -rf audiodecoder.2sf-$GIT_REV/.git
+
+echo "packing sources..."
+  tar cvJf audiodecoder.2sf-$GIT_REV.tar.xz audiodecoder.2sf-$GIT_REV
+
+echo "remove temporary sourcedir..."
+  rm -rf audiodecoder.2sf-$GIT_REV


### PR DESCRIPTION
This adds a 2sf audio decoder addon.

I consider this a training run, I got another 10 or so on the way, but want to see if this is okay.
I have built it for x86_64 (Generic) and arm (RPi2).