### PR TITLE
pulseaudio and kodi

### DIFF
--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -55,7 +55,6 @@ load-module module-suspend-on-idle
 ### Enable positioned event sounds
 load-module module-position-event-sounds
 
-
 ### Automatically load modules for dbus
 .ifexists module-dbus-protocol.so
  load-module module-dbus-protocol
@@ -72,10 +71,6 @@ load-module module-position-event-sounds
 
 .ifexists module-zeroconf-publish.so
   load-module module-zeroconf-publish
-.endif
-
-.ifexists module-zeroconf-discover.so
-  load-module module-zeroconf-discover
 .endif
 
 load-module module-native-protocol-tcp auth-anonymous=1

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -110,7 +110,3 @@ post_makeinstall_target() {
   cp $PKG_DIR/config/system.pa $INSTALL/etc/pulse/
   cp $PKG_DIR/config/pulseaudio-system.conf $INSTALL/etc/dbus-1/system.d/
 }
-
-post_install() {
-  enable_service pulseaudio.service
-}

--- a/packages/audio/pulseaudio/system.d/pulseaudio.service
+++ b/packages/audio/pulseaudio/system.d/pulseaudio.service
@@ -1,10 +1,15 @@
 [Unit]
 Description=PulseAudio Sound System
 After=syslog.target local-fs.target
+ConditionPathExists=/storage/.cache/services/pulse.conf
 
 [Service]
+Restart=on-failure
 ExecStart=/usr/bin/pulseaudio --system
-Restart=always
+TimeoutStopSec=1s
+RestartSec=2
+StartLimitInterval=60
+StartLimitBurst=10
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/mediacenter/kodi/patches/kodi-100.16-allow-pulseaudio-on-the-rpi.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.16-allow-pulseaudio-on-the-rpi.patch
@@ -1,0 +1,48 @@
+diff -Naur a/xbmc/cores/AudioEngine/AESinkFactory.cpp b/xbmc/cores/AudioEngine/AESinkFactory.cpp
+--- a/xbmc/cores/AudioEngine/AESinkFactory.cpp	2015-11-02 01:54:40.000000000 -0800
++++ b/xbmc/cores/AudioEngine/AESinkFactory.cpp	2015-11-05 15:00:36.874646180 -0800
+@@ -28,6 +28,9 @@
+ #elif defined(TARGET_RASPBERRY_PI)
+   #include "Sinks/AESinkPi.h"
+   #include "Sinks/AESinkALSA.h"
++  #if defined(HAS_PULSEAUDIO)
++    #include "Sinks/AESinkPULSE.h"
++  #endif
+ #elif defined(TARGET_DARWIN_IOS)
+   #include "Sinks/AESinkDARWINIOS.h"
+ #elif defined(TARGET_DARWIN_OSX)
+@@ -67,6 +70,9 @@
+ #elif defined(TARGET_RASPBERRY_PI)
+         driver == "PI"          ||
+         driver == "ALSA"        ||
++  #if defined(HAS_PULSEAUDIO)
++        driver == "PULSE"       ||
++  #endif
+ #elif defined(TARGET_DARWIN_IOS)
+         driver == "DARWINIOS"  ||
+ #elif defined(TARGET_DARWIN_OSX)
+@@ -112,6 +118,10 @@
+   if (driver == "ALSA")
+     sink = new CAESinkALSA();
+   #endif
++  #if defined(HAS_PULSEAUDIO)
++  if (driver == "PULSE")
++    sink = new CAESinkPULSE();
++  #endif
+ #elif defined(TARGET_DARWIN_IOS)
+     sink = new CAESinkDARWINIOS();
+ #elif defined(TARGET_DARWIN_OSX)
+@@ -202,6 +212,13 @@
+   CAESinkPi::EnumerateDevicesEx(info.m_deviceInfoList, force);
+   if(!info.m_deviceInfoList.empty())
+     list.push_back(info);
++  #if defined(HAS_PULSEAUDIO)
++  info.m_deviceInfoList.clear();
++  info.m_sinkName = "PULSE";
++  CAESinkPULSE::EnumerateDevicesEx(info.m_deviceInfoList, force);
++  if(!info.m_deviceInfoList.empty())
++    list.push_back(info);
++  #endif
+   #if defined(HAS_ALSA)
+   info.m_deviceInfoList.clear();
+   info.m_sinkName = "ALSA";


### PR DESCRIPTION
EDIT: Updated 2015-11-07, see included update.

``` 
kodi-100.15-allow-pulse-and-alsa-together.patch
```
~~Allows enumerating both pulseaudio and alsa devices in Kodi.~~

~~I am aware that this could be problematic, but it is something we need otherwise pulseaudio won't be used. I have see xbmc/xbmc#5908 and reading over some of the negative effects I don't think they will effect us on OpenELEC.~~

``` "We will plain segfault when we open alsa devices while PA server is initializing." ```
systemd solves this for us and makes sure that pulseaudio is started before kodi.

``` "PulseAudio might hog your Audio device and you cannot open the ALSA device exclusively" ```
I haven't seen this yet but have only done limited testing

ping @fritsch 

----------

```
kodi-100.16-allow-pulseaudio-on-the-rpi.patch
```
Not sure why this isn't used by default but maybe there is something I'm missing.
Here is a log from my RPi2 with this patch http://sprunge.us/WKfJ

ping @popcornmix

----------
The other commit is to remove the pulseaudio module that creates a null sink (if no audio devices are detected)

----------
Update 2015-11-07:

I have made some changes to this PR since my first message and I will edit it to explain what this PR currently does.

This PR, with the changes to our OE settings add-on allows the user to use exclusively pulseaudio or alsa. So with pulseaudio active the following is possible:

 - On x86_64 this can be a bluetooth audio device or any other hardware audio device.
 - On the RPi this can only be a bluetooth device (we do not load snd_bcm2835 by default so no alsa devices are enumerated). This may change at some point.