### PR TITLE
pkg-config: allow pkg-config:host to be rebuilt

### DIFF
--- a/packages/devel/pkg-config/patches/pkg-config-01_rebuild.patch
+++ b/packages/devel/pkg-config/patches/pkg-config-01_rebuild.patch
@@ -1,0 +1,26 @@
+diff --git a/Makefile.am b/Makefile.am
+index 41e48e8..7178ec8 100644
+--- a/Makefile.am
++++ b/Makefile.am
+@@ -39,7 +39,7 @@ pkg_config_SOURCES= \
+ if HOST_TOOL
+ host_tool = $(host)-pkg-config$(EXEEXT)
+ install-exec-hook:
+-	cd $(DESTDIR)$(bindir) && $(LN) pkg-config$(EXEEXT) $(host_tool)
++	cd $(DESTDIR)$(bindir) && rm -f $(host_tool) && $(LN) pkg-config$(EXEEXT) $(host_tool)
+ uninstall-hook:
+ 	cd $(DESTDIR)$(bindir) && rm -f $(host_tool)
+ endif
+diff --git a/Makefile.in b/Makefile.in
+index a1ad77c..88a421c 100644
+--- a/Makefile.in
++++ b/Makefile.in
+@@ -1093,7 +1093,7 @@ uninstall-man: uninstall-man1
+ 	uninstall-man1
+ 
+ @HOST_TOOL_TRUE@install-exec-hook:
+-@HOST_TOOL_TRUE@	cd $(DESTDIR)$(bindir) && $(LN) pkg-config$(EXEEXT) $(host_tool)
++@HOST_TOOL_TRUE@	cd $(DESTDIR)$(bindir) && rm -f $(host_tool) && $(LN) pkg-config$(EXEEXT) $(host_tool)
+ @HOST_TOOL_TRUE@uninstall-hook:
+ @HOST_TOOL_TRUE@	cd $(DESTDIR)$(bindir) && rm -f $(host_tool)
+ 


### PR DESCRIPTION
because joe the builder dont want to "make clean" even when he is supposed to. 

however. it's a bug. 