### PR TITLE
scripts/image: do not symlink /usr/var

### DIFF
--- a/scripts/image
+++ b/scripts/image
@@ -80,7 +80,6 @@ fi
   mkdir -p $INSTALL/var
   mkdir -p $INSTALL/flash
   mkdir -p $INSTALL/storage
-  ln -sf /var $INSTALL/usr/var
   ln -sf /var/media $INSTALL/media
 
   if [ "$TARGET_ARCH" = "x86_64" -o "$TARGET_ARCH" = "powerpc64" ]; then


### PR DESCRIPTION
this seems to be leftover from pre-y2k days

