### PR TITLE
Include RPi 2 overlock mode preset

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
+++ b/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
@@ -48,7 +48,8 @@
 # mode 'Modest'                 :    800   |    300    |    400     |      0
 # mode 'Medium'                 :    900   |    333    |    450     |      2
 # mode 'High'                   :    950   |    450    |    450     |      6
-# mode 'Turbo'                  :   1000   |    500    |    500     |      6
+# mode 'Turbo'                  :   1000   |    500    |    600     |      6
+# mode 'Pi2'                    :   1000   |    500    |    500     |      2
 
 # arm_freq=700
 # core_freq=250


### PR DESCRIPTION
From the official RPi config tool: https://github.com/asb/raspi-config/commit/4ee1fde44ee544a7eade9ecf94141eb40aabab60

A small fix for turbo to match the config tool and an additional RPi2 preset.
Several tutorials only talk about 1000-500-500, but it actually needs the over_voltage in this config to be stable. So I think it's good to have it mentioned in the default config comments.