### PR TITLE
linux: fix i2c_reglen in HVR-2205 patch

### DIFF
--- a/packages/linux/patches/4.1.3/linux-229-hauppauge-hvr-2205-and-2255.patch
+++ b/packages/linux/patches/4.1.3/linux-229-hauppauge-hvr-2205-and-2255.patch
@@ -134,7 +134,7 @@ diff -urN a/drivers/media/pci/saa7164/saa7164-cards.c b/drivers/media/pci/saa716
 +			.name		= "SI2168-1",
 +			.i2c_bus_nr	= SAA7164_I2C_BUS_2,
 +			.i2c_bus_addr	= 0xc8 >> 1,
-+			.i2c_reg_len	= REGLEN_8bit,
++			.i2c_reg_len	= REGLEN_0bit,
 +		}, {
 +			.id		= 0x25,
 +			.type		= SAA7164_UNIT_TUNER,
@@ -148,7 +148,7 @@ diff -urN a/drivers/media/pci/saa7164/saa7164-cards.c b/drivers/media/pci/saa716
 +			.name		= "SI2168-2",
 +			.i2c_bus_nr	= SAA7164_I2C_BUS_2,
 +			.i2c_bus_addr	= 0xcc >> 1,
-+			.i2c_reg_len	= REGLEN_8bit,
++			.i2c_reg_len	= REGLEN_0bit,
 +		} },
 +	},
  };


### PR DESCRIPTION
Fix the i2c reglen in the HVR-2205 patch. This is now confirmed and working. Sorry for the noise... 

User Hoffy in the forum reported and retested this:
http://openelec.tv/forum/82-dvb-t-t2-support/77386-hauppauge-hvr-2205-support?start=15