### PR TITLE
scripts/checkdeps: fix gentoo deps 

### DIFF
--- a/scripts/checkdeps
+++ b/scripts/checkdeps
@@ -44,7 +44,8 @@ case "$DISTRO" in
       ;;
     gentoo)
       deps="$deps g++ mkfontscale mkfontdir bdftopcf xsltproc java"
-      deps_pkg="$deps_pkg g++ mkfontscale mkfontdir bdftopcf libxslt jre"
+      deps_pkg="$deps_pkg gcc[cxx] mkfontscale mkfontdir bdftopcf libxslt virtual/jre"
+      files_pkg="glibc ncurses"
       ;;
     arch)
       # md5deep is only available in the aur

--- a/scripts/image
+++ b/scripts/image
@@ -268,7 +268,7 @@ fi
       # only for matrix system or all? (one tar for all updates?)
         if [ "$PROJECT" == "imx6" -a "$SYSTEM" == "matrix" ]; then
           $SCRIPTS/unpack imx6-mfgtool2-tbs-matrix
-          
+
           mkdir -p $RELEASE_DIR/MfgTool2-TBS-Matrix
           cp -PR $BUILD/imx6-mfgtool2-tbs-matrix-*/imx6-mfgtool2-tbs-matrix-*/* $RELEASE_DIR/MfgTool2-TBS-Matrix
         fi


### PR DESCRIPTION
+ Fix the dependencies of OpenElec on a gentoo system in `scripts/checkdeps`
On Gentoo the header-files are always installed with the builded libs/exe, there are no dev- or header-packages available, so fix the `files_pkg`.
Also, build gcc with support for c++, if g++ is not available and use virtual/jre for java (the user can install which jre/jdk he/she like).
    `g++  ->   gcc[cxx]`
    `jre  ->   virtual/jre`

+ Remove spaces in `scripts/image`.