### PR TITLE
Fix error in #4324 that always meant libinput is built

### DIFF
--- a/packages/virtual/x11/package.mk
+++ b/packages/virtual/x11/package.mk
@@ -49,7 +49,7 @@ fi
 get_graphicdrivers
 
 # Drivers 
-if [ -n $LIBINPUT ]; then
+if [ -n "$LIBINPUT" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-libinput"
 else
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET xf86-input-evdev"


### PR DESCRIPTION
See discussion in #4324 - thanks @stefansaraev.