### PR TITLE
Use a temporary filename when creating new crashlog

### DIFF
--- a/packages/mediacenter/kodi/scripts/kodi.sh
+++ b/packages/mediacenter/kodi/scripts/kodi.sh
@@ -49,7 +49,7 @@ print_crash_report()
     mkdir -p $CRASHLOG_DIR
   fi
   DATE=`date +%Y%m%d%H%M%S`
-  FILE="$CRASHLOG_DIR/kodi_crashlog_$DATE.log"
+  FILE="$CRASHLOG_DIR/.kodi_crashlog.log"
   echo "############## kodi CRASH LOG ###############" > $FILE
   echo >> $FILE
   echo "################ SYSTEM INFO ################" >> $FILE
@@ -80,6 +80,9 @@ print_crash_report()
   echo "############### END LOG FILE ################" >> $FILE
   echo >> $FILE
   echo "############ END kodi CRASH LOG #############" >> $FILE
+  OFILE="$FILE"
+  FILE="$CRASHLOG_DIR/kodi_crashlog_$DATE.log"
+  mv "$OFILE" "$FILE"
   echo "Crash report available at $FILE"
 }
 


### PR DESCRIPTION
Creating a new crashlog sometimes takes a while, and requesting users to "upload the latest crashlog" has resulted in partial crashlogs being presented (ie. the crashlog is being created as they're uploading it).

Using a temporary filename until the crashlog is complete would help alleviate this problem.