### PR TITLE
installer: fix menu display, log file function

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -611,8 +611,7 @@ menu_main() {
     --title "$MSG_TITLE" --menu "$MSG_MENU" 20 70 5 \
       1 "Quick Install of OpenELEC" \
       2 "Repair / Upgrade" \
-      3 "Setup OpenELEC" \
-      4 "Show logfile" 2> $TMPDIR/mainmenu
+      3 "Show logfile" 2> $TMPDIR/mainmenu
 
   case $? in
     0)
@@ -663,6 +662,9 @@ LOGFILE="$TMPDIR/install.log"
 # prepare temporary directory
 rm -rf $TMPDIR
 mkdir -p $TMPDIR
+
+#create log file
+touch "$LOGFILE"
 
 # main
 


### PR DESCRIPTION
remove unused menu item, which breaks view log function
create empty log file, so view log function works prior to install

Signed-off-by: Matt DeVillier <matt.devillier@gmail.com>