### PR TITLE
Python: update to Python-2.7.10

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="Python"
-PKG_VERSION="2.7.3"
+PKG_VERSION="2.7.10"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
@fritsch @sraue 

I admit, this is completely untested. I don't use OpenELEC, much less package for it. But quite a few of my Kodi addon's users are running into [this python bug](https://stackoverflow.com/questions/29099404/ssl-insecureplatform-error-when-using-requests-package) and it's fixed by either Python >= 2.7.9 or pyOpenSSL.

I was encouraged to submit a one-liner PR, so here it is. :-)

I see in the changelog that some earlier version bumps (with surrounding patches) were reverted. But I didn't see an explanation for why. Perhaps we'll be lucky and this one-liner will work.

---Alex