### PR TITLE
Configure RPi/RPi2 platform with optimal CPU and IO settings

### DIFF
--- a/projects/RPi/initramfs/platform_init
+++ b/projects/RPi/initramfs/platform_init
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2015 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# Enable io_is_busy for improved sdhost performance - essentially, equivalent of force_turbo=1 but for mmc
+echo 1 > /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
+
+# Configure frequency scaling properties - should improve performance a little (turbo, in most cases)
+echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+echo 100000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
+echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor

--- a/projects/RPi2/initramfs/platform_init
+++ b/projects/RPi2/initramfs/platform_init
@@ -1,0 +1,28 @@
+#!/bin/sh
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2015 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+# Enable io_is_busy for improved sdhost performance - essentially, equivalent of force_turbo=1 but for mmc
+echo 1 > /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
+
+# Configure frequency scaling properties - should improve performance a little (turbo, in most cases)
+echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
+echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
+echo 100000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
+echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor


### PR DESCRIPTION
The following settings are (or are about to become) the default on other distributions (Raspbian, OSMC etc.) and it is recommended they should also be the default for OpenELEC too:
```
echo 1 > /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
echo ondemand > /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
echo 100000 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
echo 50 > /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
```
The existing values are:
```
rpi22:~ # cat /sys/devices/system/cpu/cpufreq/ondemand/io_is_busy
0
rpi22:~ # cat /sys/devices/system/cpu/cpu0/cpufreq/scaling_governor
ondemand
rpi22:~ # cat /sys/devices/system/cpu/cpufreq/ondemand/up_threshold
50
rpi22:~ # cat /sys/devices/system/cpu/cpufreq/ondemand/sampling_rate
355000
rpi22:~ # cat /sys/devices/system/cpu/cpufreq/ondemand/sampling_down_factor
1
```
`up_threshold` is also being set (to 50) by the [cpufreq-threshold](https://github.com/OpenELEC/OpenELEC.tv/blob/master/packages/linux/system.d/cpufreq-threshold.service) service - if this is only for the benefit of the RPi/RPi2, then this service could be eliminated (I can squash removal into this PR, if desired).

This should be OK for master.