### PR TITLE
Revert "update to 0.2.5598, update link, fix licence"

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.2.5598"
+PKG_VERSION="0.2.4764"
 PKG_REV="1"
 PKG_ARCH="any"
-PKG_LICENSE="BSD"
+PKG_LICENSE="GPL"
 PKG_SITE="http://lib.openmpt.org/libopenmpt/"
-PKG_URL="http://buildbot.openmpt.org/builds/auto/src/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="audio"


### PR DESCRIPTION
This reverts commit e3e071547d327a961ae6cbe2b9b6ff9c93e9a2bb.

openmpt is now broken. I require a revert. ref #4319