### PR TITLE
[systemd] Update our patch to work with systemd-228 - closes #4470

### DIFF
--- a/packages/sysutils/systemd/patches/systemd-06_stop-execute_preset-doing-stupid-things.patch
+++ b/packages/sysutils/systemd/patches/systemd-06_stop-execute_preset-doing-stupid-things.patch
@@ -1,20 +1,20 @@
-From 233596980655a02b77caf56fab05708e8e155bd6 Mon Sep 17 00:00:00 2001
+From 8cfc723a596bcdab404f4861571b178d76eb1f7a Mon Sep 17 00:00:00 2001
 From: Stefan Saraev <stefan@saraev.ca>
 Date: Tue, 28 Oct 2014 22:32:18 +0200
-Subject: [PATCH 6/8] stop unit_file_preset_all doing stupid things
+Subject: [PATCH] stop execute_preset doing stupid things
 
 populating shitload of useless symlinks into /storage/.config/system.d
 is not so-nice fuckery. and systemctl preset-all is useless on an
 embedded distro like openelec anyway.
 ---
- src/shared/install.c |    5 +++++
+ src/shared/install.c | 5 +++++
  1 file changed, 5 insertions(+)
 
 diff --git a/src/shared/install.c b/src/shared/install.c
-index 65f1c24..945001d 100644
+index 17e03e5..f7e51af 100644
 --- a/src/shared/install.c
 +++ b/src/shared/install.c
-@@ -2033,6 +2033,11 @@ int unit_file_preset_all(
+@@ -2165,6 +2165,11 @@ static int execute_preset(
                  UnitFileChange **changes,
                  unsigned *n_changes) {
  
@@ -23,9 +23,6 @@ index 65f1c24..945001d 100644
 +        // just because systemd "thinks" (o_O) /etc is empty
 +        return 0;
 +
-         _cleanup_(install_context_done) InstallContext plus = {}, minus = {};
-         _cleanup_lookup_paths_free_ LookupPaths paths = {};
-         _cleanup_free_ char *config_path = NULL;
--- 
-1.7.10.4
-
+         int r;
+ 
+         assert(plus);


### PR DESCRIPTION
Need to nop `execute_preset()` in 228 and not `unit_file_preset_all()` to stop systemd populating `/storage/.config/system.d` with useless symlinks.