### PR TITLE
linux: add Elgato EyeTV Sat v3 (maybe v2.x)

### DIFF
--- a/packages/linux/patches/4.1.6/linux-230-elgato-eyetv-sat-v3.patch
+++ b/packages/linux/patches/4.1.6/linux-230-elgato-eyetv-sat-v3.patch
@@ -1,0 +1,50 @@
+diff --git a/drivers/media/usb/dvb-usb/az6027.c b/drivers/media/usb/dvb-usb/az6027.c
+index 92e47d6..2e71136 100644
+--- a/drivers/media/usb/dvb-usb/az6027.c
++++ b/drivers/media/usb/dvb-usb/az6027.c
+@@ -1090,6 +1090,7 @@ static struct usb_device_id az6027_usb_table[] = {
+ 	{ USB_DEVICE(USB_VID_TECHNISAT, USB_PID_TECHNISAT_USB2_HDCI_V2) },
+ 	{ USB_DEVICE(USB_VID_ELGATO, USB_PID_ELGATO_EYETV_SAT) },
+ 	{ USB_DEVICE(USB_VID_ELGATO, USB_PID_ELGATO_EYETV_SAT_V2) },
++	{ USB_DEVICE(USB_VID_ELGATO, USB_PID_ELGATO_EYETV_SAT_V3) },
+ 	{ },
+ };
+ 
+@@ -1138,7 +1139,7 @@ static struct dvb_usb_device_properties az6027_properties = {
+ 
+ 	.i2c_algo         = &az6027_i2c_algo,
+ 
+-	.num_device_descs = 7,
++	.num_device_descs = 8,
+ 	.devices = {
+ 		{
+ 			.name = "AZUREWAVE DVB-S/S2 USB2.0 (AZ6027)",
+@@ -1168,6 +1169,10 @@ static struct dvb_usb_device_properties az6027_properties = {
+ 			.name = "Elgato EyeTV Sat",
+ 			.cold_ids = { &az6027_usb_table[6], NULL },
+ 			.warm_ids = { NULL },
++		}, {
++			.name = "Elgato EyeTV Sat",
++			.cold_ids = { &az6027_usb_table[7], NULL },
++			.warm_ids = { NULL },
+ 		},
+ 		{ NULL },
+ 	}
+
+warning: LF will be replaced by CRLF in az6027.c.
+The file will have its original line endings in your working directory.
+diff --git a/drivers/media/dvb-core/dvb-usb-ids.h b/drivers/media/dvb-core/dvb-usb-ids.h
+index c117fb3..7552f38 100644
+--- a/drivers/media/dvb-core/dvb-usb-ids.h
++++ b/drivers/media/dvb-core/dvb-usb-ids.h
+@@ -365,6 +365,7 @@
+ #define USB_PID_ELGATO_EYETV_DTT_Dlx			0x0020
+ #define USB_PID_ELGATO_EYETV_SAT			0x002a
+ #define USB_PID_ELGATO_EYETV_SAT_V2			0x0025
++#define USB_PID_ELGATO_EYETV_SAT_V3			0x0036
+ #define USB_PID_DVB_T_USB_STICK_HIGH_SPEED_COLD		0x5000
+ #define USB_PID_DVB_T_USB_STICK_HIGH_SPEED_WARM		0x5001
+ #define USB_PID_FRIIO_WHITE				0x0001
+
+warning: LF will be replaced by CRLF in dvb-usb-ids.h.
+The file will have its original line endings in your working directory.


### PR DESCRIPTION
This adds support for Elgato EyeTV Sat v3 or maybe 2.x (revision is a bit unclear).
It is the same hardware (as already supported v1, v2) with a different hw id.


ping @trsqr if this is a valid fix [(fix is working of course)](http://openelec.tv/forum/83-dvb-s-s2-support/78070-elgato-eyetv-sat#147269)