### PR TITLE
buildsys improvements

### DIFF
--- a/scripts/build
+++ b/scripts/build
@@ -53,8 +53,14 @@ STAMP=$STAMPS/$PACKAGE_NAME/build_$TARGET
 
 $SCRIPTS/unpack $PACKAGE_NAME
 
-if [ -f $STAMP -a $PKG_DIR/package.mk -nt $STAMP ]; then
-  rm -f $STAMP
+STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
+
+if [ -f $STAMP ] ; then
+  . $STAMP
+  PKG_DEEPMD5=$(md5deep -r $STAMP_DEPENDS 2>/dev/null | sort | md5sum | cut -d" " -f1)
+  if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
+    rm -f $STAMP
+  fi
 fi
 
 if [ ! -f $STAMP ]; then
@@ -358,7 +364,8 @@ if [ ! -f $STAMP ]; then
       $SED "s:\(['= ]\)/usr:\\1$SYSROOT_PREFIX/usr:g" $i; \
     done
 
-    for i in `sed -n "s/^\([^#].*\)=\".*$/\1/p" $PROJECT_DIR/$PROJECT/options | grep -v "#"`; do
+    PKG_DEEPMD5=$(md5deep -r $STAMP_DEPENDS 2>/dev/null | sort | md5sum | cut -d" " -f1)
+    for i in PKG_NAME PKG_DEEPMD5; do
       eval val=\$$i
       echo "STAMP_$i=\"$val\"" >> $STAMP
     done

--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -31,8 +31,8 @@ case $1 in
     deps_pkg="wget"
     ;;
   build)
-    deps="bash bc gcc g++ sed patch touch tar bzip2 gzip perl cp gawk makeinfo gperf zip unzip mkfontscale mkfontdir bdftopcf diff xsltproc java"
-    deps_pkg="bash bc gcc g++ sed patch fileutils tar bzip2 gzip perl coreutils gawk texinfo gperf zip unzip xfonts-utils xfonts-utils xfonts-utils diff xsltproc default-jre"
+    deps="bash bc gcc g++ sed patch touch tar bzip2 gzip perl cp gawk makeinfo gperf zip unzip mkfontscale mkfontdir bdftopcf diff xsltproc java md5deep"
+    deps_pkg="bash bc gcc g++ sed patch fileutils tar bzip2 gzip perl coreutils gawk texinfo gperf zip unzip xfonts-utils xfonts-utils xfonts-utils diff xsltproc default-jre md5deep"
     files="/usr/include/stdio.h /usr/include/ncurses.h"
     files_pkg="libc6-dev libncurses5-dev"
     if [ -f /etc/redhat-release ]; then

--- a/scripts/skip_unpack
+++ b/scripts/skip_unpack
@@ -1,0 +1,46 @@
+#!/bin/bash
+
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+. config/options $1
+
+if [ -z "$1" ]; then
+  echo "usage: $0 package_name"
+  exit 1
+fi
+
+if [ ! -f $PKG_DIR/package.mk ]; then
+  printf "${boldred}$1: no package.mk file found${endcolor}\n"
+  exit 1
+fi
+
+STAMP=$PKG_BUILD/.openelec-unpack
+
+if [ -f $STAMP ] ; then
+  printf "%${BUILD_INDENT}c ${boldcyan}SKIP_UNPACK${endcolor}   $1\n" ' '>&$SILENT_OUT
+  export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
+
+  rm -f $STAMP
+  STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
+  PKG_DEEPMD5=$(md5deep -r $STAMP_DEPENDS 2>/dev/null | sort | md5sum | cut -d" " -f1)
+  for i in PKG_NAME PKG_DEEPMD5; do
+    eval val=\$$i
+    echo "STAMP_$i=\"$val\"" >> $STAMP
+  done
+fi

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -38,36 +38,19 @@ mkdir -p $BUILD
 
 [ ! -d "$SOURCES/$1" -a ! -d "$PKG_DIR/sources" ] && exit 0
 
+STAMP_DEPENDS="$PKG_DIR $PKG_NEED_UNPACK $PROJECT_DIR/$PROJECT/patches/$PKG_NAME"
+
 for i in $BUILD/$1-*; do
   if [ -d $i -a -f "$i/.openelec-unpack" ] ; then
     . "$i/.openelec-unpack"
     if [ "$STAMP_PKG_NAME" = "$1" ]; then
-      # trigger unpack / full rebuild on any package.mk change
-      if [ $PKG_DIR/package.mk -nt "$i/.openelec-unpack" ]; then
-        CLEAN_SOURCE=yes
-        break
+      PKG_DEEPMD5=$(md5deep -r $STAMP_DEPENDS 2>/dev/null | sort | md5sum | cut -d" " -f1)
+      if [ ! "$PKG_DEEPMD5" = "$STAMP_PKG_DEEPMD5" ] ; then
+        $SCRIPTS/clean $1
       fi
-      # handle $PKG_NEED_UNPACK
-      for file in $PKG_NEED_UNPACK; do
-        if [ -f "$file" -a "$file" -nt "$i/.openelec-unpack" ] ; then
-          CLEAN_SOURCE=yes
-          break
-        fi
-      done
-      # trigger unpack / full rebuild on any patch / script / etc.. change
-      for file in $PKG_DIR/{patches,scripts,config}/* $PKG_DIR/patches/$PKG_VERSION/*.patch $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/*.patch; do
-        if [ -f "$file" -a "$file" -nt "$i/.openelec-unpack" ]; then
-          CLEAN_SOURCE=yes
-          break
-        fi
-      done
     fi
   fi
 done
-
-if [ "$CLEAN_SOURCE" = "yes" ]; then
-  $SCRIPTS/clean $1
-fi
 
 [ -f "$STAMP" ] && exit 0
 
@@ -165,7 +148,8 @@ done
 
 rm -f $STAMPS/$1/build_*
 
-for i in PKG_NAME PKG_VERSION PKG_REV PKG_SHORTDESC PKG_LONGDESC PKG_SITE PKG_URL PKG_SECTION; do
+PKG_DEEPMD5=$(md5deep -r $STAMP_DEPENDS 2>/dev/null | sort | md5sum | cut -d" " -f1)
+for i in PKG_NAME PKG_DEEPMD5; do
   eval val=\$$i
-  echo "STAMP_$i=\"$val"\" >> $STAMP
+  echo "STAMP_$i=\"$val\"" >> $STAMP
 done


### PR DESCRIPTION
instead of comparing "timestamps" (package.mk newer than $STAMP and so on), this aims to detect changes by comparing md5 sums of the whole package dir (via md5deep)

this is good for people who need to do huge rebases often (or switching branches back and forth without actualy building). 