### PR TITLE
scripts/create_addon: fixes

### DIFF
--- a/scripts/create_addon
+++ b/scripts/create_addon
@@ -122,6 +122,9 @@ pack_addon() {
     if [ -f $ADDON_BUILD/$PKG_ADDON_ID/icon.png ]; then
       cp $ADDON_BUILD/$PKG_ADDON_ID/icon.png $ADDON_INSTALL_DIR/icon.png
     fi
+    if [ -f $ADDON_BUILD/$PKG_ADDON_ID/addon.xml ]; then
+      cp $ADDON_BUILD/$PKG_ADDON_ID/addon.xml $ADDON_INSTALL_DIR/addon.xml
+    fi
   fi
 }
 


### PR DESCRIPTION
I'm not sure why this didn't happen already :)
It is useful when you are making an add-on repo

As for using the specific add-on repo, this helps to maintain separate repo's 