### PR TITLE
audiodecoder.usf: don't build on RPi

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/audiodecoder.usf/package.mk
@@ -32,6 +32,7 @@ PKG_AUTORECONF="no"
 
 PKG_IS_ADDON="yes"
 PKG_ADDON_TYPE="kodi.audiodecoder"
+PKG_ADDON_PROJECTS="Generic Nvidia_Legacy RPi2 imx6 WeTek_Play"
 
 configure_target() {
   cmake -DCMAKE_TOOLCHAIN_FILE=$CMAKE_CONF \


### PR DESCRIPTION
package build fails on RPi without this (and is currently missing from 6.0 repo) as first gen. pi doesn't support neon fpu. - this has been "build" tested, I've no idea how to test the actual decoder