### PR TITLE
ffmpeg: enable png encoder

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -163,6 +163,7 @@ configure_target() {
               --enable-encoder=aac \
               --enable-encoder=wmav2 \
               --enable-encoder=mjpeg \
+              --enable-encoder=png \
               --disable-decoder=mpeg_xvmc \
               --enable-hwaccels \
               --disable-muxers \


### PR DESCRIPTION
Following on from #4488, this will be required by https://github.com/xbmc/xbmc/pull/8583 to enable `png` encoding. No harm in enabling now.