### PR TITLE
Fix openssh-7.0p1 package after 24e80bbc - fixes #4280

### DIFF
--- a/packages/network/openssh/package.mk
+++ b/packages/network/openssh/package.mk
@@ -63,6 +63,9 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin/ssh-add
   rm -rf $INSTALL/usr/bin/ssh-agent
   rm -rf $INSTALL/usr/bin/ssh-keyscan
+
+  sed -i $INSTALL/etc/ssh/sshd_config -e "s|^#PermitRootLogin.*|PermitRootLogin yes|g"
+  echo "PubkeyAcceptedKeyTypes +ssh-dss" >> $INSTALL/etc/ssh/sshd_config
 }
 
 post_install() {


### PR DESCRIPTION
Enable root password login and ssh-dss public key.

Courtesy of @stefansaraev on #irc.