### PR TITLE
Add pvr hdhomerun

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -1,0 +1,50 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="pvr.hdhomerun"
+PKG_VERSION="070aca3"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.kodi.tv"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_DEPENDS_TARGET="toolchain kodi-platform jsoncpp libhdhomerun"
+PKG_PRIORITY="optional"
+PKG_SECTION=""
+PKG_SHORTDESC="pvr.hdhomerun"
+PKG_LONGDESC="pvr.hdhomerun"
+PKG_AUTORECONF="no"
+
+PKG_IS_ADDON="yes"
+PKG_ADDON_TYPE="xbmc.pvrclient"
+
+configure_target() {
+  cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \
+        -DCMAKE_INSTALL_PREFIX=/usr \
+        -DCMAKE_MODULE_PATH=$SYSROOT_PREFIX/usr/lib/kodi \
+        -DCMAKE_PREFIX_PATH=$SYSROOT_PREFIX/usr \
+        -DHDHOMERUN_LIBRARIES=$SYSROOT_PREFIX/usr/lib/libhdhomerun.so \
+        -DHDHOMERUN_INCLUDE_DIRS=$SYSROOT_PREFIX/usr/include/hdhomerun \
+        ..
+}
+
+addon() {
+  mkdir -p $ADDON_BUILD/$PKG_ADDON_ID/
+  cp -PR $PKG_BUILD/.install_pkg/usr/share/kodi/addons/$PKG_NAME/* $ADDON_BUILD/$PKG_ADDON_ID/
+  cp -PL $PKG_BUILD/.install_pkg/usr/lib/kodi/addons/$PKG_NAME/*.so $ADDON_BUILD/$PKG_ADDON_ID/
+}

--- a/packages/multimedia/libhdhomerun/package.mk
+++ b/packages/multimedia/libhdhomerun/package.mk
@@ -41,4 +41,10 @@ makeinstall_target() {
 
   mkdir -p $INSTALL/usr/lib/
     cp -PR libhdhomerun.so $INSTALL/usr/lib/
+
+  mkdir -p $SYSROOT_PREFIX/usr/include/hdhomerun
+    cp *.h $SYSROOT_PREFIX/usr/include/hdhomerun
+
+  mkdir -p $SYSROOT_PREFIX/usr/lib
+    cp libhdhomerun.so $SYSROOT_PREFIX/usr/lib
 }


### PR DESCRIPTION
Both commits are needed to successfully build [`pvr.hdhomerun`](https://github.com/kodi-pvr/pvr.hdhomerun).

Creating the pkconfig file in `libhdhomerun` is a rather ugly hack, due to `libhdhomerun` not having a usable `make install` and not installing itself as a library, as it should.

Hopefully Silicon Dust can update their package in future to avoid hacks like this.