### PR TITLE
Add drivers for RTL8192EU

### DIFF
--- a/distributions/OpenELEC/options
+++ b/distributions/OpenELEC/options
@@ -60,7 +60,7 @@
 # for a list of additinoal drivers see packages/linux-drivers
 # Space separated list is supported,
 # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU RTL8812AU dvbhdhomerun"
+  ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8192EU RTL8188EU RTL8812AU dvbhdhomerun"
 
 # build and install bluetooth support (yes / no)
   BLUETOOTH_SUPPORT="yes"

--- a/packages/linux-drivers/RTL8192EU/package.mk
+++ b/packages/linux-drivers/RTL8192EU/package.mk
@@ -1,0 +1,52 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2015 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="RTL8192EU"
+PKG_VERSION="6793bae"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="https://github.com/Mange/rtl8192eu-linux-driver"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain linux"
+PKG_NEED_UNPACK="$LINUX_DEPENDS"
+PKG_PRIORITY="optional"
+PKG_SECTION="driver"
+PKG_SHORTDESC="Realtek RTL8192EU Linux 3.x driver"
+PKG_LONGDESC="Realtek RTL8192EU Linux 3.x driver"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="no"
+
+pre_make_target() {
+  unset LDFLAGS
+}
+
+make_target() {
+  make V=1 \
+       ARCH=$TARGET_ARCH \
+       KSRC=$(kernel_path) \
+       CROSS_COMPILE=$TARGET_PREFIX \
+       CONFIG_POWER_SAVING=n \
+       USER_EXTRA_CFLAGS="-Wno-error=date-time"
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME
+    cp *.ko $INSTALL/lib/modules/$(get_module_dir)/$PKG_NAME
+}

--- a/tools/mkpkg/mkpkg_RTL8192EU
+++ b/tools/mkpkg/mkpkg_RTL8192EU
@@ -1,0 +1,43 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2015 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+echo "getting sources..."
+  if [ ! -d RTL8192EU.git ]; then
+    git clone https://github.com/Mange/rtl8192eu-linux-driver.git --depth=1 -b master RTL8192EU.git
+  fi
+
+  cd RTL8192EU.git
+    git pull
+    GIT_REV=`git log -n1 --format=%h`
+  cd ..
+
+echo "copying sources..."
+  rm -rf RTL8192EU-$GIT_REV
+  cp -R RTL8192EU.git RTL8192EU-$GIT_REV
+
+echo "cleaning sources..."
+  rm -rf RTL8192EU-$GIT_REV/.git
+
+echo "packing sources..."
+  tar cvJf RTL8192EU-$GIT_REV.tar.xz RTL8192EU-$GIT_REV
+
+echo "remove temporary sourcedir..."
+  rm -rf RTL8192EU-$GIT_REV


### PR DESCRIPTION
This includes D-Link Wireless N300 Nano USB Adapter DWA-131 (Rev E1; USB ID: 2001:3319).

To be 100% honest now, most of this is cargo culted on my part. I copied the package for RTL8192**D**U and worked from that one. I found a new repo that hosted the source code for this chipset's driver and updated everything I could find.

I can't try this out currently as it tries to download the source code from `http://sources.openelec.tv/mirror/RTL8192EU/RTL8192EU-9e65859.tar.xz` and that URL obviously does not exist. Can I get it to compile from a local copy of the repo so I can verify this is working first?

Any suggestions on how to proceeed?

**TODO:**
- [ ] Pass review.
- [x] Make sure driver loads correctly and works for me.

---

Might I just say, your build pipeline is amazing. Great job! It's welcoming, easy and has great output. Everything's top-notch. I can see you spend time refining this, and I want to commend all of you for it.