### PR TITLE
kodi: disable pvrplayback.signalquality on new installs

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -37,6 +37,13 @@
   </section>
 
   <section id="pvr">
+    <category id="pvrplayback">
+      <group id="1">
+        <setting id="pvrplayback.signalquality" type="boolean" label="19037" help="36229">
+          <default>false</default>
+        </setting>
+      </group>
+    </category>
     <category id="pvrpowermanagement">
       <group id="2">
         <setting id="pvrpowermanagement.setwakeupcmd" type="string" label="19245" help="">


### PR DESCRIPTION
this was reported to cause stuttering/artifacts

note. this only disables tte pvr-specific "signal quality" part of codecinfo screen (g). user can re-enable it if he wants, we just set it default off

@sraue objections ?