### PR TITLE
RFC: Disable libaacs, causes GUI hangs on some BD ISOs

### DIFF
--- a/distributions/OpenELEC/options
+++ b/distributions/OpenELEC/options
@@ -47,7 +47,7 @@
 
 # build and install with AACS support
 # (BD decryption support in KODI) (yes / no)
-  BLURAY_AACS_SUPPORT="yes"
+  BLURAY_AACS_SUPPORT="no"
 
 # build and install with DVDCSS support
 # (DVD decryption support in KODI) (yes / no)


### PR DESCRIPTION
When starting playback of some BD ISOs, the Kodi GUI will hang (one core at 100% load, busy dialog spinning, GUI unresponsive), requiring that Kodi be restarted.

This behaviour is confirmed on RPi, RPi2 and x86 (with Kodi 15 and also Kodi 16).

The problem has been traced to the libaacs library. When playing a problematic BD ISO, this is the last entry written to the log:
```
19:31:12 T:139902096132096   DEBUG: LIRC: Update - NEW at 36030:1c 0 KEY_ENTER devinput (KEY_ENTER)
19:31:12 T:139902096132096   DEBUG: OnKey: 11 (0x0b) pressed, action is Select
19:31:12 T:139902096132096   DEBUG: OnPlayMedia /storage/freenas/media/Demos/ISOs/MVC/Drachenzähmen leicht gemacht 3D.iso
19:31:12 T:139902096132096   DEBUG: GetMovieId (/storage/freenas/media/Demos/ISOs/MVC/Drachenzähmen leicht gemacht 3D.iso), query = select idMovie from movie where idFile=5856
19:31:12 T:139902096132096   DEBUG: GetEpisodeId (/storage/freenas/media/Demos/ISOs/MVC/Drachenzähmen leicht gemacht 3D.iso), query = select idEpisode from episode where idFile=5856
19:31:12 T:139902096132096   DEBUG: GetMusicVideoId (/storage/freenas/media/Demos/ISOs/MVC/Drachenzähmen leicht gemacht 3D.iso), query = select idMVideo from musicvideo where idFile=5856
19:31:12 T:139902096132096   DEBUG: CAnnouncementManager - Announcement: OnAdd from xbmc
19:31:12 T:139902096132096   DEBUG: GOT ANNOUNCEMENT, type: 2, from xbmc, message OnAdd
19:31:12 T:139901324654336   DEBUG: SECTION:LoadDLL(libbluray.so.1)
19:31:12 T:139901324654336   DEBUG: Loading: libbluray.so.1
19:31:12 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - bluray.c:1380: libbluray version 0.8.1
19:31:12 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - bluray.c:1401: BLURAY initialized!
19:31:12 T:139901324654336   DEBUG: CDVDInputStreamBluray - Opening dir udf://%2fstorage%2ffreenas%2fmedia%2fDemos%2fISOs%2fMVC%2fDrachenz%c3%a4hmen%20leicht%20gemacht%203D.iso
19:31:12 T:139901324654336   DEBUG: CDVDInputStreamBluray - Closed dir (0x7f3d3c096370)
19:31:13 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - aacs.c:77: AACS/Unit_Key_RO.inf found. Disc seems to be AACS protected.
19:31:13 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - aacs.c:98: Using libaacs for AACS
19:31:13 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - aacs.c:118: Loading aacs library (0x7f3d3c0ece00)
19:31:13 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - aacs.c:133: Loaded libaacs (0x7f3d3c0ece00)
19:31:13 T:139901324654336   DEBUG: CDVDInputStreamBluray::Logger - aacs.c:136: Registering libaacs filesystem handler 0x8e1918 (0x7f3d3c0ece00)
19:31:13 T:139902096132096   DEBUG: ------ Window Init (DialogBusy.xml) ------
19:31:13 T:139902096132096   DEBUG: LIRC: Update - NEW at 36712:1c 0 KEY_ENTER_UP devinput (KEY_ENTER_UP)
```
Full Kodi 16 log (Nvidia_Legacy, with libaacs): http://sprunge.us/fKKM
Full Kodi 15 log (5.95.5 Nvidia_Legacy with libaacs): http://sprunge.us/MiWU

Disabling libaacs will fix the problem and the BD ISOs will play normally, at least on RPi/RPi2. On x86 I haven't been able to play the ISO at all as the "Play with 3d mode" menu isn't working (this is the only menu option that will successfully play the BD ISO on RPi without libaacs).

Building libaacs with all [upstream commits](http://git.videolan.org/?p=libaacs.git) since 0.8.1 (31 at the time of writing, HEAD=c6dc792eba169e34b34f542c32066c04601cf428) does not resolve the problem, so it is either unknown to the libaacs developers or they don't yet have a fix.

This PR proposes that libaacs is disabled for all platforms. Is there any point to libaacs?

Edit: Updated to confirm same "hang" behaviour in 5.59.5/Kodi 15, and added complete debug logs.