### PR TITLE
brcmfmac_sdio-firmware: fix service type

### DIFF
--- a/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac_sdio-firmware-aml@.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac_sdio-firmware-aml@.service
@@ -3,6 +3,6 @@ Description=Broadcom sdio firmware update for %I
 ConditionPathExists=/dev/ttyS1
 
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=yes
 ExecStart=/usr/bin/brcm_patchram_plus --patchram /lib/firmware/brcm/%I.hcd --baudrate 3000000 --use_baudrate_for_download /dev/ttyS1 --enable_hci --no2bytes --tosleep=50000

--- a/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac_sdio-firmware-imx@.service
+++ b/packages/linux-firmware/brcmfmac_sdio-firmware/system.d/brcmfmac_sdio-firmware-imx@.service
@@ -3,6 +3,6 @@ Description=Broadcom sdio firmware update for %I
 ConditionPathExists=/dev/ttymxc3
 
 [Service]
-Type=oneshot
+Type=simple
 RemainAfterExit=yes
 ExecStart=/usr/bin/brcm_patchram_plus --patchram /lib/firmware/brcm/%I.hcd --baudrate 3000000 --use_baudrate_for_download /dev/ttymxc3 --enable_hci --no2bytes --tosleep=50000


### PR DESCRIPTION
should be simple, not oneshot.

because:

meh:~ # systemd-analyze
Bootup is not yet finished. Please try again later.
