### PR TITLE
libcec: build python wrapper

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -54,7 +54,6 @@ configure_target() {
 
   cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
         -DBUILD_SHARED_LIBS=1 \
-        -DSKIP_PYTHON_WRAPPER:STRING=1 \
         -DCMAKE_INSTALL_PREFIX=/usr \
         -DCMAKE_INSTALL_LIBDIR=/usr/lib \
         -DCMAKE_INSTALL_LIBDIR_NOARCH=/usr/lib \
@@ -62,4 +61,8 @@ configure_target() {
         -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
         $EXTRA_CMAKE_OPTS \
         ..
+}
+
+post_makeinstall_target() {
+  mv $INSTALL/usr/lib/python2.7/dist-packages $INSTALL/usr/lib/python2.7/site-packages
 }


### PR DESCRIPTION
Enables building the libcec Python wrapper included in libcec 3.0, in addition to the other wrappers.

It would handy to be able to control libcec from Python.
In my case I've got two cec adapters in my RPi, one to control Kodi, one to control a set-top box through a Python script running on the RPi.