### PR TITLE
kodi: add patch to support keys on the rii mini i8+

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-999.41-KEY_CONFIG.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.41-KEY_CONFIG.patch
@@ -1,0 +1,55 @@
+diff -Naur kodi-15.2-02e7013.orig/system/keymaps/keyboard.xml kodi-15.2-02e7013/system/keymaps/keyboard.xml
+--- kodi-15.2-02e7013.orig/system/keymaps/keyboard.xml	2015-10-29 12:37:08.058499004 -0700
++++ kodi-15.2-02e7013/system/keymaps/keyboard.xml	2015-10-29 12:45:00.594628676 -0700
+@@ -117,6 +117,7 @@
+       <browser_search/>
+       <browser_favorites>ActivateWindow(Favourites)</browser_favorites>
+       <favorites>ActivateWindow(Favourites)</favorites>
++      <config>ActivateWindow(Settings)</config>
+       <browser_home>ActivateWindow(Home)</browser_home>
+       <homepage>ActivateWindow(Home)</homepage>
+       <volume_mute>Mute</volume_mute>
+diff -Naur kodi-15.2-02e7013.orig/xbmc/input/linux/LinuxInputDevices.cpp kodi-15.2-02e7013/xbmc/input/linux/LinuxInputDevices.cpp
+--- kodi-15.2-02e7013.orig/xbmc/input/linux/LinuxInputDevices.cpp	2015-10-29 12:37:08.081498954 -0700
++++ kodi-15.2-02e7013/xbmc/input/linux/LinuxInputDevices.cpp	2015-10-29 12:41:16.155311681 -0700
+@@ -267,6 +267,7 @@
+   { KEY_SEARCH        , XBMCK_BROWSER_SEARCH},
+   { KEY_FILE          , XBMCK_LAUNCH_FILE_BROWSER},
+   { KEY_SELECT        , XBMCK_RETURN      },
++  { KEY_CONFIG        , XBMCK_CONFIG      },
+   // The Little Black Box Remote Additions
+   { 384               , XBMCK_LEFT        }, // Red
+   { 378               , XBMCK_RIGHT       }, // Green
+diff -Naur kodi-15.2-02e7013.orig/xbmc/input/XBMC_keysym.h kodi-15.2-02e7013/xbmc/input/XBMC_keysym.h
+--- kodi-15.2-02e7013.orig/xbmc/input/XBMC_keysym.h	2015-10-29 12:37:08.058499004 -0700
++++ kodi-15.2-02e7013/xbmc/input/XBMC_keysym.h	2015-10-29 12:47:22.085956459 -0700
+@@ -228,6 +228,7 @@
+   XBMCK_TEXT        = 0x14c,
+   XBMCK_FAVORITES   = 0x14d,
+   XBMCK_HOMEPAGE    = 0x14e,
++  XBMCK_CONFIG      = 0x14f,
+ 
+   // Add any other keys here
+ 
+diff -Naur kodi-15.2-02e7013.orig/xbmc/input/XBMC_keytable.cpp kodi-15.2-02e7013/xbmc/input/XBMC_keytable.cpp
+--- kodi-15.2-02e7013.orig/xbmc/input/XBMC_keytable.cpp	2015-10-29 12:37:08.059499002 -0700
++++ kodi-15.2-02e7013/xbmc/input/XBMC_keytable.cpp	2015-10-29 12:48:24.243691840 -0700
+@@ -242,6 +242,7 @@
+ , { XBMCK_TEXT,                   0,    0, XBMCVK_TEXT,          "text" }
+ , { XBMCK_FAVORITES,              0,    0, XBMCVK_FAVORITES,     "favorites" }
+ , { XBMCK_HOMEPAGE ,              0,    0, XBMCVK_HOMEPAGE,      "homepage" }
++, { XBMCK_CONFIG,                 0,    0, XBMCVK_CONFIG,        "config" }
+ };
+ 
+ static int XBMCKeyTableSize = sizeof(XBMCKeyTable)/sizeof(XBMCKEYTABLE);
+diff -Naur kodi-15.2-02e7013.orig/xbmc/input/XBMC_vkeys.h kodi-15.2-02e7013/xbmc/input/XBMC_vkeys.h
+--- kodi-15.2-02e7013.orig/xbmc/input/XBMC_vkeys.h	2015-10-29 12:37:08.059499002 -0700
++++ kodi-15.2-02e7013/xbmc/input/XBMC_vkeys.h	2015-10-29 12:49:07.284549633 -0700
+@@ -220,6 +220,7 @@
+   XBMCVK_TEXT           = 0xE8,
+   XBMCVK_FAVORITES      = 0xE9,
+   XBMCVK_HOMEPAGE       = 0xEA,
++  XBMCVK_CONFIG         = 0xEB,
+ 
+   XBMCVK_LAST           = 0xFF
+ } XBMCVKey;


### PR DESCRIPTION
fixes #4401 

should be picked for openelec-6.0 if there is time