### PR TITLE
kodi/udevprovider: filter out OE specific mounts

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.13-udevprovider-filter-out-OE-specific-mounts.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.13-udevprovider-filter-out-OE-specific-mounts.patch
@@ -1,0 +1,37 @@
+From eca92b6b2da62765247faaad90f4efcf529a73aa Mon Sep 17 00:00:00 2001
+From: Stefan Saraev <stefan@saraev.ca>
+Date: Sun, 26 Apr 2015 15:13:15 +0300
+Subject: [PATCH 13/13] udevprovider: filter out OE specific mounts
+
+---
+ xbmc/storage/linux/UDevProvider.cpp | 14 ++++++++++++++
+ 1 file changed, 14 insertions(+)
+
+diff --git a/xbmc/storage/linux/UDevProvider.cpp b/xbmc/storage/linux/UDevProvider.cpp
+index dffee34..b7cd25b 100644
+--- a/xbmc/storage/linux/UDevProvider.cpp
++++ b/xbmc/storage/linux/UDevProvider.cpp
+@@ -152,6 +152,20 @@ void CUDevProvider::GetDisks(VECSOURCES& disks, bool removable)
+       continue;
+     }
+ 
++    // OE: filter out openelec specific mounts
++    if (strstr(mountpoint, "/flash"))
++    {
++      udev_device_unref(device);
++      continue;
++    }
++
++    if (strstr(mountpoint, "/storage"))
++    {
++      udev_device_unref(device);
++      continue;
++    }
++    // OE
++
+     // look for devices on the usb bus, or mounted on */media/ (sdcards), or optical devices
+     const char *bus = udev_device_get_property_value(device, "ID_BUS");
+     const char *optical = udev_device_get_property_value(device, "ID_CDROM"); // matches also DVD, Blu-ray
+-- 
+2.1.4
+


### PR DESCRIPTION
this hides /flash and /storage from videos/music -> files -> add -> browse.

@ksooo FYI