### PR TITLE
systemd-addon-wrapper: make binary addons executable ...

### DIFF
--- a/packages/mediacenter/kodi/scripts/systemd-addon-wrapper
+++ b/packages/mediacenter/kodi/scripts/systemd-addon-wrapper
@@ -30,6 +30,7 @@ if [ -f "/storage/.kodi/addons/$1/system.d/$1.service" ] ; then
   else
     # disable = false: setup
     systemctl enable "/storage/.kodi/addons/$1/system.d/$1.service"
+    chmod +x "/storage/.kodi/addons/$1/bin"/*
     systemctl start "$1.service"
   fi
 fi


### PR DESCRIPTION
... before starting service