### PR TITLE
add new package: packages/sysutils/serdisplib 1.97.9

### DIFF
--- a/distributions/OpenELEC/options
+++ b/distributions/OpenELEC/options
@@ -146,7 +146,7 @@
 
 # LCD driver to Use - Possible drivers are ( Comma seperated:
 # bayrad,CFontz,CFontz633,CFontzPacket,curses,CwLnx,dm140,
-# ea65,EyeboxOne,g15,glcdlib,glk,hd44780,i2500vfd,
+# ea65,EyeboxOne,g15,glcd,glcdlib,glk,hd44780,i2500vfd,
 # icp_a106,imon,imonlcd,IOWarrior,irman,irtrans,
 # joy,lb216,lcdm001,lcterm,lirc,lis,MD8800,mdm166a,
 # ms6931,mtc_s16209x,MtxOrb,mx5000,NoritakeVFD,

--- a/packages/sysutils/lcdproc/package.mk
+++ b/packages/sysutils/lcdproc/package.mk
@@ -37,6 +37,16 @@ if [ "$IRSERVER_SUPPORT" = yes ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET irserver"
 fi
 
+IFS=$','
+for i in $LCD_DRIVER; do
+  case $i in
+    glcd) PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET serdisplib"
+      ;;
+    *)
+  esac
+done
+unset IFS
+
 PKG_CONFIGURE_OPTS_TARGET="--enable-libusb --enable-drivers=$LCD_DRIVER,!curses,!svga --enable-seamless-hbars"
 
 pre_make_target() {
@@ -59,6 +69,7 @@ post_makeinstall_target() {
       -e "s|^#Hello=\"   LCDproc!\"|Hello=\"$DISTRONAME\"|" \
       -e "s|^#GoodBye=\"Thanks for using\"|GoodBye=\"Thanks for using\"|" \
       -e "s|^#GoodBye=\"   LCDproc!\"|GoodBye=\"$DISTRONAME\"|" \
+      -e "s|^#normal_font=.*$|normal_font=/usr/share/fonts/liberation/LiberationMono-Bold.ttf|" \
       -i $INSTALL/etc/LCDd.conf
 
     mkdir -p $INSTALL/usr/lib/openelec

--- a/packages/sysutils/serdisplib/package.mk
+++ b/packages/sysutils/serdisplib/package.mk
@@ -1,0 +1,58 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="serdisplib"
+PKG_VERSION="1.97.9"
+PKG_REV="0"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://serdisplib.sourceforge.net/"
+PKG_URL="$SOURCEFORGE_SRC/$PKG_NAME/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_DEPENDS_TARGET="toolchain libusb-compat"
+PKG_PRIORITY="optional"
+PKG_SECTION="sysutils"
+PKG_SHORTDESC="serdisplib: a lcd control library"
+PKG_LONGDESC="Library to drive serial/parallel/usb displays with built-in controllers"
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+PKG_CONFIGURE_OPTS_TARGET="--prefix=$SYSROOT_PREFIX/usr \
+                           --bindir=$SYSROOT_PREFIX/usr/bin \
+                           --enable-libusb \
+                           --disable-libSDL \
+                           --with-drivers=all"
+
+pre_configure_target() {
+  # serdisplib fails to build in subdirs (found this in packages/devel/attr/package.mk)
+  cd $ROOT/$PKG_BUILD
+    rmdir .$TARGET_NAME
+}
+
+post_make_target() {
+  # copy necessary libs and headers to build the driver glcd from lcdproc
+  mkdir -p $SYSROOT_PREFIX/usr/include/serdisplib
+  cp include/serdisplib/*.h $SYSROOT_PREFIX/usr/include/serdisplib
+  mkdir -p $SYSROOT_PREFIX/usr/lib
+  cp lib/libserdisp.so* $SYSROOT_PREFIX/usr/lib
+}
+
+makeinstall_target() {
+  mkdir -p $INSTALL/usr/lib
+  cp lib/libserdisp.so* $INSTALL/usr/lib
+}

--- a/packages/sysutils/serdisplib/patches/serdisplib-disable_SDL_crosscompile.patch
+++ b/packages/sysutils/serdisplib/patches/serdisplib-disable_SDL_crosscompile.patch
@@ -1,0 +1,57 @@
+diff -Naur serdisplib-1.97.9/configure serdisplib-1.97.9-b/configure
+--- serdisplib-1.97.9/configure	2010-02-21 20:49:29.000000000 +0100
++++ serdisplib-1.97.9-b/configure	2015-06-10 17:49:18.780035766 +0200
+@@ -4347,6 +4347,11 @@
+ #    HAVE_SDL_H
+ #    HAVE_SDL_SDL_H
+ #  HAVE_LIBSDL
++
++has_libSDL="false"   # pre-init
++
++# SDL only if not cross compiling (until better solution has been found)
++if test "$ac_cv_build" == "$ac_cv_host" ; then
+ # Extract the first word of "sdl-config", so it can be a program name with args.
+ set dummy sdl-config; ac_word=$2
+ echo "$as_me:$LINENO: checking for $ac_word" >&5
+@@ -4387,7 +4392,6 @@
+ fi
+ 
+ 
+-has_libSDL="false"   # pre-init
+ if test ! -z "${LIBSDL_CONFIG}"; then
+   LIBSDL_CFLAGS=`${LIBSDL_CONFIG} --cflags`
+   CFLAGS="${CFLAGS} ${LIBSDL_CFLAGS}"
+@@ -4761,6 +4765,7 @@
+       fi
+   fi
+ fi
++fi
+ 
+ 
+ 
+diff -Naur serdisplib-1.97.9/configure.in serdisplib-1.97.9-b/configure.in
+--- serdisplib-1.97.9/configure.in	2010-02-21 20:49:29.000000000 +0100
++++ serdisplib-1.97.9-b/configure.in	2015-06-10 17:46:33.986014606 +0200
+@@ -143,9 +143,13 @@
+ #    HAVE_SDL_H
+ #    HAVE_SDL_SDL_H
+ #  HAVE_LIBSDL
+-AC_PATH_PROG(LIBSDL_CONFIG, sdl-config)
+ 
+ has_libSDL="false"   # pre-init
++
++# SDL only if not cross compiling (until better solution has been found)
++if test "$ac_cv_build" == "$ac_cv_host" ; then
++AC_PATH_PROG(LIBSDL_CONFIG, sdl-config)
++
+ if test ! -z "${LIBSDL_CONFIG}"; then
+   LIBSDL_CFLAGS=`${LIBSDL_CONFIG} --cflags`
+   CFLAGS="${CFLAGS} ${LIBSDL_CFLAGS}"
+@@ -183,6 +187,7 @@
+       fi
+   fi
+ fi
++fi
+ AC_SUBST(has_libSDL)
+ AC_SUBST(HAVE_LIBSDL)
+ 


### PR DESCRIPTION

Hi,

this request adds support for displays driven by serdisplib through the lcdproc driver glcd.
Header files from serdisplib must be available when glcd is build, else glcd is build without support for serdisplib. 

extend packages/sysutils/lcdproc/package.mk 
If in the file "distributions/OpenELEC/options" SERDISPLIB_SUPPORT is set to "yes", then serdisplib will be a dependency of lcdproc. Furthermore it checks, if the driver glcd is set in LCD_DRIVER, else it will add them automatic to LCD_DRIVER. So an installed serdisplib is nothing without glcd.

add packages/sysutils/serdisplib/package.mk
adds support for serdisplib-1.97.9
Even if SDL is disabled, you must apply the patch "serdisplib-disable_SDL_crosscompile.patch", else configure will fail.