### PR TITLE
libinput bump to 1.1.0

### DIFF
--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libinput"
-PKG_VERSION="1.0.2"
+PKG_VERSION="1.1.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -36,5 +36,5 @@ PKG_CONFIGURE_OPTS_TARGET="--with-xorg-module-dir=$XORG_PATH_MODULES"
 
 post_makeinstall_target() {
   mkdir -p $INSTALL/usr/share/X11/xorg.conf.d
-    cp $ROOT/$PKG_BUILD/conf/99-libinput.conf $INSTALL/usr/share/X11/xorg.conf.d
+    cp $ROOT/$PKG_BUILD/conf/90-libinput.conf $INSTALL/usr/share/X11/xorg.conf.d
 }


### PR DESCRIPTION
libinput bump is needed by xf86-input-libinput version 0.15.0

and fix xf86-input-libinput default config location