### PR TITLE
taglib: update bytevector.patch

### DIFF
--- a/packages/audio/taglib/patches/taglib-01_bytevector.patch
+++ b/packages/audio/taglib/patches/taglib-01_bytevector.patch
@@ -1,4 +1,12 @@
-## patch taken from kodi (unified deps)
+From 4a7d31c87bf41c1de21cb725176d5b34c2a95720 Mon Sep 17 00:00:00 2001
+From: Tsuda Kageyu <tsuda.kageyu@gmail.com>
+Date: Thu, 14 Nov 2013 14:05:32 +0900
+Subject: [PATCH] Rewrote ByteVector::replace() simpler
+
+---
+ taglib/toolkit/tbytevector.cpp | 77 +++++++++++++++---------------------------
+ tests/test_bytevector.cpp      |  5 +++
+ 2 files changed, 33 insertions(+), 49 deletions(-)
 
 diff --git a/taglib/toolkit/tbytevector.cpp b/taglib/toolkit/tbytevector.cpp
 index b658246..566a20f 100644
@@ -106,7 +114,7 @@ diff --git a/tests/test_bytevector.cpp b/tests/test_bytevector.cpp
 index 9efd23a..eca74f8 100644
 --- a/tests/test_bytevector.cpp
 +++ b/tests/test_bytevector.cpp
-@@ -239,6 +239,11 @@ public:
+@@ -239,6 +239,11 @@ class TestByteVector : public CppUnit::TestFixture
        a.replace(ByteVector("ab"), ByteVector());
        CPPUNIT_ASSERT_EQUAL(ByteVector("cdf"), a);
      }


### PR DESCRIPTION
cosmetics. the patch is upstream. I have no idea why I thought it's from kodi unified depends (or it got lost in some xbmc pr rebase, dunno)

