### PR TITLE
linux: add missing I2C functions to the Hauppauge HVR-2205 patch

### DIFF
--- a/packages/linux/patches/4.1.3/linux-229-hauppauge-hvr-2205-and-2255.patch
+++ b/packages/linux/patches/4.1.3/linux-229-hauppauge-hvr-2205-and-2255.patch
@@ -616,3 +616,21 @@ diff -urN a/drivers/media/pci/saa7164/saa7164-vbi.c b/drivers/media/pci/saa7164/
  
  	return 0;
  }
+diff -urN a/drivers/media/pci/saa7164/saa7164-i2c.c b/drivers/media/pci/saa7164/saa7164-i2c.c
+--- a/drivers/media/pci/saa7164/saa7164-i2c.c
++++ b/drivers/media/pci/saa7164/saa7164-i2c.c
+@@ -39,9 +39,10 @@ static int i2c_xfer(struct i2c_adapter *i2c_adap, struct i2c_msg *msgs, int num)
+ 		dprintk(DBGLVL_I2C, "%s(num = %d) addr = 0x%02x  len = 0x%x\n",
+ 			__func__, num, msgs[i].addr, msgs[i].len);
+ 		if (msgs[i].flags & I2C_M_RD) {
+-			/* Unsupported - Yet*/
+-			printk(KERN_ERR "%s() Unsupported - Yet\n", __func__);
+-			continue;
++			retval = saa7164_api_i2c_read(bus,
++				msgs[i].addr,
++				0 /* reglen */,
++				NULL /* reg */, msgs[i].len, msgs[i].buf);
+ 		} else if (i + 1 < num && (msgs[i + 1].flags & I2C_M_RD) &&
+ 			   msgs[i].addr == msgs[i + 1].addr) {
+ 			/* write then read from same address */
+


### PR DESCRIPTION
I2C function modifications were missing from the original HVR-2205 patch.

Reported by user Hoffy in the forums:
http://openelec.tv/forum/82-dvb-t-t2-support/77386-hauppauge-hvr-2205-support#144375