### PR TITLE
Nvidia_Legacy/linux: sync kernel config with Generic

### DIFF
--- a/projects/Nvidia_Legacy/linux/linux.x86_64.conf
+++ b/projects/Nvidia_Legacy/linux/linux.x86_64.conf
@@ -152,16 +152,30 @@ CONFIG_NUMA_BALANCING=y
 CONFIG_NUMA_BALANCING_DEFAULT_ENABLED=y
 CONFIG_CGROUPS=y
 # CONFIG_CGROUP_DEBUG is not set
-# CONFIG_CGROUP_FREEZER is not set
-# CONFIG_CGROUP_DEVICE is not set
-# CONFIG_CPUSETS is not set
-# CONFIG_CGROUP_CPUACCT is not set
-# CONFIG_MEMCG is not set
-# CONFIG_CGROUP_PERF is not set
-# CONFIG_CGROUP_SCHED is not set
-# CONFIG_BLK_CGROUP is not set
+CONFIG_CGROUP_FREEZER=y
+CONFIG_CGROUP_DEVICE=y
+CONFIG_CPUSETS=y
+CONFIG_PROC_PID_CPUSET=y
+CONFIG_CGROUP_CPUACCT=y
+CONFIG_PAGE_COUNTER=y
+CONFIG_MEMCG=y
+CONFIG_MEMCG_SWAP=y
+CONFIG_MEMCG_SWAP_ENABLED=y
+CONFIG_MEMCG_KMEM=y
+CONFIG_CGROUP_PERF=y
+CONFIG_CGROUP_SCHED=y
+CONFIG_FAIR_GROUP_SCHED=y
+CONFIG_CFS_BANDWIDTH=y
+CONFIG_RT_GROUP_SCHED=y
+CONFIG_BLK_CGROUP=y
+# CONFIG_DEBUG_BLK_CGROUP is not set
 # CONFIG_CHECKPOINT_RESTORE is not set
-# CONFIG_NAMESPACES is not set
+CONFIG_NAMESPACES=y
+CONFIG_UTS_NS=y
+CONFIG_IPC_NS=y
+# CONFIG_USER_NS is not set
+CONFIG_PID_NS=y
+CONFIG_NET_NS=y
 # CONFIG_SCHED_AUTOGROUP is not set
 # CONFIG_SYSFS_DEPRECATED is not set
 CONFIG_RELAY=y
@@ -296,6 +310,7 @@ CONFIG_BLOCK=y
 CONFIG_BLK_DEV_BSG=y
 CONFIG_BLK_DEV_BSGLIB=y
 # CONFIG_BLK_DEV_INTEGRITY is not set
+# CONFIG_BLK_DEV_THROTTLING is not set
 # CONFIG_BLK_CMDLINE_PARSER is not set
 
 #
@@ -330,6 +345,7 @@ CONFIG_BLOCK_COMPAT=y
 CONFIG_IOSCHED_NOOP=y
 # CONFIG_IOSCHED_DEADLINE is not set
 CONFIG_IOSCHED_CFQ=y
+# CONFIG_CFQ_GROUP_IOSCHED is not set
 CONFIG_DEFAULT_CFQ=y
 # CONFIG_DEFAULT_NOOP is not set
 CONFIG_DEFAULT_IOSCHED="cfq"
@@ -728,7 +744,7 @@ CONFIG_NET_PTP_CLASSIFY=y
 CONFIG_NETFILTER=y
 # CONFIG_NETFILTER_DEBUG is not set
 CONFIG_NETFILTER_ADVANCED=y
-# CONFIG_BRIDGE_NETFILTER is not set
+CONFIG_BRIDGE_NETFILTER=m
 
 #
 # Core Netfilter Configuration
@@ -798,7 +814,7 @@ CONFIG_NETFILTER_XT_NAT=m
 #
 # Xtables matches
 #
