### PR TITLE
linux: for imx6 include soc fan and status led packages

### DIFF
--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -37,6 +37,7 @@ case "$LINUX" in
   imx6)
     PKG_VERSION="cuboxi-3.14-ea83bda"
     PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET imx6-status-led imx6-soc-fan"
     ;;
   *)
     PKG_VERSION="4.0.3"


### PR DESCRIPTION
now cuboxi image should be the same as before