### PR TITLE
(jarvis) giflib: update to giflib-5.1.1

### DIFF
--- a/packages/graphics/giflib/package.mk
+++ b/packages/graphics/giflib/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="giflib"
-PKG_VERSION="5.0.5"
+PKG_VERSION="5.1.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
used only for texturepacker (host). safe to bump