-# CONFIG_NETFILTER_XT_MATCH_ADDRTYPE is not set
+CONFIG_NETFILTER_XT_MATCH_ADDRTYPE=m
 # CONFIG_NETFILTER_XT_MATCH_BPF is not set
 # CONFIG_NETFILTER_XT_MATCH_CGROUP is not set
 # CONFIG_NETFILTER_XT_MATCH_CLUSTER is not set
@@ -807,7 +823,7 @@ CONFIG_NETFILTER_XT_NAT=m
 # CONFIG_NETFILTER_XT_MATCH_CONNLABEL is not set
 # CONFIG_NETFILTER_XT_MATCH_CONNLIMIT is not set
 # CONFIG_NETFILTER_XT_MATCH_CONNMARK is not set
-# CONFIG_NETFILTER_XT_MATCH_CONNTRACK is not set
+CONFIG_NETFILTER_XT_MATCH_CONNTRACK=m
 # CONFIG_NETFILTER_XT_MATCH_CPU is not set
 # CONFIG_NETFILTER_XT_MATCH_DCCP is not set
 # CONFIG_NETFILTER_XT_MATCH_DEVGROUP is not set
@@ -828,6 +844,7 @@ CONFIG_NETFILTER_XT_MATCH_IPRANGE=m
 # CONFIG_NETFILTER_XT_MATCH_NFACCT is not set
 # CONFIG_NETFILTER_XT_MATCH_OSF is not set
 CONFIG_NETFILTER_XT_MATCH_OWNER=m
+# CONFIG_NETFILTER_XT_MATCH_PHYSDEV is not set
 # CONFIG_NETFILTER_XT_MATCH_PKTTYPE is not set
 # CONFIG_NETFILTER_XT_MATCH_QUOTA is not set
 # CONFIG_NETFILTER_XT_MATCH_RATEEST is not set
@@ -1033,7 +1050,7 @@ CONFIG_STANDALONE=y
 # CONFIG_PREVENT_FIRMWARE_BUILD is not set
 CONFIG_FW_LOADER=y
 CONFIG_FIRMWARE_IN_KERNEL=y
