### PR TITLE
installer: get rid of fs labels. use UUIDs instead.

### DIFF
--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -377,124 +377,6 @@ do_install_quick() {
   esac
 }
 
-do_install_custom() {
-  # show menu
-  MSG_TITLE="\Z4[ REPAIR/UPGRADE MENU ]\Zn"
-  MSG_MENU="\nUse the up/down arrows to select the correct partition where you want to overwrite KERNEL and SYSTEM files.\n\n Please select a partition:"
-  MSG_CANCEL="Back"
-  DIALOG_OPTIONS="--defaultno"
-
-  get_device_unmount
-
-  if [ "$DEVICES" = "" ]; then
-    msg_no_device
-  fi
-
-  PARTITION_LIST=""
-  for device in $DEVICES; do
-    get_partition $device
-    for partition in $PARTITIONS; do
-      LABEL=$(tune2fs -l $device$partition | awk 'BEGIN {FS=":"} /Filesystem volume name/ {gsub(/ /,"",$2); print $2}')
-      if [ "$LABEL" = "$DISKLABEL_SYSTEM" ]; then
-        DEVICE_MODEL=$(parted -s $device -m print | grep ^$device | cut -f7 -d ":" | sed "s/;//")
-        DEVICE_SIZE=$(parted -s $device -m print | grep ^$device | cut -f2 -d ":")
-        DEVICE_NAME=$(echo $DEVICE_MODEL ${DEVICE_SIZE} | sed 's/ /_/g')
-        PARTITION_LIST="$PARTITION_LIST $device$partition $DEVICE_NAME"
-      fi
-    done
-  done
-
-  if [ "$PARTITION_LIST" = "" ]; then
-    msg_no_device
-  fi
-
-  dialog --colors --backtitle "$BACKTITLE" --cancel-label "$MSG_CANCEL" \
-    $DIALOG_OPTIONS --title "$MSG_TITLE" --menu "$MSG_MENU" 20 50 5 \
-    $PARTITION_LIST 2> $TMPDIR/device_for_install
-
-  # now we must do everything
-  case $? in
-    0)
-      INSTALL_PARTITION=$(cat "$TMPDIR/device_for_install")
-      INSTALL_PARTITION_FULL=$(echo $PARTITION_LIST | sed "s|.*$INSTALL_PARTITION \([^ ]*\).*|$INSTALL_PARTITION \1|")
-
-      # check for confirmation (twice!)
-      MSG_TITLE="\Z1[ Confirmation before copying ]\Zn"
-      MSG_DETAIL="\nIf you continue the target partition will be\noverwritten with new KERNEL and SYSTEM files:\n\n$INSTALL_PARTITION_FULL\n\n"
-      DIALOG_OPTIONS="--defaultno"
-      dialog --colors --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
-        $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
-      if [ $? -ne 0 ]; then
-        menu_main
-      fi
-
-      MSG_TITLE="\Z1[ Confirmation before copying ]\Zn"
-      MSG_DETAIL="\nThis is last chance to abort the copying!\n\nIf you continue the target partition will be\noverwritten with new KERNEL and SYSTEM files:\n\n$INSTALL_PARTITION_FULL\n\n\n"
-      DIALOG_OPTIONS="--defaultno"
-      dialog --colors --backtitle "$BACKTITLE" --title "$MSG_TITLE" \
-        $DIALOG_OPTIONS --yesno "$MSG_DETAIL" 0 0
-      if [ $? -ne 0 ]; then
-        menu_main
-      fi
-
-      # mount system partition
-      msg_progress_install "5" "creating $TMPDIR/part1"
-      mkdir -p $TMPDIR/part1 >> $LOGFILE 2>&1
-
-      msg_progress_install "10" "mounting $INSTALL_PARTITION to $TMPDIR/part1"
-      mount -t ext4 $INSTALL_PARTITION $TMPDIR/part1 >> $LOGFILE 2>&1
-
-      # check for enough target space
-      msg_progress_install "15" "checking for space on $INSTALL_PARTITION"
-
-      KERNEL_SIZE=$(stat -t /flash/KERNEL | awk '{print $2}')
-      SYSTEM_SIZE=$(stat -t /flash/SYSTEM | awk '{print $2}')
-      SRC_SIZE=$(( $KERNEL_SIZE + $SYSTEM_SIZE ))
-
-      DEST_SIZE=$(df $TMPDIR/part1 | awk '/[0-9]%/{print $4}')
-      DEST_SIZE=$(( $DEST_SIZE * 1024 ))
-      if [ -f $TMPDIR/part1/KERNEL ]; then
-        KERNEL_SIZE=$(stat -t $TMPDIR/part1/KERNEL | awk '{print $2}')
-        DEST_SIZE=$(( $DEST_SIZE + $KERNEL_SIZE ))
-      fi
-      if [ -f $TMPDIR/part1/SYSTEM ]; then
-        SYSTEM_SIZE=$(stat -t $TMPDIR/part1/SYSTEM | awk '{print $2}')
-        DEST_SIZE=$(( $DEST_SIZE + $SYSTEM_SIZE ))
-      fi
-
-      if [ $SRC_SIZE -ge $DEST_SIZE ]; then
-        umount $TMPDIR/part1 >> $LOGFILE 2>&1
-        rmdir $TMPDIR/part1 >> $LOGFILE 2>&1
-        msg_target_space
-        menu_main
-      fi
-
-      # install system files
-      msg_progress_install "20" "installing Kernel"
-      cp /flash/KERNEL $TMPDIR/part1 >> $LOGFILE 2>&1
-
-      msg_progress_install "40" "installing System"
-      cp /flash/SYSTEM $TMPDIR/part1 >> $LOGFILE 2>&1
-      sync
-
-      # umount system partition, remove mountpoint
-      msg_progress_install "95" "unmount $TMPDIR/part1"
-      umount $TMPDIR/part1 >> $LOGFILE 2>&1
-
-      msg_progress_install "100" "remove $TMPDIR/part1"
-      rmdir $TMPDIR/part1 >> $LOGFILE 2>&1
-
-      menu_main
-      ;;
-    1)
-      menu_main
-      ;;
-    255)
-      do_poweroff
-      ;;
-  esac
-}
-
 msg_no_device() {
   # show a warning dialog if we dont find not mounted devices for install and return to main menu
   MSG_TITLE="\Z1[ WARNING ]\Zn"
@@ -577,16 +459,14 @@ menu_main() {
   dialog --colors --backtitle "$BACKTITLE" --cancel-label "$MSG_CANCEL" \
     --title "$MSG_TITLE" --menu "$MSG_MENU" 20 70 5 \
       1 "Quick Install of OpenELEC" \
-      2 "Repair / Upgrade" \
-      3 "Show logfile" 2> $TMPDIR/mainmenu
+      2 "Show logfile" 2> $TMPDIR/mainmenu
 
   case $? in
     0)
       ITEM_MAINMENU=$(cat "$TMPDIR/mainmenu")
       case $ITEM_MAINMENU in
         1) do_install_quick; break;;
