### PR TITLE
Build mkfs.(v)fat from dosfstools for the host

### DIFF
--- a/packages/sysutils/dosfstools/package.mk
+++ b/packages/sysutils/dosfstools/package.mk
@@ -40,9 +40,25 @@ make_init() {
   : # reuse make_target()
 }
 
+pre_build_host() {
+  mkdir -p $PKG_BUILD/.$HOST_NAME
+  cp -RP $PKG_BUILD/* $PKG_BUILD/.$HOST_NAME
+}
+
+make_host() {
+  cd $ROOT/$PKG_BUILD/.$HOST_NAME
+  make PREFIX=/usr
+}
+
 makeinstall_init() {
   mkdir -p $INSTALL/sbin
     cp fsck.fat $INSTALL/sbin
     ln -sf fsck.fat $INSTALL/sbin/fsck.msdos
     ln -sf fsck.fat $INSTALL/sbin/fsck.vfat
+}
+
+makeinstall_host() {
+  mkdir -p $ROOT/$TOOLCHAIN/sbin
+    cp mkfs.fat $ROOT/$TOOLCHAIN/sbin
+    ln -sf mkfs.fat $ROOT/$TOOLCHAIN/sbin/mkfs.vfat
 }

--- a/scripts/image
+++ b/scripts/image
@@ -25,6 +25,7 @@ show_config
 $SCRIPTS/checkdeps
 $SCRIPTS/build toolchain
 $SCRIPTS/build squashfs:host
+$SCRIPTS/build dosfstools:host
 $SCRIPTS/build fakeroot:host
 $SCRIPTS/build kmod:host
 


### PR DESCRIPTION
Build dosfstools for the host from `scripts/image` by default, like it is done for squashfs.
Tested the build `dosfstools:host` with a clean build* dir, except toolchain nothing else is needed.
The error i had descriped here #4375 is gone.