-CONFIG_EXTRA_FIRMWARE="bnx2/bnx2-mips-06-6.2.1.fw bnx2/bnx2-mips-09-6.2.1a.fw bnx2/bnx2-rv2p-06-6.0.15.fw bnx2/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-09ax-6.0.17.fw tigon/tg3.bin tigon/tg3_tso5.bin tigon/tg3_tso.bin rtl_nic/rtl8105e-1.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8411-2.fw"
+CONFIG_EXTRA_FIRMWARE="bnx2/bnx2-mips-06-6.2.1.fw bnx2/bnx2-mips-09-6.2.1a.fw bnx2/bnx2-rv2p-06-6.0.15.fw bnx2/bnx2-rv2p-09-6.0.17.fw bnx2/bnx2-rv2p-09ax-6.0.17.fw tigon/tg3.bin tigon/tg3_tso5.bin tigon/tg3_tso.bin rtl_nic/rtl8105e-1.fw rtl_nic/rtl8106e-1.fw rtl_nic/rtl8106e-2.fw rtl_nic/rtl8107e-1.fw rtl_nic/rtl8107e-2.fw rtl_nic/rtl8168d-1.fw rtl_nic/rtl8168d-2.fw rtl_nic/rtl8168e-1.fw rtl_nic/rtl8168e-2.fw rtl_nic/rtl8168e-3.fw rtl_nic/rtl8168f-1.fw rtl_nic/rtl8168f-2.fw rtl_nic/rtl8168g-1.fw rtl_nic/rtl8168g-2.fw rtl_nic/rtl8168g-3.fw rtl_nic/rtl8168h-1.fw rtl_nic/rtl8168h-2.fw rtl_nic/rtl8402-1.fw rtl_nic/rtl8411-1.fw rtl_nic/rtl8411-2.fw radeon/ARUBA_me.bin radeon/ARUBA_pfp.bin radeon/ARUBA_rlc.bin radeon/BARTS_mc.bin radeon/BARTS_me.bin radeon/BARTS_pfp.bin radeon/BARTS_smc.bin radeon/bonaire_ce.bin radeon/BONAIRE_ce.bin radeon/BONAIRE_mc2.bin radeon/bonaire_mc.bin radeon/BONAIRE_mc.bin radeon/bonaire_me.bin radeon/BONAIRE_me.bin radeon/bonaire_mec.bin radeon/BONAIRE_mec.bin radeon/bonaire_pfp.bin radeon/BONAIRE_pfp.bin radeon/bonaire_rlc.bin radeon/BONAIRE_rlc.bin radeon/bonaire_sdma.bin radeon/BONAIRE_sdma.bin radeon/bonaire_smc.bin radeon/BONAIRE_smc.bin radeon/BONAIRE_uvd.bin radeon/BONAIRE_vce.bin radeon/BTC_rlc.bin radeon/CAICOS_mc.bin radeon/CAICOS_me.bin radeon/CAICOS_pfp.bin radeon/CAICOS_smc.bin radeon/CAYMAN_mc.bin radeon/CAYMAN_me.bin radeon/CAYMAN_pfp.bin radeon/CAYMAN_rlc.bin radeon/CAYMAN_smc.bin radeon/CEDAR_me.bin radeon/CEDAR_pfp.bin radeon/CEDAR_rlc.bin radeon/CEDAR_smc.bin radeon/CYPRESS_me.bin radeon/CYPRESS_pfp.bin radeon/CYPRESS_rlc.bin radeon/CYPRESS_smc.bin radeon/CYPRESS_uvd.bin radeon/hainan_ce.bin radeon/HAINAN_ce.bin radeon/HAINAN_mc2.bin radeon/hainan_mc.bin radeon/HAINAN_mc.bin radeon/hainan_me.bin radeon/HAINAN_me.bin radeon/hainan_pfp.bin radeon/HAINAN_pfp.bin radeon/hainan_rlc.bin radeon/HAINAN_rlc.bin radeon/hainan_smc.bin radeon/HAINAN_smc.bin radeon/hawaii_ce.bin radeon/HAWAII_ce.bin radeon/HAWAII_mc2.bin radeon/hawaii_mc.bin radeon/HAWAII_mc.bin radeon/hawaii_me.bin radeon/HAWAII_me.bin radeon/hawaii_mec.bin radeon/HAWAII_mec.bin radeon/hawaii_pfp.bin radeon/HAWAII_pfp.bin radeon/hawaii_rlc.bin radeon/HAWAII_rlc.bin radeon/hawaii_sdma.bin radeon/HAWAII_sdma.bin radeon/hawaii_smc.bin radeon/HAWAII_smc.bin radeon/JUNIPER_me.bin radeon/JUNIPER_pfp.bin radeon/JUNIPER_rlc.bin radeon/JUNIPER_smc.bin radeon/kabini_ce.bin radeon/KABINI_ce.bin radeon/kabini_me.bin radeon/KABINI_me.bin radeon/kabini_mec.bin radeon/KABINI_mec.bin radeon/kabini_pfp.bin radeon/KABINI_pfp.bin radeon/kabini_rlc.bin radeon/KABINI_rlc.bin radeon/kabini_sdma.bin radeon/KABINI_sdma.bin radeon/kaveri_ce.bin radeon/KAVERI_ce.bin radeon/kaveri_me.bin radeon/KAVERI_me.bin radeon/kaveri_mec2.bin radeon/kaveri_mec.bin radeon/KAVERI_mec.bin radeon/kaveri_pfp.bin radeon/KAVERI_pfp.bin radeon/kaveri_rlc.bin radeon/KAVERI_rlc.bin radeon/kaveri_sdma.bin radeon/KAVERI_sdma.bin radeon/mullins_ce.bin radeon/MULLINS_ce.bin radeon/mullins_me.bin radeon/MULLINS_me.bin radeon/mullins_mec.bin radeon/MULLINS_mec.bin radeon/mullins_pfp.bin radeon/MULLINS_pfp.bin radeon/mullins_rlc.bin radeon/MULLINS_rlc.bin radeon/mullins_sdma.bin radeon/MULLINS_sdma.bin radeon/oland_ce.bin radeon/OLAND_ce.bin radeon/OLAND_mc2.bin radeon/oland_mc.bin radeon/OLAND_mc.bin radeon/oland_me.bin radeon/OLAND_me.bin radeon/oland_pfp.bin radeon/OLAND_pfp.bin radeon/oland_rlc.bin radeon/OLAND_rlc.bin radeon/oland_smc.bin radeon/OLAND_smc.bin radeon/PALM_me.bin radeon/PALM_pfp.bin radeon/pitcairn_ce.bin radeon/PITCAIRN_ce.bin radeon/PITCAIRN_mc2.bin radeon/pitcairn_mc.bin radeon/PITCAIRN_mc.bin radeon/pitcairn_me.bin radeon/PITCAIRN_me.bin radeon/pitcairn_pfp.bin radeon/PITCAIRN_pfp.bin radeon/pitcairn_rlc.bin radeon/PITCAIRN_rlc.bin radeon/pitcairn_smc.bin radeon/PITCAIRN_smc.bin radeon/R100_cp.bin radeon/R200_cp.bin radeon/R300_cp.bin radeon/R420_cp.bin radeon/R520_cp.bin radeon/R600_me.bin radeon/R600_pfp.bin radeon/R600_rlc.bin radeon/R600_uvd.bin radeon/R700_rlc.bin radeon/REDWOOD_me.bin radeon/REDWOOD_pfp.bin radeon/REDWOOD_rlc.bin radeon/REDWOOD_smc.bin radeon/RS600_cp.bin radeon/RS690_cp.bin radeon/RS780_me.bin radeon/RS780_pfp.bin radeon/RS780_uvd.bin radeon/RV610_me.bin radeon/RV610_pfp.bin radeon/RV620_me.bin radeon/RV620_pfp.bin radeon/RV630_me.bin radeon/RV630_pfp.bin radeon/RV635_me.bin radeon/RV635_pfp.bin radeon/RV670_me.bin radeon/RV670_pfp.bin radeon/RV710_me.bin radeon/RV710_pfp.bin radeon/RV710_smc.bin radeon/RV710_uvd.bin radeon/RV730_me.bin radeon/RV730_pfp.bin radeon/RV730_smc.bin radeon/RV740_smc.bin radeon/RV770_me.bin radeon/RV770_pfp.bin radeon/RV770_smc.bin radeon/RV770_uvd.bin radeon/SUMO2_me.bin radeon/SUMO2_pfp.bin radeon/SUMO_me.bin radeon/SUMO_pfp.bin radeon/SUMO_rlc.bin radeon/SUMO_uvd.bin radeon/tahiti_ce.bin radeon/TAHITI_ce.bin radeon/TAHITI_mc2.bin radeon/tahiti_mc.bin radeon/TAHITI_mc.bin radeon/tahiti_me.bin radeon/TAHITI_me.bin radeon/tahiti_pfp.bin radeon/TAHITI_pfp.bin radeon/tahiti_rlc.bin radeon/TAHITI_rlc.bin radeon/tahiti_smc.bin radeon/TAHITI_smc.bin radeon/TAHITI_uvd.bin radeon/TURKS_mc.bin radeon/TURKS_me.bin radeon/TURKS_pfp.bin radeon/TURKS_smc.bin radeon/verde_ce.bin radeon/VERDE_ce.bin radeon/VERDE_mc2.bin radeon/verde_mc.bin radeon/VERDE_mc.bin radeon/verde_me.bin radeon/VERDE_me.bin radeon/verde_pfp.bin radeon/VERDE_pfp.bin radeon/verde_rlc.bin radeon/VERDE_rlc.bin radeon/verde_smc.bin radeon/VERDE_smc.bin"
 CONFIG_EXTRA_FIRMWARE_DIR="firmware"
 # CONFIG_FW_LOADER_USER_HELPER_FALLBACK is not set
 CONFIG_WANT_DEV_COREDUMP=y
