### PR TITLE
(fix) fix util-linux:host after 490ce24

### DIFF
--- a/packages/sysutils/util-linux/package.mk
+++ b/packages/sysutils/util-linux/package.mk
@@ -77,7 +77,7 @@ if [ "$SWAP_SUPPORT" = "yes" ]; then
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-swapon"
 fi
 
-PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared $UTILLINUX_CONFIG_DEFAULT"
+PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared --enable-libuuid --disable-wall"
 
 PKG_CONFIGURE_OPTS_INIT="--prefix=/ \
                          --bindir=/bin \


### PR DESCRIPTION
- parted:host needs libuuid
- mkimage needs uuidgen. --disable-all-programs is meh

EDIT: and well. f**k wall. there is chgrp wtf in Makefile. no-go without fakeroot.

@sraue 