### PR TITLE
cosmetics ;)

### DIFF
--- a/packages/devel/enca/package.mk
+++ b/packages/devel/enca/package.mk
@@ -32,8 +32,6 @@ PKG_LONGDESC="Enca detects the encoding of text files, on the basis of knowledge
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-export CFLAGS="$CFLAGS -fPIC -DPIC"
-
 PKG_MAKEINSTALL_OPTS_TARGET="-C lib"
 PKG_CONFIGURE_OPTS_TARGET="ac_cv_file__dev_random=yes \
                            ac_cv_file__dev_urandom=no \
@@ -46,6 +44,10 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_file__dev_random=yes \
                            --without-librecode \
                            --disable-rpath \
                            --with-gnu-ld"
+
+pre_configure_target() {
+  export CFLAGS="$CFLAGS -fPIC -DPIC"
+}
 
 pre_make_target() {
   make CC="$HOST_CC" \

--- a/packages/devel/fribidi/package.mk
+++ b/packages/devel/fribidi/package.mk
@@ -42,8 +42,10 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
                            --with-gnu-ld \
                            --without-glib"
 
-export CFLAGS="$CFLAGS -DFRIBIDI_CHUNK_SIZE=4080"
-export CFLAGS="$CFLAGS -fPIC -DPIC"
+pre_configure_target() {
+  export CFLAGS="$CFLAGS -DFRIBIDI_CHUNK_SIZE=4080"
+  export CFLAGS="$CFLAGS -fPIC -DPIC"
+}
 
 post_makeinstall_target() {
   mkdir -p $ROOT/$TOOLCHAIN/bin

--- a/packages/sysutils/squashfs/package.mk
+++ b/packages/sysutils/squashfs/package.mk
@@ -33,8 +33,6 @@ PKG_LONGDESC="Squashfs is intended to be a general read-only filesystem, for arc
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
-export LDFLAGS="$LDFLAGS -fwhole-program"
-
 make_host() {
   make -C squashfs-tools mksquashfs \
        XZ_SUPPORT=1 LZO_SUPPORT=1 \

--- a/packages/tools/hdparm/package.mk
+++ b/packages/tools/hdparm/package.mk
@@ -33,5 +33,3 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 PKG_MAKE_OPTS_TARGET="binprefix=/usr sbindir=/usr/bin"
-
-export LDFLAGS="$CFLAGS $LDFLAGS -fwhole-program"

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -35,9 +35,11 @@ PKG_AUTORECONF="yes"
 PKG_CONFIGURE_OPTS_TARGET="--disable-utf8 \
                            --disable-nls"
 
-export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/ncurses"
-export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
-export LIBS="$LIBS -lz"
+pre_configure_target() {
+  export CFLAGS="$CFLAGS -I$SYSROOT_PREFIX/usr/include/ncurses"
+  export LDFLAGS=`echo $LDFLAGS | sed -e "s|-Wl,--as-needed||"`
+  export LIBS="$LIBS -lz"
+}
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/nano

--- a/packages/x11/util/xorg-launch-helper/package.mk
+++ b/packages/x11/util/xorg-launch-helper/package.mk
@@ -32,7 +32,9 @@ PKG_LONGDESC="Xorg-launch-helper is a small utility that transforms the X server
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-export LIBS="-lsystemd"
+pre_configure_target() {
+  export LIBS="-lsystemd"
+}
 
 post_makeinstall_target() {
   # do not install systemd services


### PR DESCRIPTION
its not good to export *FLAGS/LIBS globaly. those should be in pre_configure_target() (or whatever makes sense, depending on the package)

some -fwhole-program ldflags removed, not needed.

@sraue 