### PR TITLE
[HACK] Allow nvidia legacy driver to work with 4.2+ kernel

### DIFF
--- a/projects/Nvidia_Legacy/patches/linux/linux-0001-export-mtrr.patch
+++ b/projects/Nvidia_Legacy/patches/linux/linux-0001-export-mtrr.patch
@@ -1,0 +1,18 @@
+--- a/arch/x86/kernel/cpu/mtrr/main.c	2015-10-18 08:10:52.951166026 +0100
++++ b/arch/x86/kernel/cpu/mtrr/main.c	2015-10-18 08:11:54.651493742 +0100
+@@ -448,6 +448,7 @@
+ 	return mtrr_add_page(base >> PAGE_SHIFT, size >> PAGE_SHIFT, type,
+ 			     increment);
+ }
++EXPORT_SYMBOL(mtrr_add);
+ 
+ /**
+  * mtrr_del_page - delete a memory type region
+@@ -536,6 +537,7 @@
+ 		return -EINVAL;
+ 	return mtrr_del_page(reg, base >> PAGE_SHIFT, size >> PAGE_SHIFT);
+ }
++EXPORT_SYMBOL(mtrr_del);
+ 
+ /**
+  * arch_phys_wc_add - add a WC MTRR and handle errors if PAT is unavailable


### PR DESCRIPTION
Don't merge until Nvidia_Legacy is switched to the 4.2+ kernel.

Hopefully there will be a better solution for this problem before that happens.

See discussion in #4382 for details.