### PR TITLE
linux: TechnoTrend S2-4600 patch improvements

### DIFF
--- a/packages/linux/patches/4.0.1/linux-228-technotrend-s2-4600.patch
+++ b/packages/linux/patches/4.0.1/linux-228-technotrend-s2-4600.patch
@@ -1,6 +1,6 @@
 diff -urN a/drivers/media/dvb-core/dvb-usb-ids.h b/drivers/media/dvb-core/dvb-usb-ids.h
---- a/drivers/media/dvb-core/dvb-usb-ids.h	2015-03-18 15:11:52.000000000 +0200
-+++ b/drivers/media/dvb-core/dvb-usb-ids.h	2015-03-21 12:13:33.967120836 +0200
+--- a/drivers/media/dvb-core/dvb-usb-ids.h	2015-04-29 11:22:30.000000000 +0300
++++ b/drivers/media/dvb-core/dvb-usb-ids.h	2015-05-05 20:35:29.392417272 +0300
 @@ -245,6 +245,7 @@
  #define USB_PID_TECHNOTREND_CONNECT_S2400               0x3006
  #define USB_PID_TECHNOTREND_CONNECT_S2400_8KEEPROM	0x3009
@@ -10,8 +10,8 @@ diff -urN a/drivers/media/dvb-core/dvb-usb-ids.h b/drivers/media/dvb-core/dvb-us
  #define USB_PID_TECHNOTREND_TVSTICK_CT2_4400		0x3014
  #define USB_PID_TERRATEC_CINERGY_DT_XS_DIVERSITY	0x005a
 diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw2102.c
---- a/drivers/media/usb/dvb-usb/dw2102.c	2015-03-18 15:11:52.000000000 +0200
-+++ b/drivers/media/usb/dvb-usb/dw2102.c	2015-03-21 12:16:04.791127250 +0200
+--- a/drivers/media/usb/dvb-usb/dw2102.c	2015-04-29 11:22:30.000000000 +0300
++++ b/drivers/media/usb/dvb-usb/dw2102.c	2015-05-05 20:37:20.376421156 +0300
 @@ -2,7 +2,8 @@
   *	DVBWorld DVB-S 2101, 2102, DVB-S2 2104, DVB-C 3101,
   *	TeVii S600, S630, S650, S660, S480, S421, S632
@@ -31,7 +31,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  
  /* Max transfer size done by I2C transfer functions */
  #define MAX_XFER_SIZE  64
-@@ -112,11 +115,9 @@
+@@ -112,12 +115,15 @@
  		"Please see linux/Documentation/dvb/ for more details " \
  		"on firmware-problems."
  
@@ -39,13 +39,18 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
 +struct dw2102_state {
  	u8 initialized;
 -};
