### PR TITLE
[KODI/PVR] fix shutter in tv playback

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.01-PR7593-pvr-fix-shutter.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.01-PR7593-pvr-fix-shutter.patch
@@ -1,0 +1,30 @@
+From f1d16a914a4ca6b99f916606fbba811adc083849 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Wed, 22 Jul 2015 16:41:34 +0200
+Subject: [PATCH] [pvr] fix stuttering indruduced by
+ 9c3adb5a9f390ad73c52469ed79de297dad68d80
+
+---
+ xbmc/pvr/PVRGUIInfo.cpp | 9 ++++++++-
+ 1 file changed, 8 insertions(+), 1 deletion(-)
+
+diff --git a/xbmc/pvr/PVRGUIInfo.cpp b/xbmc/pvr/PVRGUIInfo.cpp
+index 627fa77..d64b598 100644
+--- a/xbmc/pvr/PVRGUIInfo.cpp
++++ b/xbmc/pvr/PVRGUIInfo.cpp
+@@ -681,7 +681,14 @@ void CPVRGUIInfo::UpdateBackendCache(void)
+ 
+   // Update the backend information for all backends once per iteration
+   if (m_iCurrentActiveClient == 0)
+-    m_backendProperties = g_PVRClients->GetBackendProperties();
++  {
++    std::vector<SBackend> backendProperties;
++    {
++      CSingleExit exit(m_critSection);
++      backendProperties = g_PVRClients->GetBackendProperties();
++    }
++    m_backendProperties = backendProperties;
++  }
+ 
+   // Get the properties for the currently active backend
+   const auto &backend = GetCurrentActiveBackend();

--- a/packages/mediacenter/kodi/patches/kodi-999.02-PR7617-pvr-holding.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.02-PR7617-pvr-holding.patch
@@ -1,0 +1,39 @@
+From ec41388ebee3b100445ac34fdafab25242c09559 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Thu, 23 Jul 2015 13:04:58 +0200
+Subject: [PATCH] [pvr] fix holding lock while querying backend
+
+---
+ xbmc/pvr/addons/PVRClients.cpp | 17 +++++++++++++----
+ 1 file changed, 13 insertions(+), 4 deletions(-)
+
+diff --git a/xbmc/pvr/addons/PVRClients.cpp b/xbmc/pvr/addons/PVRClients.cpp
+index d09e195..32e0526 100644
+--- a/xbmc/pvr/addons/PVRClients.cpp
++++ b/xbmc/pvr/addons/PVRClients.cpp
+@@ -261,12 +261,21 @@ bool CPVRClients::GetClientName(int iClientId, std::string &strName) const
+ std::vector<SBackend> CPVRClients::GetBackendProperties() const
+ {
+   std::vector<SBackend> backendProperties;
+-  CSingleLock lock(m_critSection);
++  std::vector<PVR_CLIENT> clients;
++
++  {
++    CSingleLock lock(m_critSection);
++
++    for (PVR_CLIENTMAP_CITR itr = m_clientMap.begin(); itr != m_clientMap.end(); itr++)
++    {
++      PVR_CLIENT client = itr->second;
++      if (client)
++        clients.push_back(client);
++    }
++  }
+ 
+-  for (const auto &entry : m_clientMap)
++  for (const auto &client : clients)
+   {
+-    const auto &client = entry.second;
+-    
+     if (!client->ReadyToUse())
+       continue;
+ 


### PR DESCRIPTION
Backport https://github.com/xbmc/xbmc/pull/7593 and https://github.com/xbmc/xbmc/pull/7617
Both are merged upstream for 15.1.

Fixes shutter of tv playback.
Tested on RPi2 with master and 5.95.3. No shutter after 2hours of playback.
Without this patch, shuttering starts after 1-5min.