### PR TITLE
RPi/RPi2: use rc-core-based gpio_ir_recv driver and ir-keytable instead of lirc_rpi/lircd for GPIO IR rereivers.

### DIFF
--- a/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
+++ b/packages/tools/bcm2835-bootloader/files/3rdparty/bootloader/config.txt
@@ -103,6 +103,9 @@
 # decode_DTS=0x00000000
 # decode_DDP=0x00000000
 
+# enable rc-core driver for RPi-style GPIO IR receiver at GPIO pin 18
+dtoverlay=ir-gpio
+
 ################################################################################
 # End of default configuration
 # all values below this line were inserted from config.txt.bk (your old config)

--- a/packages/tools/bcm2835-bootloader/scripts/update.sh
+++ b/packages/tools/bcm2835-bootloader/scripts/update.sh
@@ -32,6 +32,7 @@
 
   cp -p $SYSTEM_ROOT/usr/share/bootloader/*.dtb $BOOT_ROOT
   cp -pR $SYSTEM_ROOT/usr/share/bootloader/overlays $BOOT_ROOT
+  cp -p $(get_build_dir linux)/arch/arm/boot/dts/overlays/ir-gpio-overlay.dtb $BOOT_ROOT/overlays/
 
 # cleanup not more needed files
   rm -rf $BOOT_ROOT/loader.bin

--- a/projects/RPi2/patches/linux/linux-02-gpio_ir_rpi.patch
+++ b/projects/RPi2/patches/linux/linux-02-gpio_ir_rpi.patch
@@ -1,0 +1,51 @@
+diff -Naur linux-4.1.12/arch/arm/boot/dts/overlays/ir-gpio-overlay.dts linux_new/arch/arm/boot/dts/overlays/ir-gpio-overlay.dts
+--- linux-4.1.12/arch/arm/boot/dts/overlays/ir-gpio-overlay.dts	1970-01-01 01:00:00.000000000 +0100
++++ linux_new/arch/arm/boot/dts/overlays/ir-gpio-overlay.dts	2015-11-13 19:40:22.893626713 +0100
+@@ -0,0 +1,36 @@
++// Definitions for lirc-rpi module
++/dts-v1/;
++/plugin/;
++
++/ {
++	compatible = "brcm,bcm2708";
++
++	fragment@0 {
++		target-path = "/";
++		__overlay__ {
++			ir_gpio: ir-receiver {
++				compatible = "gpio-ir-receiver";
++				gpios = <&gpio 18 1>;
++
++				// parameter for keymap name
++				linux,rc-map-name = "rc-rc6-mce";
++			};
++		};
++	};
++
++	fragment@1 {
++		target = <&gpio>;
++		__overlay__ {
++			lirc_pins: lirc_pins {
++				brcm,pins = <18>;
++				brcm,function = <0>; // in
++				brcm,pull = <0>; // up
++			};
++		};
++	};
++
++	__overrides__ {
++		gpio_in_pin =   <&lirc_pins>,"brcm,pins:4";
++		gpio_in_pull =  <&lirc_pins>,"brcm,pull:4";
++	};
++};
+diff -Naur linux-4.1.12/arch/arm/boot/dts/overlays/Makefile linux_new/arch/arm/boot/dts/overlays/Makefile
+--- linux-4.1.12/arch/arm/boot/dts/overlays/Makefile	2015-11-13 19:45:19.293396364 +0100
++++ linux_new/arch/arm/boot/dts/overlays/Makefile	2015-11-13 19:41:42.775451133 +0100
+@@ -29,6 +29,7 @@
+ dtb-$(RPI_DT_OVERLAYS) += iqaudio-dac-overlay.dtb
+ dtb-$(RPI_DT_OVERLAYS) += iqaudio-dacplus-overlay.dtb
+ dtb-$(RPI_DT_OVERLAYS) += lirc-rpi-overlay.dtb
++dtb-$(RPI_DT_OVERLAYS) += ir-gpio-overlay.dtb
+ dtb-$(RPI_DT_OVERLAYS) += mcp2515-can0-overlay.dtb
+ dtb-$(RPI_DT_OVERLAYS) += mcp2515-can1-overlay.dtb
+ dtb-$(RPI_DT_OVERLAYS) += mmc-overlay.dtb


### PR DESCRIPTION
This PR enables the ir_gpio_recv driver by adding a Device Tree overlay. This driver, together with ir-keytable, is a perfect replacement for the combination of lirc_rpi and lircd.

Using the kernel-based rc_core drivers leads to a way better user experience, as the remote control  respone is faster, smoother and more consistent. Addtionally, it prevents the usual double-key trouble often caused by LIRC/gpio_lirc, without delay-prone application-side filters.

How it works:
The kernel patch introduces a new Device Tree overlay, which will be compiled together with the Linux kernel. When installing the boot loader, the DTOverlay will be copied to the boot partion and added to the config.txt. 

When using the ir_gpio_recv, the LIRC daemon is no longer needed on the Raspberries, but it doesn't hurt if it is present either. However, the config.txt should not contain a dtoverlay=lirc-rpi line, as both drivers (loaded automatically by the kernel) would probably race for pin resources.

How to use:
1. make sure that config.txt contains the line "dtoverlay=ir-gpio" and the receiver is connected to GPIO#18
2. enable appropriate protocols (example: RC5 and RC6): "ir-keytable -p RC5,RC6", load keytable as necessary
3. make sure that eventlircd is active
4. test it: "irw /run/lirc/lircd"