@@ -1076,7 +1093,7 @@ CONFIG_BLK_DEV_LOOP_MIN_COUNT=0
 # CONFIG_BLK_DEV_CRYPTOLOOP is not set
 # CONFIG_BLK_DEV_DRBD is not set
 CONFIG_BLK_DEV_NBD=y
-# CONFIG_BLK_DEV_NVME is not set
+CONFIG_BLK_DEV_NVME=y
 # CONFIG_BLK_DEV_SKD is not set
 # CONFIG_BLK_DEV_SX8 is not set
 CONFIG_BLK_DEV_RAM=y
@@ -1357,14 +1374,15 @@ CONFIG_NET_CORE=y
 # CONFIG_EQUALIZER is not set
 # CONFIG_NET_FC is not set
 # CONFIG_NET_TEAM is not set
-# CONFIG_MACVLAN is not set
+CONFIG_MACVLAN=m
+# CONFIG_MACVTAP is not set
 # CONFIG_IPVLAN is not set
 # CONFIG_VXLAN is not set
 CONFIG_NETCONSOLE=y
 CONFIG_NETPOLL=y
 CONFIG_NET_POLL_CONTROLLER=y
 CONFIG_TUN=y
-# CONFIG_VETH is not set
+CONFIG_VETH=m
 # CONFIG_NLMON is not set
 # CONFIG_ARCNET is not set
 
