### PR TITLE
various pulseaudio fixes

### DIFF
--- a/packages/audio/pulseaudio/config/pulseaudio-system.conf
+++ b/packages/audio/pulseaudio/config/pulseaudio-system.conf
@@ -1,0 +1,33 @@
+<?xml version="1.0"?><!--*-nxml-*-->
+<!DOCTYPE busconfig PUBLIC "-//freedesktop//DTD D-BUS Bus Configuration 1.0//EN"
+ "http://www.freedesktop.org/standards/dbus/1.0/busconfig.dtd">
+
+<!--
+This file is part of PulseAudio.
+
+PulseAudio is free software; you can redistribute it and/or modify it
+under the terms of the GNU Lesser General Public License as
+published by the Free Software Foundation; either version 2.1 of the
+License, or (at your option) any later version.
+
+PulseAudio is distributed in the hope that it will be useful, but WITHOUT
+ANY WARRANTY; without even the implied warranty of MERCHANTABILITY
+or FITNESS FOR A PARTICULAR PURPOSE. See the GNU Lesser General
+Public License for more details.
+
+You should have received a copy of the GNU Lesser General Public
+License along with PulseAudio; if not, see <http://www.gnu.org/licenses/>.
+-->
+
+<busconfig>
+
+  <!-- System-wide PulseAudio runs as 'root' user. This fragment is
+       not necessary for user PulseAudio instances. -->
+
+  <policy user="root">
+    <allow own="org.pulseaudio.Server"/>
+    <allow send_destination="org.pulseaudio.Server"/>
+    <allow receive_sender="org.pulseaudio.Server"/>
+  </policy>
+
+</busconfig>

--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -55,6 +55,12 @@ load-module module-suspend-on-idle
 ### Enable positioned event sounds
 load-module module-position-event-sounds
 
+
+### Automatically load modules for dbus
+.ifexists module-dbus-protocol.so
+ load-module module-dbus-protocol
+.endif
+
 ### Automatically load modules for bluetooth
 .ifexists module-bluetooth-policy.so
  load-module module-bluetooth-policy
@@ -66,9 +72,11 @@ load-module module-position-event-sounds
 
 .ifexists module-zeroconf-publish.so
   load-module module-zeroconf-publish
+.endif
+
+.ifexists module-zeroconf-discover.so
   load-module module-zeroconf-discover
 .endif
 
 load-module module-native-protocol-tcp auth-anonymous=1
 load-module module-switch-on-connect
