### PR TITLE
[rbp]Add MediaTek WiFi driver option (unset)

### DIFF
--- a/projects/RPi/linux/linux.arm.conf
+++ b/projects/RPi/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.1.2 Kernel Configuration
+# Linux/arm 4.1.6 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -1225,6 +1225,7 @@ CONFIG_RT2X00_LIB_CRYPTO=y
 CONFIG_RT2X00_LIB_LEDS=y
 # CONFIG_RT2X00_DEBUG is not set
 CONFIG_RTL_CARDS=m
+# CONFIG_WL_MEDIATEK is not set
 # CONFIG_RTL8192CU is not set
 # CONFIG_WL_TI is not set
 CONFIG_ZD1211RW=m
@@ -3018,7 +3019,6 @@ CONFIG_COMMON_CLK=y
 # CONFIG_SH_TIMER_TMU is not set
 # CONFIG_EM_TIMER_STI is not set
 CONFIG_MAILBOX=y
-CONFIG_BCM2708_MBOX=y
 # CONFIG_ARM_MHU is not set
 # CONFIG_PL320_MBOX is not set
 # CONFIG_ALTERA_MBOX is not set

--- a/projects/RPi2/linux/linux.arm.conf
+++ b/projects/RPi2/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 4.1.2 Kernel Configuration
+# Linux/arm 4.1.6 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -1277,6 +1277,7 @@ CONFIG_RT2X00_LIB_CRYPTO=y
 CONFIG_RT2X00_LIB_LEDS=y
 # CONFIG_RT2X00_DEBUG is not set
 CONFIG_RTL_CARDS=m
+# CONFIG_WL_MEDIATEK is not set
 # CONFIG_RTL8192CU is not set
 # CONFIG_WL_TI is not set
 CONFIG_ZD1211RW=m
@@ -3073,7 +3074,6 @@ CONFIG_ARM_ARCH_TIMER_EVTSTREAM=y
 # CONFIG_SH_TIMER_TMU is not set
 # CONFIG_EM_TIMER_STI is not set
 CONFIG_MAILBOX=y
-CONFIG_BCM2708_MBOX=y
 # CONFIG_ARM_MHU is not set
 # CONFIG_PL320_MBOX is not set
 # CONFIG_ALTERA_MBOX is not set


### PR DESCRIPTION
The MediaTek option is new in 4.1.6 and required for a successful build.

Also drop CONFIG_BCM2708_MBOX as this is no longer required.