-        2) do_install_custom; break;;
-        3) logfile_show; break;;
+        2) logfile_show; break;;
       esac
       ;;
     1)

--- a/packages/tools/installer/scripts/installer
+++ b/packages/tools/installer/scripts/installer
@@ -275,23 +275,19 @@ do_install_quick() {
       # create filesystem
       msg_progress_install "23" "creating filesystem on ${INSTALL_DEVICE}1"
       if [ "$UEFI" = "1" ]; then
-        mkfs.vfat ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+        UUID_1=$(date '+%d%m')
+        UUID_2=$(date '+%M%S')
+        FAT_VOL_ID="${UUID_1}${UUID_2}"
+        UUID_SYSTEM="${UUID_1}-${UUID_2}"
+        mkfs.vfat -i "$FAT_VOL_ID" ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
       else
-        mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
-      fi
-
-      msg_progress_install "25" "set uuid and disklabel $DISKLABEL_SYSTEM on ${INSTALL_DEVICE}${PART1}"
-      if [ "$UEFI" = "1" ]; then
-        dosfslabel ${INSTALL_DEVICE}${PART1}  $DISKLABEL_SYSTEM >> $LOGFILE 2>&1
-      else
-        tune2fs -U random -L $DISKLABEL_SYSTEM  ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
+        UUID_SYSTEM="$(uuidgen)"
+        mke2fs -t ext4 -U "$UUID_SYSTEM" -m 0 ${INSTALL_DEVICE}${PART1} >> $LOGFILE 2>&1
       fi
 
       msg_progress_install "28" "creating filesystem on ${INSTALL_DEVICE}${PART2}"
-      mke2fs -t ext4 -m 0 ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
-
-      msg_progress_install "30" "set uuid and disklabel $DISKLABEL_STORAGE on ${INSTALL_DEVICE}${PART2}"
-      tune2fs -U random -L $DISKLABEL_STORAGE  ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
+      UUID_STORAGE="$(uuidgen)"
+      mke2fs -t ext4 -U "$UUID_STORAGE" -m 0 ${INSTALL_DEVICE}${PART2} >> $LOGFILE 2>&1
 
       # mount system partition
       msg_progress_install "35" "creating $TMPDIR/part1"
@@ -321,13 +317,13 @@ do_install_quick() {
       sync
 
       # configuring bootloader
-      msg_progress_install "80" "setup bootloader with boot label = $DISKLABEL_SYSTEM and disk label = $DISKLABEL_STORAGE"
+      msg_progress_install "80" "setup bootloader with boot uuid = $UUID_SYSTEM and disk uuid = $UUID_STORAGE"
       echo "DEFAULT linux" > $TMPDIR/part1/extlinux.conf
       echo "PROMPT 0" >> $TMPDIR/part1/extlinux.conf
       echo " " >> $TMPDIR/part1/extlinux.conf
       echo "LABEL linux" >> $TMPDIR/part1/extlinux.conf
       echo " KERNEL /KERNEL" >> $TMPDIR/part1/extlinux.conf
-      echo " APPEND boot=LABEL=$DISKLABEL_SYSTEM disk=LABEL=$DISKLABEL_STORAGE $EXTLINUX_PARAMETERS quiet" >> $TMPDIR/part1/extlinux.conf
+      echo " APPEND boot=UUID=$UUID_SYSTEM disk=UUID=$UUID_STORAGE $EXTLINUX_PARAMETERS quiet" >> $TMPDIR/part1/extlinux.conf
       # uefi boot / hybrid mode
       if [ "$UEFI" = "1" ]; then
         mv $TMPDIR/part1/extlinux.conf $TMPDIR/part1/syslinux.cfg


### PR DESCRIPTION
here a quite common use case: joe has two fixed disks. joe has openelec 4.x on
disk1, joe wants to install ~~OE6~~ OE7 on disk2 for testing.
so does joe, but next boot, shit happens (blkid / boot order hazzard in init)
disk1 is /flash, disk2 is /storage - new install fucked up, or disk2 is /flash, disk1 is
/storage - old install fucked up  or even worse.. joe mad at ~~us~~ you (you, because I dont care too much)

this fix is imo long overdue, ~~but please do NOT merge for OE6. hold on until master is open for OE7/jarvis~~

this PR also removes the (partialy, on uefi only) broken "custom install / restore" feature. I have no intention to fix it. honestly, I think it is not needed at all and should go. so, please no bikesheding, if you want that feature, feel free to fix it, I'll be more than happy to include your fix in this PR.