### PR TITLE
kodi: disable pvermanager.syncchannelgroups (fixup)

### DIFF
--- a/packages/mediacenter/kodi/config/appliance.xml
+++ b/packages/mediacenter/kodi/config/appliance.xml
@@ -38,7 +38,7 @@
 
   <section id="pvr">
     <category id="pvrmanager">
-      <group id="1">
+      <group id="2">
         <setting id="pvrmanager.syncchannelgroups">
           <default>false</default>
         </setting>


### PR DESCRIPTION
Please also pick to 6.0 as pointed out by @anaconda