@@ -1865,7 +1883,7 @@ CONFIG_TOUCHSCREEN_USB_EGALAX=y
 # CONFIG_TOUCHSCREEN_USB_ZYTRONIC is not set
 # CONFIG_TOUCHSCREEN_USB_ETT_TC45USB is not set
 # CONFIG_TOUCHSCREEN_USB_NEXIO is not set
-CONFIG_TOUCHSCREEN_USB_EASYTOUCH=y
+# CONFIG_TOUCHSCREEN_USB_EASYTOUCH is not set
 # CONFIG_TOUCHSCREEN_TOUCHIT213 is not set
 # CONFIG_TOUCHSCREEN_TSC_SERIO is not set
 # CONFIG_TOUCHSCREEN_TSC2007 is not set
@@ -1922,7 +1940,7 @@ CONFIG_VT_CONSOLE_SLEEP=y
 CONFIG_HW_CONSOLE=y
 CONFIG_VT_HW_CONSOLE_BINDING=y
 CONFIG_UNIX98_PTYS=y
-# CONFIG_DEVPTS_MULTIPLE_INSTANCES is not set
+CONFIG_DEVPTS_MULTIPLE_INSTANCES=y
 # CONFIG_LEGACY_PTYS is not set
 # CONFIG_SERIAL_NONSTANDARD is not set
 # CONFIG_NOZOMI is not set
@@ -2846,15 +2864,62 @@ CONFIG_DVB_AF9033=m
 #
 # Graphics support
 #
-# CONFIG_AGP is not set
+CONFIG_AGP=y
+# CONFIG_AGP_AMD64 is not set
+CONFIG_AGP_INTEL=y
+# CONFIG_AGP_SIS is not set
+CONFIG_AGP_VIA=y
+CONFIG_INTEL_GTT=y
 CONFIG_VGA_ARB=y
 CONFIG_VGA_ARB_MAX_GPUS=16
-# CONFIG_VGA_SWITCHEROO is not set
+CONFIG_VGA_SWITCHEROO=y
 
 #
 # Direct Rendering Manager
 #