-

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -98,12 +98,6 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
                            --with-module-dir=/usr/lib/pulse"
 
 post_makeinstall_target() {
-# add_user pulse x 499 498 "PulseAudio System Daemon" "/var/run/pulse" "/bin/sh"
-# add_group pulse 498
-# add_group pulse-access 497
-
-  sed -e 's%user="pulse"%user="root"%g' -i $INSTALL/etc/dbus-1/system.d/pulseaudio-system.conf
-
   rm -rf $INSTALL/usr/bin/esdcompat
   rm -rf $INSTALL/usr/include
   rm -rf $INSTALL/usr/lib/cmake
@@ -114,6 +108,7 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/bash-completion
 
   cp $PKG_DIR/config/system.pa $INSTALL/etc/pulse/
+  cp $PKG_DIR/config/pulseaudio-system.conf $INSTALL/etc/dbus-1/system.d/
 
   # Remove unwanted symlinks
   for file in $INSTALL/*; do

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -19,7 +19,7 @@
 ################################################################################
 
 PKG_NAME="pulseaudio"
-PKG_VERSION="7.0"
+PKG_VERSION="7.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -109,13 +109,6 @@ post_makeinstall_target() {
 
   cp $PKG_DIR/config/system.pa $INSTALL/etc/pulse/
   cp $PKG_DIR/config/pulseaudio-system.conf $INSTALL/etc/dbus-1/system.d/
-
-  # Remove unwanted symlinks
-  for file in $INSTALL/*; do
-    if [ -L "$file" ]; then
-      rm $file
-    fi
-  done
 }
 
 post_install() {

--- a/packages/audio/pulseaudio/profile.d/04-pulseaudio.conf
+++ b/packages/audio/pulseaudio/profile.d/04-pulseaudio.conf
@@ -1,1 +1,0 @@
-export SDL_AUDIODRIVER=pulse

--- a/packages/audio/pulseaudio/system.d/pulseaudio.service
+++ b/packages/audio/pulseaudio/system.d/pulseaudio.service
@@ -1,15 +1,10 @@
 [Unit]
 Description=PulseAudio Sound System
 After=syslog.target local-fs.target
-Requires=bluetooth.service
 
 [Service]
-Type=forking
-ExecStart=/usr/bin/pulseaudio --start --daemonize --log-level=0
-TimeoutStopSec=5
+ExecStart=/usr/bin/pulseaudio --system
 Restart=always
-RestartSec=2
-StartLimitInterval=0
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/devel/libtool/package.mk
+++ b/packages/devel/libtool/package.mk
@@ -33,5 +33,5 @@ PKG_IS_ADDON="no"
 
 PKG_AUTORECONF="no"
 
-PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared HELP2MAN=/bin/true"
+PKG_CONFIGURE_OPTS_HOST="--enable-static --disable-shared"
 

--- a/packages/devel/libtool/patches/libtool-03-remove-help2man-dependency.patch
+++ b/packages/devel/libtool/patches/libtool-03-remove-help2man-dependency.patch
@@ -1,0 +1,26 @@
+diff -Naur a/Makefile.am b/Makefile.am
+--- a/Makefile.am	2015-01-20 07:34:33.000000000 -0800
++++ b/Makefile.am	2015-10-27 11:16:49.027497480 -0700
+@@ -406,22 +406,6 @@
+ 	$(AM_V_GEN)$(MAKEINFO) -P '$(srcdir)/doc' --no-headers \
+ 	    $(MAKEINFOFLAGS) -o '$@' '$(notes_texi)'
+ 
+-dist_man1_MANS		= $(libtool_1) $(libtoolize_1)
+-MAINTAINERCLEANFILES	+= $(dist_man1_MANS)
+-update_mans = \
+-  PATH=".$(PATH_SEPARATOR)$$PATH"; export PATH; \
+-  $(HELP2MAN) --output='$@'
+-
+-# It's wrong to make distributed files (e.g. $(libtool_1)) rely on
+-# files created in the build tree, so instead we regenerate the
+-# manual pages if the sources for the build-tree files we want to
+-# run have changed.
+-$(libtool_1): $(ltmain_sh)
+-	$(AM_V_GEN)$(update_mans) --help-option=--help-all libtool
+-$(libtoolize_1): $(libtoolize_in)
+-	$(AM_V_GEN)$(update_mans) libtoolize
+-
+-
+ ## ------------- ##
+ ## Installation. ##
+ ## ------------- ##

--- a/packages/mediacenter/kodi/patches/kodi-100.14-dont-enumerate-pulse-devices.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.14-dont-enumerate-pulse-devices.patch
@@ -1,0 +1,27 @@
+diff -Naur kodi-15.2-rc3-9efd358.orig/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp kodi-15.2-rc3-9efd358/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+--- kodi-15.2-rc3-9efd358.orig/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2015-10-13 09:55:11.000000000 -0700
++++ kodi-15.2-rc3-9efd358/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp	2015-10-16 13:39:27.037518528 -0700
+@@ -1123,13 +1123,6 @@
+ 
+   m_controlMonitor.Clear();
+ 
+-  /* Always enumerate the default device.
+-   * Note: If "default" is a stereo device, EnumerateDevice()
+-   * will automatically add "@" instead to enable surroundXX mangling.
+-   * We don't want to do that if "default" can handle multichannel
+-   * itself (e.g. in case of a pulseaudio server). */
+-  EnumerateDevice(list, "default", "", config);
+-
+   void **hints;
+ 
+   if (snd_device_name_hint(-1, "pcm", &hints) < 0)
+@@ -1554,7 +1547,8 @@
+   }
+ 
+   snd_pcm_close(pcmhandle);
+-  list.push_back(info);
++  if (info.m_deviceName != "pulse")
++    list.push_back(info);
+ }
+ 
+ bool CAESinkALSA::GetELD(snd_hctl_t *hctl, int device, CAEDeviceInfo& info, bool& badHDMI)


### PR DESCRIPTION
libtool needs this patch on my build machine as there is no /bin/true in the built toolchain for target

(pulseaudio requires libtool:target)