### PR TITLE
[download serivce] fix critical security bug - broken https

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -33,7 +33,7 @@ if [ -n "$PKG_URL" ]; then
     PACKAGE="$SOURCES/$1/$SOURCE_NAME"
     PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
     [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-    WGET_CMD="wget --timeout=30 --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1"
+    WGET_CMD="wget --timeout=30 $WGET_OPT -P $SOURCES/$1"
 
     NBWGET="1"
 


### PR DESCRIPTION
--passive-ftp is default for years. It does not need to be set.
--no-check-certificate - WTF?!  This is been added by sraue in 2010. This breaks everything HTTPS stands for. It enables the chance of MITM attacks and so on. Just like without any HTTPS.
Note written from the wget developers: It is almost always a bad idea not to check the certificates when transmitting confidential or important data. 
-c the "-c" can cause broken files on some servers. Its much better to reload the file.

This change have been tested. I have redownload all packages. There is also no broken certificate that would require no-check-certificate. If there is anytime any, then the download server have to be changed. Dont add no-check-certificate.