### PR TITLE
pulseaudio: use pulseaudio --> alsa bridge

### DIFF
--- a/packages/audio/alsa-plugins/package.mk
+++ b/packages/audio/alsa-plugins/package.mk
@@ -1,0 +1,42 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+PKG_NAME="alsa-plugins"
+PKG_VERSION="1.0.29"
+PKG_REV="1"
+PKG_ARCH="any"
+PKG_LICENSE="GPL"
+PKG_SITE="http://www.alsa-project.org/"
+PKG_URL="ftp://ftp.alsa-project.org/pub/plugins/$PKG_NAME-$PKG_VERSION.tar.bz2"
+PKG_DEPENDS_TARGET="toolchain alsa-lib"
+PKG_PRIORITY="optional"
+PKG_SECTION="audio"
+PKG_SHORTDESC=""
+PKG_LONGDESC=""
+
+PKG_IS_ADDON="no"
+PKG_AUTORECONF="yes"
+
+# package specific configure options
+PKG_CONFIGURE_OPTS_TARGET="--disable-jack \
+                           --enable-pulseaudio \
+                           --disable-samplerate \
+                           --disable-maemo-plugin \
+                           --disable-maemo-resource-manager \
+                           --disable-avcodec \
+                           --with-plugindir=/usr/lib/alsa"

--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -55,7 +55,6 @@ load-module module-suspend-on-idle
 ### Enable positioned event sounds
 load-module module-position-event-sounds
 
-
 ### Automatically load modules for dbus
 .ifexists module-dbus-protocol.so
  load-module module-dbus-protocol
@@ -72,10 +71,6 @@ load-module module-position-event-sounds
 
 .ifexists module-zeroconf-publish.so
   load-module module-zeroconf-publish
-.endif
-
-.ifexists module-zeroconf-discover.so
-  load-module module-zeroconf-discover
 .endif
 
 load-module module-native-protocol-tcp auth-anonymous=1

--- a/packages/audio/pulseaudio/package.mk
+++ b/packages/audio/pulseaudio/package.mk
@@ -79,6 +79,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-silent-rules \
                            --disable-bluez5-ofono-headset \
                            --disable-bluez5-native-headset \
                            --enable-udev \
+                           --with-udev-rules-dir=/usr/lib/udev/rules.d
                            --disable-hal-compat \
                            --enable-ipv6 \
                            --enable-openssl \

--- a/packages/audio/pulseaudio/profile.d/99-pulseaudio.conf
+++ b/packages/audio/pulseaudio/profile.d/99-pulseaudio.conf
@@ -1,0 +1,19 @@
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2014 Stephan Raue (stephan@openelec.tv)
+#
+#  OpenELEC is free software: you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation, either version 2 of the License, or
+#  (at your option) any later version.
+#
+#  OpenELEC is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE.  See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.  If not, see <http://www.gnu.org/licenses/>.
+################################################################################
+
+export LD_LIBRARY_PATH="$LD_LIBRARY_PATH:/usr/lib/pulseaudio"

--- a/packages/audio/pulseaudio/system.d/pulseaudio.service
+++ b/packages/audio/pulseaudio/system.d/pulseaudio.service
@@ -3,8 +3,12 @@ Description=PulseAudio Sound System
 After=syslog.target local-fs.target
 
 [Service]
+Restart=on-failure
 ExecStart=/usr/bin/pulseaudio --system
-Restart=always
+TimeoutStopSec=1s
+RestartSec=2
+StartLimitInterval=60
+StartLimitBurst=10
 
 [Install]
 WantedBy=multi-user.target

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -73,10 +73,7 @@ fi
 
 if [ "$PULSEAUDIO_SUPPORT" = yes ]; then
 # for PulseAudio support
-  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET pulseaudio"
-  KODI_PULSEAUDIO="--enable-pulse"
-else
-  KODI_PULSEAUDIO="--disable-pulse"
+  PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET pulseaudio alsa-plugins"
 fi
 
 if [ "$ESPEAK_SUPPORT" = yes ]; then
@@ -254,7 +251,7 @@ PKG_CONFIGURE_OPTS_TARGET="gl_cv_func_gettimeofday_clobber=no \
                            $KODI_XORG \
                            --disable-ccache \
                            $KODI_ALSA \
-                           $KODI_PULSEAUDIO \
+                           --disable-pulse \
                            --enable-rtmp \
                            $KODI_SAMBA \
                            $KODI_NFS \


### PR DESCRIPTION
This replaces #4427 

This creates a pulseaudio --> alsa bridge device that shows up in kodi as "PulseAudio Sound Server"

This device can be selected to use pulseaudio output. If not needed then one could select the default sound device that they desire.

I am not 100% sure if the causes audio handling issues and needs to be tested to make sure DTS-HD and TrueHD work on devices that support it.

This was the method as described by @fritsch 

@MilhouseVH can you include this into your test builds?
I tested on the RPi2 and I can still select a passthrough device, so let me know if that bug exists again with this PR.