### PR TITLE
IMX: Backport latest fixes

### DIFF
--- a/projects/imx6/patches/kodi/kodi-27-check-all-resolutions-fixup.patch
+++ b/projects/imx6/patches/kodi/kodi-27-check-all-resolutions-fixup.patch
@@ -1,0 +1,30 @@
+From 2a4a8fecbee1e7d7c9e3fd600389fb07dae7a277 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Thu, 7 May 2015 22:06:42 +0200
+Subject: [PATCH] IMX: Fix path to edid on default imx kernel
+
+---
+ xbmc/windowing/egl/EGLNativeTypeIMX.cpp | 4 ++--
+ 1 file changed, 2 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+index 4a384f8..8fce775 100644
+--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
++++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+@@ -337,11 +337,11 @@ float CEGLNativeTypeIMX::GetMonitorSAR()
+   size_t n;
+   int done = 0;
+ 
+-  // kernels <= 3.18 use ./soc0/soc.0
++  // kernels <= 3.18 use ./soc0/soc.1 in official imx kernel
+   // kernels  > 3.18 use ./soc0/soc
+   f_edid = fopen("/sys/devices/soc0/soc/20e0000.hdmi_video/edid", "r");
+   if(!f_edid)
+-    f_edid = fopen("/sys/devices/soc0/soc.0/20e0000.hdmi_video/edid", "r");
++    f_edid = fopen("/sys/devices/soc0/soc.1/20e0000.hdmi_video/edid", "r");
+ 
+   if(!f_edid)
+     return 0;
+-- 
+1.9.1
+

--- a/projects/imx6/patches/kodi/kodi-28-resolutions-lie-a-bit.patch
+++ b/projects/imx6/patches/kodi/kodi-28-resolutions-lie-a-bit.patch
@@ -1,0 +1,36 @@
+From b42f428df68d1886b241d953a79a6a0b501a4969 Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Sun, 10 May 2015 07:47:28 +0200
+Subject: [PATCH] IMX: Edid lie a bit when we are only slightly off
+
+---
+ xbmc/windowing/egl/EGLNativeTypeIMX.cpp | 13 ++++++++++++-
+ 1 file changed, 12 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+index 8fce775..2a23b1a 100644
+--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
++++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+@@ -426,7 +426,18 @@ bool CEGLNativeTypeIMX::ModeToResolution(std::string mode, RESOLUTION_INFO *res)
+   res->bFullScreen   = true;
+   res->iSubtitles    = (int)(0.965 * res->iHeight);
+ 
+-  res->fPixelRatio   = !m_sar ? 1.0f : (float)m_sar / res->iScreenWidth * res->iScreenHeight;
++
++  float pixel_ratio  = 1.0f;
++  // workaround minimal off when getting sar in a rounded way
++  // it is better to lie for computed 1918 pixels than rescaling full
++  // screen content with a lossy scaler
++  if (m_sar > 0.0f)
++  {
++    pixel_ratio = ((float)m_sar / res->iScreenWidth * res->iScreenHeight);
++    if (fabs((float) res->iScreenWidth * pixel_ratio - res->iScreenWidth) < 3.0f)
++      pixel_ratio = 1.0f;
++  }
++  res->fPixelRatio   = pixel_ratio;
+   res->strMode       = StringUtils::Format("%dx%d @ %.2f%s - Full Screen", res->iScreenWidth, res->iScreenHeight, res->fRefreshRate,
+                                            res->dwFlags & D3DPRESENTFLAG_INTERLACED ? "i" : "");
+   res->strId         = mode;
+-- 
+1.9.1
+

