### PR TITLE
[WeTek_Play] enable cec as default

### DIFF
--- a/projects/WeTek_Play/filesystem/usr/lib/systemd/system/hdmi-cec.service
+++ b/projects/WeTek_Play/filesystem/usr/lib/systemd/system/hdmi-cec.service
@@ -1,0 +1,12 @@
+[Unit]
+Description=hdmi cec service
+DefaultDependencies=no
+ConditionPathExists=!/storage/.no-hdmi-cec
+
+[Service]
+Type=oneshot
+RemainAfterExit=yes
+ExecStart=/bin/sh -c "echo 0x0b > /sys/class/amhdmitx/amhdmitx0/cec_config"
+
+[Install]
+WantedBy=sysinit.target


### PR DESCRIPTION
This can be disabled by using the cmdline argument ```nocec```

There is a problem with the fact that we advertise cec support but it is not enabled by default.

#4305 

ping @stefansaraev @codesnake 

Disclaimer: I don't have a Wetek device so I am unable to test ;)