### PR TITLE
libcec: update to version 3.0.1

### DIFF
--- a/packages/devel/libcec/package.mk
+++ b/packages/devel/libcec/package.mk
@@ -17,12 +17,13 @@
 ################################################################################
 
 PKG_NAME="libcec"
-PKG_VERSION="3.0.0"
+PKG_VERSION="3.0.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://libcec.pulse-eight.com/"
-PKG_URL="http://mirrors.xbmc.org/build-deps/sources/$PKG_NAME-$PKG_VERSION-6.tar.gz"
+PKG_URL="https://github.com/Pulse-Eight/libcec/archive/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SOURCE_DIR="$PKG_NAME-$PKG_NAME-$PKG_VERSION"
 PKG_DEPENDS_TARGET="toolchain systemd lockdev platform"
 PKG_PRIORITY="optional"
 PKG_SECTION="system"

--- a/packages/devel/libcec/patches/libcec-02-fix-crash-on-some-systems.patch
+++ b/packages/devel/libcec/patches/libcec-02-fix-crash-on-some-systems.patch
@@ -1,0 +1,18 @@
+# see upstream commit, https://github.com/Pulse-Eight/libcec/commit/678739a0d8aa5897fa1906a8fdeeb67b83f7d1e9
+
+diff -Naur a/src/libcec/platform/drm/drm-edid.cpp b/src/libcec/platform/drm/drm-edid.cpp
+--- a/src/libcec/platform/drm/drm-edid.cpp	2015-07-03 10:20:49.000000000 -0700
++++ b/src/libcec/platform/drm/drm-edid.cpp	2015-11-10 13:09:14.902629922 -0800
+@@ -51,6 +51,12 @@
+  
+   DIR *dir = opendir(baseDir.c_str());
+ 
++  // DRM subfolder may not exist on some systems
++  if (dir == NULL)
++  {
++    return iPA;
++  }
++
+   struct dirent *entry = readdir(dir);
+   std::string enablededid;
+   std::string line;


### PR DESCRIPTION
Patch made from upstream commit PulseEight/libcec@678739a0d8aa5897fa1906a8fdeeb67b83f7d1e9

This fixes #4412 

This should probably get picked for openelec-6.0 also