### PR TITLE
libnfs: update to 1.9.7

### DIFF
--- a/packages/network/libnfs/package.mk
+++ b/packages/network/libnfs/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libnfs"
-PKG_VERSION="1.9.5"
+PKG_VERSION="1.9.7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
libnfs 1.9.7 has been tested in my RPi/RPi2/Generic builds since Feb 10 without any problems.