### PR TITLE
bcm2835-driver: update to version 6b7cebd

### DIFF
--- a/packages/graphics/bcm2835-driver/package.mk
+++ b/packages/graphics/bcm2835-driver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-driver"
-PKG_VERSION="7f01b12"
+PKG_VERSION="6b7cebd"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="nonfree"

--- a/packages/tools/bcm2835-bootloader/package.mk
+++ b/packages/tools/bcm2835-bootloader/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="bcm2835-bootloader"
-PKG_VERSION="7f01b12"
+PKG_VERSION="6b7cebd"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"


### PR DESCRIPTION
This includes the updated firmware for the RPi zero