### PR TITLE
WeTek_Play: Make ugly IEC958 workaround less ulgy

### DIFF
--- a/projects/WeTek_Play/patches/kodi/0017-enable-IEC958.patch
+++ b/projects/WeTek_Play/patches/kodi/0017-enable-IEC958.patch
@@ -2,17 +2,16 @@ diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngin
 index e22db7a..dcdaf2e 100644
 --- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
 +++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
-@@ -1291,6 +1291,12 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+@@ -1342,6 +1342,12 @@ void CAESinkALSA::EnumerateDevice(AEDeviceInfoList &list, const std::string &dev
+     if (snd_card_get_name(cardNr, &cardName) == 0)
+       info.m_displayName = cardName;
  
- AEDeviceType CAESinkALSA::AEDeviceTypeFromName(const std::string &name)
- {
-+#ifdef HAS_LIBAMCODEC
-+  // ugly workaround to show DTS / AC3 caps
-+  // but don't run into multi channel issues
-+  // as we can only open 2 pcm channels
-+  return AE_DEVTYPE_IEC958;
-+#endif
-   if (name.substr(0, 4) == "hdmi")
-     return AE_DEVTYPE_HDMI;
-   else if (name.substr(0, 6) == "iec958" || name.substr(0, 5) == "spdif")
-
++    // ugly workaround to show DTS / AC3 caps
++    // but don't run into multi channel issues
++    // as we can only open 2 pcm channels
++    if (info.m_displayName == "AML-DUMMY-CODEC")
++      info.m_deviceType = AE_DEVTYPE_IEC958;
++
+     if (info.m_deviceType == AE_DEVTYPE_HDMI && info.m_displayName.size() > 5 &&
+         info.m_displayName.substr(info.m_displayName.size()-5) == " HDMI")
+     {


### PR DESCRIPTION
This patch makes my stereo-only USB sound card *not* look like a S/PDIF device.

After this patch DD and DTS passthrough still work fine.