### PR TITLE
pulseaudio: remove automatic loading of udev module

### DIFF
--- a/packages/audio/pulseaudio/config/system.pa
+++ b/packages/audio/pulseaudio/config/system.pa
@@ -18,14 +18,6 @@
 # This startup script is used only if PulseAudio is started in system
 # mode.
 
-### Automatically load driver modules depending on the hardware available
-.ifexists module-udev-detect.so
-load-module module-udev-detect
-.else
-### Use the static hardware detection module (for systems that lack udev/hal support)
-load-module module-detect
-.endif
-
 ### Load several protocols
 .ifexists module-esound-protocol-unix.so
 load-module module-esound-protocol-unix


### PR DESCRIPTION
This change makes it safe to enable pulseaudio for all builds

With this change pulseaudio will only be used for bluetooth audio and sending network audio.

It is not practical to configure pulseaudio for HDMI as there are many different options (profile, codecs, default sink, etc)