### PR TITLE
[linux] add patch from upstream to fix rtl28xxu

### DIFF
--- a/packages/linux/patches/4.1.10/linux-200-rtl28xxu-fix-control-message-flaws.patch
+++ b/packages/linux/patches/4.1.10/linux-200-rtl28xxu-fix-control-message-flaws.patch
@@ -1,0 +1,54 @@
+# from upstream http://git.linuxtv.org/cgit.cgi/anttip/media_tree.git/commit/?h=rtl2832u_test2&id=3fde4395e9c58ab45470529f29864446230c5368
+
+diff --git a/drivers/media/usb/dvb-usb-v2/rtl28xxu.c b/drivers/media/usb/dvb-usb-v2/rtl28xxu.c
+index c3cac4c..197a4f2 100644
+--- a/drivers/media/usb/dvb-usb-v2/rtl28xxu.c
++++ b/drivers/media/usb/dvb-usb-v2/rtl28xxu.c
+@@ -34,6 +34,14 @@ static int rtl28xxu_ctrl_msg(struct dvb_usb_device *d, struct rtl28xxu_req *req)
+ 	unsigned int pipe;
+ 	u8 requesttype;
+ 
++	mutex_lock(&d->usb_mutex);
++
++	if (req->size > sizeof(dev->buf)) {
++		dev_err(&d->intf->dev, "too large message %u\n", req->size);
++		ret = -EINVAL;
++		goto err_mutex_unlock;
++	}
++
+ 	if (req->index & CMD_WR_FLAG) {
+ 		/* write */
+ 		memcpy(dev->buf, req->data, req->size);
+@@ -50,14 +58,17 @@ static int rtl28xxu_ctrl_msg(struct dvb_usb_device *d, struct rtl28xxu_req *req)
+ 	dvb_usb_dbg_usb_control_msg(d->udev, 0, requesttype, req->value,
+ 			req->index, dev->buf, req->size);
+ 	if (ret < 0)
+-		goto err;
++		goto err_mutex_unlock;
+ 
+ 	/* read request, copy returned data to return buf */
+ 	if (requesttype == (USB_TYPE_VENDOR | USB_DIR_IN))
+ 		memcpy(req->data, dev->buf, req->size);
+ 
++	mutex_unlock(&d->usb_mutex);
++
+ 	return 0;
+-err:
++err_mutex_unlock:
++	mutex_unlock(&d->usb_mutex);
+ 	dev_dbg(&d->intf->dev, "failed=%d\n", ret);
+ 	return ret;
+ }
+diff --git a/drivers/media/usb/dvb-usb-v2/rtl28xxu.h b/drivers/media/usb/dvb-usb-v2/rtl28xxu.h
+index 9f6115a..1380629 100644
+--- a/drivers/media/usb/dvb-usb-v2/rtl28xxu.h
++++ b/drivers/media/usb/dvb-usb-v2/rtl28xxu.h
+@@ -71,7 +71,7 @@
+ 
+ 
+ struct rtl28xxu_dev {
+-	u8 buf[28];
++	u8 buf[128];
+ 	u8 chip_id;
+ 	u8 tuner;
+ 	char *tuner_name;


### PR DESCRIPTION
@sraue please pick for openelec-6.0

This fixes and closes #4364 