### PR TITLE
[RFC] Stop being stingy with System partition size

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -27,7 +27,7 @@
   OE_TMP=$(mktemp -d)
   LOOP=$(losetup -f)
 
-  SYSTEM_SIZE=256
+  SYSTEM_SIZE=512
   STORAGE_SIZE=32 # STORAGE_SIZE must be >= 32 !
 
   DISK_SIZE=$(( $SYSTEM_SIZE + $STORAGE_SIZE + 4 ))


### PR DESCRIPTION
I realise the default partition size is large enough for regular releases, however it's not large enough if a user wishes to assist with testing and tries to use a debug-enabled build which is then too large to install. Or if a user has a problem with a stock release, and needs to use a debug enabled build to provide more detailed information.

The size of debug-enabled `SYSTEM`+`KERNEL` is 278MB+10MB (RPi/RPi2) and 347MB+12MB (Generic, including NVidia legacy drivers).

Therefore a partition size of 512MB is comfortably large enough for the foreseeable future, allowing more users to get involved with testing/debugging, and without taking too much extra space from `Storage`.

Given the size of storage devices that most users have available these days, using a partition size that is only just large enough for an official release seems rather unnecessary.

Any users wishing to squeeze OpenELEC into an exceptionally small storage device that requires the `System` partition to be as small as possible still has the option to manually create and size their partitions - such users are likely to be the exception, and not the rule.