### PR TITLE
[gcc] update to 5.2.0

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="gcc"
-PKG_VERSION="4.9.3"
+PKG_VERSION="5.2.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -69,7 +69,8 @@ BOOTSTRAP_CONFIGURE_OPTS="--host=$HOST_NAME \
                           --disable-decimal-float \
                           $GCC_OPTS \
                           --disable-nls \
-                          --enable-checking=release"
+                          --enable-checking=release \
+                          --with-default-libstdcxx-abi=gcc4-compatible"
 
 PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME \
                          --with-sysroot=$SYSROOT_PREFIX \
@@ -106,7 +107,8 @@ PKG_CONFIGURE_OPTS_HOST="--target=$TARGET_NAME \
                          --enable-clocale=gnu \
                          $GCC_OPTS \
                          --disable-nls \
-                         --enable-checking=release"
+                         --enable-checking=release \
+                         --with-default-libstdcxx-abi=gcc4-compatible"
 
 pre_configure_bootstrap() {
   setup_toolchain host

--- a/packages/linux/patches/4.1.10/linux-004-fix-build-with-gcc-5.patch
+++ b/packages/linux/patches/4.1.10/linux-004-fix-build-with-gcc-5.patch
@@ -1,0 +1,16 @@
+# see https://github.com/wongsyrone/openwrt-1/commit/93c0a5173414cfa7684547de3c3a1f3dc4240383
+# and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65932
+
+diff -Naur linux-4.1.10.orig/arch/arm/Makefile linux-4.1.10/arch/arm/Makefile
+--- linux-4.1.10.orig/arch/arm/Makefile	2015-10-03 04:49:38.000000000 -0700
++++ linux-4.1.10/arch/arm/Makefile	2015-10-05 13:43:26.066966475 -0700
+@@ -118,7 +118,8 @@
+ endif
+ 
+ # Need -Uarm for gcc < 3.x
+-KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm
++# Maybe we need -fno-ipa-sra for gcc > 4.9.x
++KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm -fno-ipa-sra
+ KBUILD_AFLAGS	+=$(CFLAGS_ABI) $(AFLAGS_ISA) $(arch-y) $(tune-y) -include asm/unified.h -msoft-float
+ 
+ CHECKFLAGS	+= -D__arm__

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -121,6 +121,10 @@ pre_build_target() {
   )
 }
 
+pre_configure_target() {
+  export CFLAGS="$CFLAGS -fno-schedule-insns -fno-schedule-insns2"
+}
+
 post_makeinstall_target() {
   # remove unneeded stuff
   rm -rf $INSTALL/etc/systemd/system

--- a/projects/WeTek_Play/patches/linux/004-fix-build-with-gcc-5.patch
+++ b/projects/WeTek_Play/patches/linux/004-fix-build-with-gcc-5.patch
@@ -1,0 +1,16 @@
+# see https://github.com/wongsyrone/openwrt-1/commit/93c0a5173414cfa7684547de3c3a1f3dc4240383
+# and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65932
+
+diff -Naur linux-amlogic-3.10-753dc30.orig/arch/arm/Makefile linux-amlogic-3.10-753dc30/arch/arm/Makefile
+--- linux-amlogic-3.10-753dc30.orig/arch/arm/Makefile	2015-09-30 12:37:18.000000000 -0700
++++ linux-amlogic-3.10-753dc30/arch/arm/Makefile	2015-10-05 13:39:01.341686718 -0700
+@@ -116,7 +116,8 @@
+ endif
+ 
+ # Need -Uarm for gcc < 3.x
+-KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm
++# Maybe we need -fno-ipa-sra for gcc > 4.9.x
++KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm -fno-ipa-sra
+ KBUILD_AFLAGS	+=$(CFLAGS_ABI) $(AFLAGS_ISA) $(arch-y) $(tune-y) -include asm/unified.h -msoft-float
+ 
+ CHECKFLAGS	+= -D__arm__

--- a/projects/imx6/patches/linux/linux-004-fix-build-with-gcc-5.patch
+++ b/projects/imx6/patches/linux/linux-004-fix-build-with-gcc-5.patch
@@ -1,0 +1,16 @@
+# see https://github.com/wongsyrone/openwrt-1/commit/93c0a5173414cfa7684547de3c3a1f3dc4240383
+# and https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65932
+
+diff -Naur linux-cuboxi-3.14-ea83bda.orig/arch/arm/Makefile linux-cuboxi-3.14-ea83bda/arch/arm/Makefile
+--- linux-cuboxi-3.14-ea83bda.orig/arch/arm/Makefile	2015-05-06 10:05:43.000000000 -0700
++++ linux-cuboxi-3.14-ea83bda/arch/arm/Makefile	2015-10-05 13:51:43.641612713 -0700
+@@ -120,7 +120,8 @@
+ endif
+ 
+ # Need -Uarm for gcc < 3.x
+-KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm
++# Maybe we need -fno-ipa-sra for gcc > 4.9.x
++KBUILD_CFLAGS	+=$(CFLAGS_ABI) $(CFLAGS_ISA) $(arch-y) $(tune-y) $(call cc-option,-mshort-load-bytes,$(call cc-option,-malignment-traps,)) -msoft-float -Uarm -fno-ipa-sra
+ KBUILD_AFLAGS	+=$(CFLAGS_ABI) $(AFLAGS_ISA) $(arch-y) $(tune-y) -include asm/unified.h -msoft-float
+ 
+ CHECKFLAGS	+= -D__arm__


### PR DESCRIPTION
This PR updates gcc to version 5.2.0 and fixes a few build issues.

The configure switch ```--with-default-libstdcxx-abi=gcc4-compatible``` was taken from arch linux's build
See: https://projects.archlinux.org/svntogit/packages.git/tree/gcc/trunk/PKGBUILD#n81

systemd fails to run with specific compiler optimizations, turning off these optimizations in CFLAGS fixes this.
See: https://bugzilla.yoctoproject.org/show_bug.cgi?id=8291

arm kernel fails to boot with specific compiler optimizations, turning off these optimizations fixes this. This fix is included as three seperate patches for three different kernel versions (imx6, amlogic, and mainline).
See: https://gcc.gnu.org/bugzilla/show_bug.cgi?id=65932

I have only tested this with the RPi2 build (as that is all I have), I would appreciate if people could test for imx6 and amlogic.