### PR TITLE
libhdhomerun: revert #4327

### DIFF
--- a/packages/multimedia/libhdhomerun/package.mk
+++ b/packages/multimedia/libhdhomerun/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libhdhomerun"
-PKG_VERSION="20150826"
+PKG_VERSION="20150406"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"


### PR DESCRIPTION
Revert #4327, OpenELEC fails to build with libhdhomerun version 20150826