--
--struct s6x0_state {
++	u8 last_lock;
 +	struct i2c_client *i2c_client_tuner;
+ 
+-struct s6x0_state {
++	/* fe hook functions*/
  	int (*old_set_voltage)(struct dvb_frontend *f, fe_sec_voltage_t v);
++	int (*fe_read_status)(struct dvb_frontend *fe,
++		fe_status_t *status);
  };
  
-@@ -887,7 +888,7 @@
+ /* debug */
+@@ -887,7 +893,7 @@
  
  static int su3000_power_ctrl(struct dvb_usb_device *d, int i)
  {
@@ -54,7 +59,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	u8 obuf[] = {0xde, 0};
  
  	info("%s: %d, initialized %d\n", __func__, i, state->initialized);
-@@ -973,7 +974,7 @@
+@@ -973,7 +979,7 @@
  {
  	struct dvb_usb_adapter *d =
  		(struct dvb_usb_adapter *)(fe->dvb->priv);
@@ -63,7 +68,31 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  
  	dw210x_set_voltage(fe, voltage);
  	if (st->old_set_voltage)
-@@ -1117,6 +1118,22 @@
+@@ -1000,6 +1006,23 @@
+ 	i2c_transfer(&udev_adap->dev->i2c_adap, &msg, 1);
+ }
+ 
++static int tt_s2_4600_read_status(struct dvb_frontend *fe, fe_status_t *status)
++{
++	struct dvb_usb_adapter *d =
++		(struct dvb_usb_adapter *)(fe->dvb->priv);
++	struct dw2102_state *st = (struct dw2102_state *)d->dev->priv;
++	int ret;
++
++	ret = st->fe_read_status(fe, status);
++
++	/* resync slave fifo when signal change from unlock to lock */
++	if ((*status & FE_HAS_LOCK) && (!st->last_lock))
++		su3000_streaming_ctrl(d, 1);
++
++	st->last_lock = (*status & FE_HAS_LOCK) ? 1 : 0;
++	return ret;
++}
++
+ static struct stv0299_config sharp_z0194a_config = {
+ 	.demod_address = 0x68,
+ 	.inittab = sharp_z0194a_inittab,
+@@ -1117,6 +1140,22 @@
  	.gate = TDA18271_GATE_DIGITAL,
  };
  
@@ -86,7 +115,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  static u8 m88rs2000_inittab[] = {
  	DEMOD_WRITE, 0x9a, 0x30,
  	DEMOD_WRITE, 0x00, 0x01,
-@@ -1295,7 +1312,7 @@
+@@ -1295,7 +1334,7 @@
  
  static int ds3000_frontend_attach(struct dvb_usb_adapter *d)
  {
@@ -95,7 +124,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	u8 obuf[] = {7, 1};
  
  	d->fe_adap[0].fe = dvb_attach(ds3000_attach, &s660_ds3000_config,
-@@ -1461,6 +1478,86 @@
+@@ -1461,6 +1500,92 @@
  	return -EIO;
  }
  
@@ -176,13 +205,19 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
 +
 +	state->i2c_client_tuner = client;
 +
++	/* hook fe: need to resync the slave fifo when signal locks */
++	state->fe_read_status = adap->fe_adap[0].fe->ops.read_status;
++	adap->fe_adap[0].fe->ops.read_status = tt_s2_4600_read_status;
++
++	state->last_lock = 0;
++
 +	return 0;
 +}
 +
  static int dw2102_tuner_attach(struct dvb_usb_adapter *adap)
  {
  	dvb_attach(dvb_pll_attach, adap->fe_adap[0].fe, 0x60,
-@@ -1561,6 +1658,7 @@
+@@ -1561,6 +1686,7 @@
  	TERRATEC_CINERGY_S2_R2,
  	GOTVIEW_SAT_HD,
  	GENIATECH_T220,
@@ -190,7 +225,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  };
  
  static struct usb_device_id dw2102_table[] = {
-@@ -1584,6 +1682,8 @@
+@@ -1584,6 +1710,8 @@
  	[TERRATEC_CINERGY_S2_R2] = {USB_DEVICE(USB_VID_TERRATEC, 0x00b0)},
  	[GOTVIEW_SAT_HD] = {USB_DEVICE(0x1FE1, USB_PID_GOTVIEW_SAT_HD)},
  	[GENIATECH_T220] = {USB_DEVICE(0x1f4d, 0xD220)},
@@ -199,7 +234,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	{ }
  };
  
-@@ -1857,7 +1957,7 @@
+@@ -1857,7 +1985,7 @@
  static struct dvb_usb_device_properties s6x0_properties = {
  	.caps = DVB_USB_IS_AN_I2C_ADAPTER,
  	.usb_ctrl = DEVICE_SPECIFIC,
@@ -208,7 +243,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	.firmware = S630_FIRMWARE,
  	.no_reconnect = 1,
  
-@@ -1950,7 +2050,7 @@
+@@ -1950,7 +2078,7 @@
  static struct dvb_usb_device_properties su3000_properties = {
  	.caps = DVB_USB_IS_AN_I2C_ADAPTER,
  	.usb_ctrl = DEVICE_SPECIFIC,
@@ -217,7 +252,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	.power_ctrl = su3000_power_ctrl,
  	.num_adapters = 1,
  	.identify_state	= su3000_identify_state,
-@@ -2015,7 +2115,7 @@
+@@ -2015,7 +2143,7 @@
  static struct dvb_usb_device_properties t220_properties = {
  	.caps = DVB_USB_IS_AN_I2C_ADAPTER,
  	.usb_ctrl = DEVICE_SPECIFIC,
@@ -226,7 +261,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	.power_ctrl = su3000_power_ctrl,
  	.num_adapters = 1,
  	.identify_state	= su3000_identify_state,
-@@ -2061,6 +2161,55 @@
+@@ -2061,6 +2189,55 @@
  	}
  };
  
@@ -282,7 +317,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  static int dw2102_probe(struct usb_interface *intf,
  		const struct usb_device_id *id)
  {
-@@ -2135,16 +2284,34 @@
+@@ -2135,16 +2312,34 @@
  	    0 == dvb_usb_device_init(intf, &su3000_properties,
  			 THIS_MODULE, NULL, adapter_nr) ||
  	    0 == dvb_usb_device_init(intf, &t220_properties,
@@ -318,7 +353,7 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  	.id_table = dw2102_table,
  };
  
-@@ -2155,7 +2322,8 @@
+@@ -2155,7 +2350,8 @@
  			" DVB-C 3101 USB2.0,"
  			" TeVii S600, S630, S650, S660, S480, S421, S632"
  			" Prof 1100, 7500 USB2.0,"
@@ -329,8 +364,8 @@ diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw210
  MODULE_LICENSE("GPL");
  MODULE_FIRMWARE(DW2101_FIRMWARE);
 diff -urN a/drivers/media/usb/dvb-usb/Kconfig b/drivers/media/usb/dvb-usb/Kconfig
---- a/drivers/media/usb/dvb-usb/Kconfig	2015-03-18 15:11:52.000000000 +0200
-+++ b/drivers/media/usb/dvb-usb/Kconfig	2015-03-21 12:13:33.967120836 +0200
+--- a/drivers/media/usb/dvb-usb/Kconfig	2015-04-29 11:22:30.000000000 +0300
++++ b/drivers/media/usb/dvb-usb/Kconfig	2015-05-05 20:35:29.392417272 +0300
 @@ -278,9 +278,11 @@
  	select DVB_STV6110 if MEDIA_SUBDRV_AUTOSELECT
  	select DVB_STV0900 if MEDIA_SUBDRV_AUTOSELECT


### PR DESCRIPTION
Previously the TT S2-4600 driver worked fine only in some applications (such as tvheadend), but not in others (such as vdr). This patch fixes that by adding a call to su3000_streaming_ctrl after the demod has locked.