--- a/projects/imx6/patches/kodi/kodi-29-fixup-render-capture.patch
+++ b/projects/imx6/patches/kodi/kodi-29-fixup-render-capture.patch
@@ -1,0 +1,56 @@
+From 6cc3129cd26e08fd4bdaeb211fe3246ced04703a Mon Sep 17 00:00:00 2001
+From: smallint <tahoma@gmx.de>
+Date: Mon, 11 May 2015 20:00:57 +0000
+Subject: [PATCH] [imx] RGB -> BGR for RenderCapture
+
+---
+ xbmc/cores/VideoRenderers/RenderCapture.cpp               | 2 +-
+ xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp | 5 ++++-
+ 2 files changed, 5 insertions(+), 2 deletions(-)
+
+diff --git a/xbmc/cores/VideoRenderers/RenderCapture.cpp b/xbmc/cores/VideoRenderers/RenderCapture.cpp
+index c4fe419..603b68d 100644
+--- a/xbmc/cores/VideoRenderers/RenderCapture.cpp
++++ b/xbmc/cores/VideoRenderers/RenderCapture.cpp
+@@ -65,7 +65,7 @@ CRenderCaptureIMX::~CRenderCaptureIMX()
+ 
+ int CRenderCaptureIMX::GetCaptureFormat()
+ {
+-    return CAPTUREFORMAT_RGBA;
++    return CAPTUREFORMAT_BGRA;
+ }
+ 
+ void CRenderCaptureIMX::BeginRender()
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+index 41f1d6a..c17d7b7 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+@@ -1873,6 +1873,8 @@ void CIMXContext::PrepareTask(IPUTask &ipu, CIMXBuffer *source_p, CIMXBuffer *so
+ 
+ bool CIMXContext::DoTask(IPUTask &ipu, int targetPage)
+ {
++  bool swapColors = false;
++
+   // Clear page if cropping changes
+   CRectInt dstRect(ipu.task.output.crop.pos.x, ipu.task.output.crop.pos.y,
+                    ipu.task.output.crop.pos.x + ipu.task.output.crop.w,
+@@ -1918,6 +1920,7 @@ bool CIMXContext::DoTask(IPUTask &ipu, int targetPage)
+         CLog::Log(LOGERROR, "iMX : Error allocating capture buffer\n");
+     }
+     ipu.task.output.paddr = m_bufferCapture->buf_paddr;
++    swapColors = true;
+   }
+ 
+   if ((ipu.task.input.crop.w <= 0) || (ipu.task.input.crop.h <= 0)
+@@ -2027,7 +2030,7 @@ bool CIMXContext::DoTask(IPUTask &ipu, int targetPage)
+       dst.width = ipu.task.output.width;
+       dst.height = ipu.task.output.height;
+       dst.rot = G2D_ROTATION_0;
+-      dst.format = G2D_RGBA8888;
++      dst.format = swapColors ? G2D_BGRA8888 : G2D_RGBA8888;
+       /*printf("dst planes :%x -%x -%x \n",dst.planes[0], dst.planes[1], dst.planes[2] );
+       printf("dst left %d right %d top %d bottom %d stride %d w : %d h %d rot : %d format %d\n",
+            dst.left, dst.right, dst.top, dst.bottom, dst.stride, dst.width, dst.height, dst.rot, dst.format);*/
+-- 
+1.9.1
+

--- a/projects/imx6/patches/kodi/kodi-30-fixup-artifacts-patch-in-a-more-sane-way.patch
+++ b/projects/imx6/patches/kodi/kodi-30-fixup-artifacts-patch-in-a-more-sane-way.patch
@@ -1,0 +1,42 @@
+From cbbe3863ed557986efd804c29e2f95c96ad44737 Mon Sep 17 00:00:00 2001
+From: smallint <tahoma@gmx.de>
+Date: Sat, 9 May 2015 20:30:00 +0000
+Subject: [PATCH] IMX: Attempt to revert last buffer alignment change and to
+ improve it
+
+---
+ .../dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp     | 18 +++++++++---------
+ 1 file changed, 9 insertions(+), 9 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+index 41f1d6a..a13977f 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DVDVideoCodecIMX.cpp
+@@ -1813,15 +1813,15 @@ void CIMXContext::PrepareTask(IPUTask &ipu, CIMXBuffer *source_p, CIMXBuffer *so
+     dstRect.y2 = m_fbHeight;
+   }
+ 
+-  iSrcRect.x1 = Align((int)srcRect.x1,2);
+-  iSrcRect.y1 = Align((int)srcRect.y1,2);
+-  iSrcRect.x2 = Align((int)srcRect.x2,2);
+-  iSrcRect.y2 = Align((int)srcRect.y2,2);
+-
+-  iDstRect.x1 = Align((int)dstRect.x1,2);
+-  iDstRect.y1 = Align((int)dstRect.y1,2);
+-  iDstRect.x2 = Align((int)dstRect.x2,2);
+-  iDstRect.y2 = Align((int)dstRect.y2,2);
++  iSrcRect.x1 = (int)srcRect.x1;
++  iSrcRect.y1 = (int)srcRect.y1;
++  iSrcRect.x2 = (int)srcRect.x2;
++  iSrcRect.y2 = (int)srcRect.y2;
++
++  iDstRect.x1 = Align((int)dstRect.x1,8);
++  iDstRect.y1 = Align((int)dstRect.y1,8);
++  iDstRect.x2 = Align2((int)dstRect.x2,8);
++  iDstRect.y2 = Align2((int)dstRect.y2,8);
+ 
+   ipu.task.input.crop.pos.x  = iSrcRect.x1;
+   ipu.task.input.crop.pos.y  = iSrcRect.y1;
+-- 
+1.9.1
+

--- a/projects/imx6/patches/kodi/kodi-31-enumerate-d-modes.patch
+++ b/projects/imx6/patches/kodi/kodi-31-enumerate-d-modes.patch
@@ -1,0 +1,57 @@
+From 0eea6a90952751c52466696f2e3d1e2e4500133a Mon Sep 17 00:00:00 2001
+From: fritsch <Peter.Fruehberger@gmail.com>
+Date: Fri, 8 May 2015 07:35:14 +0200
+Subject: [PATCH] IMX: Special case D: modes
+
+---
+ xbmc/windowing/egl/EGLNativeTypeIMX.cpp | 17 +++++++++++++++++
+ 1 file changed, 17 insertions(+)
+
+diff --git a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+index 8fce775..1b8e15f 100644
+--- a/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
++++ b/xbmc/windowing/egl/EGLNativeTypeIMX.cpp
+@@ -291,11 +291,14 @@ bool CEGLNativeTypeIMX::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutio
+   std::string valstr;
+   SysfsUtils::GetString("/sys/class/graphics/fb0/modes", valstr);
+   std::vector<std::string> probe_str = StringUtils::Split(valstr, "\n");
++  std::vector<std::string> d_modes;
+ 
+   // lexical order puts the modes list into our preferred
+   // order and by later filtering through FindMatchingResolution()
+   // we make sure we read _all_ S modes, following U and V modes
+   // while list will hold unique resolutions only
++  // d_modes as DVI monitors (without audio) provide are handled
++  // after those and added if they are unique
+   std::sort(probe_str.begin(), probe_str.end());
+ 
+   resolutions.clear();
+@@ -304,12 +307,26 @@ bool CEGLNativeTypeIMX::ProbeResolutions(std::vector<RESOLUTION_INFO> &resolutio
+   {
+     if(!StringUtils::StartsWith(probe_str[i], "S:") && !StringUtils::StartsWith(probe_str[i], "U:") &&
+        !StringUtils::StartsWith(probe_str[i], "V:"))
++    {
++      // save d_modes and try to insert them later if not yet available
++      if (StringUtils::StartsWith(probe_str[i], "D:"))
++        d_modes.push_back(probe_str[i]);
++
+       continue;
++    }
+ 
+     if(ModeToResolution(probe_str[i], &res))
+       if(!FindMatchingResolution(res, resolutions))
+         resolutions.push_back(res);
+   }
++
++  // add unique D: modes also
++  for (size_t i = 0; i < d_modes.size(); i++)
++  {
++    if(ModeToResolution(d_modes[i], &res))
++      if(!FindMatchingResolution(res, resolutions))
++        resolutions.push_back(res); 
++  }
+   return resolutions.size() > 0;
+ }
+ 
+-- 
+2.1.4


### PR DESCRIPTION
- Fixup for EDID
- Fixup for Artifacts
- Enumerate D modes for DVI monitors
- Fix RenderCapture

All those patches (besides the D modes) can be dropped when we reach v15