### PR TITLE
addons: update repo descriptions and lock unofficial to 6.0

### DIFF
--- a/packages/addons/repository/repository.unofficial.addon.pro/sources/addon.xml
+++ b/packages/addons/repository/repository.unofficial.addon.pro/sources/addon.xml
@@ -1,15 +1,10 @@
 <?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.unofficial.addon.pro"
-                name="Unofficial [COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] (@PROJECT@/@ARCH@) Add-ons"
+                name="[COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] Add-ons (unofficial)"
                 version="@PKG_VERSION@.@PKG_REV@"
-                provider-name="unofficial.addon.pro">
+                provider-name="OpenELEC Community">
         <extension point="xbmc.addon.repository"
-                name="Unofficial OpenELEC.tv Add-on Repository">
-                <dir minversion="14.0.0">
-                    <info>http://unofficial.addon.pro/addons/4.3/@PROJECT@/@ARCH@/addons.xml</info>
-                    <checksum>http://unofficial.addon.pro/addons/4.3/@PROJECT@/@ARCH@/addons.xml.md5</checksum>
-                    <datadir zip="true">http://unofficial.addon.pro/addons/4.3/@PROJECT@/@ARCH@</datadir>
-                </dir>
+                name="OpenELEC Add-ons (unofficial)">
                 <dir minversion="15.0.0">
                     <info>http://unofficial.addon.pro/addons/6.0/@PROJECT@/@ARCH@/addons.xml</info>
                     <checksum>http://unofficial.addon.pro/addons/6.0/@PROJECT@/@ARCH@/addons.xml.md5</checksum>
@@ -17,14 +12,9 @@
                 </dir>
         </extension>
         <extension point="xbmc.addon.metadata">
-                <summary>Unofficial addon repository for OpenELEC</summary>
-                <description>
-[COLOR red]=== BIG FAT WARNING ===[/COLOR]
-Use this repository at your own risk.
-If your house gets burned, it's your fault, not ours.
-We give no guarantee. We give no support.
-                </description>
-                <disclaimer>This is an unofficial addon repository. please don't ask for support in openelec forum / irc channel</disclaimer>
+                <summary>OpenELEC Add-ons (unofficial)</summary>
+                <description>The OpenELEC unofficial repository contains add-ons from the community. These add-ons are not supported by OpenELEC staff. If you find a broken add-on please check the OpenELEC or Kodi forums for community support threads and ask the add-on author to submit fixes via GitHub.</description>
+                <disclaimer>Add-ons in this repository are not maintained or supported by OpenELEC staff.</disclaimer>
                 <platform>all</platform>
         </extension>
 </addon>

--- a/packages/mediacenter/kodi/config/repository.openelec.tv/addon.xml
+++ b/packages/mediacenter/kodi/config/repository.openelec.tv/addon.xml
@@ -1,17 +1,17 @@
 ﻿<?xml version="1.0" encoding="UTF-8" standalone="yes"?>
 <addon id="repository.openelec.tv"
-		name="[COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] Mediacenter OS Add-ons"
-		version="4.0.0"
+		name="[COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] Add-ons (official)"
+		version="6.0.0"
 		provider-name="Team [COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR]">
 	<extension point="xbmc.addon.repository"
-		name="Official OpenELEC.tv Add-on Repository">
+		name="OpenELEC Add-ons (official)">
 		<info>@ADDON_URL@/addons.xml</info>
 		<checksum>@ADDON_URL@/addons.xml.md5</checksum>
 		<datadir zip="true">@ADDON_URL@</datadir>
 	</extension>
 	<extension point="xbmc.addon.metadata">
-		<summary>Install Add-ons, Plugins, Games and Programs from [COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR]</summary>
-		<description>Download and install Add-ons, Plugins, Games and Programs from the Official [COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] addon repository.[CR]  By using the official Repository you will be able to take advantage of our extensive file mirror service to help get you faster downloads from a region close to you.[CR]  All addons on this repository have under gone basic testing, if you find a broken or not working addon please report it to [COLOR FF757677]Open[/COLOR][COLOR FF8ABEE2]ELEC[/COLOR] so we can take any action needed.</description>
-		<platform>all</platform>
+		<summary>OpenELEC Add-ons (official)</summary>
+		<description>The OpenELEC official repository contains Kodi PVR Clients, Screensavers, Visualisations, the unofficial repo installer, and more. Add-ons in this repository are maintained and supported by OpenELEC staff and sponsors. If you find a broken or non-working add-on please report it via the forums.</description>
+		<platform>all</platform>	
 	</extension>
 </addon>


### PR DESCRIPTION
These are the same cosmetic/description changes that I made to the 7.0 branch yesterday. We also need to lock the unofficial repo to 6.0 addons to avoid it picking up earlier 4.3 ones.