-# CONFIG_DRM is not set
+CONFIG_DRM=y
+CONFIG_DRM_MIPI_DSI=y
+CONFIG_DRM_KMS_HELPER=y
+CONFIG_DRM_KMS_FB_HELPER=y
+CONFIG_DRM_LOAD_EDID_FIRMWARE=y
+CONFIG_DRM_TTM=y
+
+#
+# I2C encoder or helper chips
+#
+# CONFIG_DRM_I2C_ADV7511 is not set
+# CONFIG_DRM_I2C_CH7006 is not set
+# CONFIG_DRM_I2C_SIL164 is not set
+# CONFIG_DRM_I2C_NXP_TDA998X is not set
+# CONFIG_DRM_TDFX is not set
+# CONFIG_DRM_R128 is not set
+CONFIG_DRM_RADEON=y
+# CONFIG_DRM_RADEON_USERPTR is not set
+# CONFIG_DRM_RADEON_UMS is not set
+# CONFIG_DRM_NOUVEAU is not set
+# CONFIG_DRM_I810 is not set
+CONFIG_DRM_I915=y
+CONFIG_DRM_I915_KMS=y
+CONFIG_DRM_I915_FBDEV=y
+# CONFIG_DRM_I915_PRELIMINARY_HW_SUPPORT is not set
+# CONFIG_DRM_MGA is not set
+# CONFIG_DRM_SIS is not set
+# CONFIG_DRM_VIA is not set
+# CONFIG_DRM_SAVAGE is not set
+# CONFIG_DRM_VGEM is not set
+# CONFIG_DRM_VMWGFX is not set
+# CONFIG_DRM_GMA500 is not set
+# CONFIG_DRM_UDL is not set
+# CONFIG_DRM_AST is not set
+# CONFIG_DRM_MGAG200 is not set
+# CONFIG_DRM_CIRRUS_QEMU is not set
+# CONFIG_DRM_QXL is not set
+# CONFIG_DRM_BOCHS is not set
+CONFIG_DRM_PANEL=y
+
+#
+# Display Panels
+#
 
 #
 # Frame buffer Devices
@@ -2936,6 +3001,7 @@ CONFIG_BACKLIGHT_CLASS_DEVICE=y
 # CONFIG_BACKLIGHT_LV5207LP is not set
 # CONFIG_BACKLIGHT_BD6107 is not set
 # CONFIG_VGASTATE is not set
+CONFIG_HDMI=y
 
 #
 # Console display driver support
@@ -3065,6 +3131,7 @@ CONFIG_SND_HDA_CODEC_ANALOG=m
 CONFIG_SND_HDA_CODEC_SIGMATEL=m
 CONFIG_SND_HDA_CODEC_VIA=m
 CONFIG_SND_HDA_CODEC_HDMI=m
+CONFIG_SND_HDA_I915=y
 CONFIG_SND_HDA_CODEC_CIRRUS=m
 CONFIG_SND_HDA_CODEC_CONEXANT=m
 CONFIG_SND_HDA_CODEC_CA0110=m
@@ -3725,8 +3792,8 @@ CONFIG_DCACHE_WORD_ACCESS=y
 # CONFIG_EXT3_FS is not set
 CONFIG_EXT4_FS=y
 CONFIG_EXT4_USE_FOR_EXT23=y
-# CONFIG_EXT4_FS_POSIX_ACL is not set
-# CONFIG_EXT4_FS_SECURITY is not set
+CONFIG_EXT4_FS_POSIX_ACL=y
+CONFIG_EXT4_FS_SECURITY=y
 # CONFIG_EXT4_ENCRYPTION is not set
 # CONFIG_EXT4_DEBUG is not set
 CONFIG_JBD2=y
@@ -3772,7 +3839,7 @@ CONFIG_FANOTIFY=y
 CONFIG_AUTOFS4_FS=y
 CONFIG_FUSE_FS=m
 # CONFIG_CUSE is not set
-# CONFIG_OVERLAY_FS is not set
+CONFIG_OVERLAY_FS=m
 
 #
 # Caches
@@ -4325,6 +4392,7 @@ CONFIG_XZ_DEC=y
 # CONFIG_XZ_DEC_BCJ is not set
 # CONFIG_XZ_DEC_TEST is not set
 CONFIG_DECOMPRESS_GZIP=y
+CONFIG_INTERVAL_TREE=y
 CONFIG_ASSOCIATIVE_ARRAY=y
 CONFIG_HAS_IOMEM=y
 CONFIG_HAS_IOPORT_MAP=y


### PR DESCRIPTION
There is no reason to have different kernel configs for the two projects. Just keep them the same so it's easier to keep track of changes.