### PR TITLE
mkpkg: fix VERSION information for kodi

### DIFF
--- a/tools/mkpkg/mkpkg_kodi
+++ b/tools/mkpkg/mkpkg_kodi
@@ -98,11 +98,11 @@ for addon in $DEST_DIR.git/project/cmake/addons/addons/*.* ; do
 done
 
 cd $DEST_DIR.git
-GIT_REV=`git log -n1 --format=%h`
+GIT_HASH=`git log -n1 --format=%h`
 VERSION_MAJOR=$(grep ^VERSION_MAJOR version.txt | cut -d" " -f2)
 VERSION_MINOR=$(grep ^VERSION_MINOR version.txt | cut -d" " -f2)
 VERSION_TAG=$(grep ^VERSION_TAG version.txt | cut -d" " -f2 | tr A-Z a-z)
-PKG_VERSION="$VERSION_MAJOR.$VERSION_MINOR-$VERSION_TAG-$GIT_REV"
+PKG_VERSION="$VERSION_MAJOR.$VERSION_MINOR-$VERSION_TAG-$GIT_HASH"
 echo $PKG_VERSION
 cd ..
 


### PR DESCRIPTION
I just noticed that the reported git revision in kodi.log and system information looked oddly unfamiliar. Instead of the expected daedd5f on a current master build I saw 42fb669 - the gitrev of the pvr.wmc addon.

I think GIT_REV in mkpkg_kodi should actually be GIT_HASH so that copy_sources creates the VERSION file with the correct info.