### PR TITLE
cmake: set CMAKE_SYSTEM_PROCESSOR in toolchain file

### DIFF
--- a/packages/devel/cmake/package.mk
+++ b/packages/devel/cmake/package.mk
@@ -51,6 +51,9 @@ SET(CMAKE_SYSTEM_NAME Linux)
 #this one not so much
 SET(CMAKE_SYSTEM_VERSION 1)
 
+# processor (or hardware) of the target system
+SET(CMAKE_SYSTEM_PROCESSOR  $TARGET_ARCH)
+
 # specify the cross compiler
 SET(CMAKE_C_COMPILER   $TARGET_CC)
 SET(CMAKE_CXX_COMPILER $TARGET_CXX)


### PR DESCRIPTION
no idea how important this is. docs say "optional, not used much" but @wsnipex said it's good practice to set it. 

ping @sraue 