### PR TITLE
Include libvcsm.so in RPi/RPi2 builds - needed by upcoming firmware

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -55,6 +55,7 @@ make_target() {
     cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $SYSROOT_PREFIX/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $SYSROOT_PREFIX/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $SYSROOT_PREFIX/usr/lib
 }
 
 makeinstall_target() {
@@ -74,6 +75,7 @@ makeinstall_target() {
     cp -PRv $FLOAT/opt/vc/lib/libmmal_core.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_util.so $INSTALL/usr/lib
     cp -PRv $FLOAT/opt/vc/lib/libmmal_vc_client.so $INSTALL/usr/lib
+    cp -PRv $FLOAT/opt/vc/lib/libvcsm.so $INSTALL/usr/lib
 
 # some usefull debug tools
   mkdir -p $INSTALL/usr/bin


### PR DESCRIPTION
Safe to include now, before next bcm2835-* bump.