### PR TITLE
linux: fix TechnoTrend S2-4600 DVB-S receiver

### DIFF
--- a/packages/linux/patches/4.1/linux-228-fix-tt-s2-4600.patch
+++ b/packages/linux/patches/4.1/linux-228-fix-tt-s2-4600.patch
@@ -1,0 +1,63 @@
+diff -urN a/drivers/media/usb/dvb-usb/dw2102.c b/drivers/media/usb/dvb-usb/dw2102.c
+--- a/drivers/media/usb/dvb-usb/dw2102.c	2015-06-22 08:05:43.000000000 +0300
++++ b/drivers/media/usb/dvb-usb/dw2102.c	2015-06-24 14:36:13.236830491 +0300
+@@ -117,8 +117,13 @@
+ 
+ struct dw2102_state {
+ 	u8 initialized;
++	u8 last_lock;
+ 	struct i2c_client *i2c_client_tuner;
++
++	/* fe hook functions*/
+ 	int (*old_set_voltage)(struct dvb_frontend *f, fe_sec_voltage_t v);
++	int (*fe_read_status)(struct dvb_frontend *fe,
++		fe_status_t *status);
+ };
+ 
+ /* debug */
+@@ -928,8 +933,6 @@
+ 			break;
+ 		else
+ 			mac[i] = ibuf[0];
+-
+-		debug_dump(mac, 6, printk);
+ 	}
+ 
+ 	return 0;
+@@ -1001,6 +1004,23 @@
+ 	i2c_transfer(&udev_adap->dev->i2c_adap, &msg, 1);
+ }
+ 
++static int tt_s2_4600_read_status(struct dvb_frontend *fe, fe_status_t *status)
++{
++	struct dvb_usb_adapter *d =
++		(struct dvb_usb_adapter *)(fe->dvb->priv);
++	struct dw2102_state *st = (struct dw2102_state *)d->dev->priv;
++	int ret;
++
++	ret = st->fe_read_status(fe, status);
++
++	/* resync slave fifo when signal change from unlock to lock */
++	if ((*status & FE_HAS_LOCK) && (!st->last_lock))
++		su3000_streaming_ctrl(d, 1);
++
++	st->last_lock = (*status & FE_HAS_LOCK) ? 1 : 0;
++	return ret;
++}
++
+ static struct stv0299_config sharp_z0194a_config = {
+ 	.demod_address = 0x68,
+ 	.inittab = sharp_z0194a_inittab,
+@@ -1553,6 +1573,12 @@
+ 
+ 	state->i2c_client_tuner = client;
+ 
++	/* hook fe: need to resync the slave fifo when signal locks */
++	state->fe_read_status = adap->fe_adap[0].fe->ops.read_status;
++	adap->fe_adap[0].fe->ops.read_status = tt_s2_4600_read_status;
++
++	state->last_lock = 0;
++
+ 	return 0;
+ }
+ 


### PR DESCRIPTION
The TT S2-4600 USB receiver is broken in kernel 4.1 (fixed in 4.2) and will
not tune correctly when certain applications (such as vdr) are being used.
This patch backports the fix from 4.2 to 4.1 and can be removed when kernel
4.1 is no longer used.