### PR TITLE
Allow building with xf86-input-libinput when specified

### DIFF
--- a/packages/virtual/x11/package.mk
+++ b/packages/virtual/x11/package.mk
@@ -47,8 +47,14 @@ if [ -n "$WINDOWMANAGER" -a "$WINDOWMANAGER" != "none" ]; then
 fi
 
 get_graphicdrivers
-# Drivers
+
+# Drivers 
+if [ -n $LIBINPUT ]; then
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-libinput"
+else
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-evdev"
-  for drv in $XORG_DRIVERS; do
-    PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-video-$drv"
-  done
+fi
+
+for drv in $XORG_DRIVERS; do
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-video-$drv"
+done

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libinput"
-PKG_VERSION="0.21.0"
+PKG_VERSION="1.0.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
I'd like to still use libinput for testing on my builds (others may too) so adding LIBINPUT="yes" to you local options file will build xf86-input-libinput instead of xf86-input-evdev.

Also bumping libinput to version 1.0.1
