### PR TITLE
samba: add restore share

### DIFF
--- a/packages/network/samba/config/smb.conf
+++ b/packages/network/samba/config/smb.conf
@@ -158,3 +158,11 @@
   public = yes
   writable = yes
   root preexec = mkdir -p /storage/backup
+
+[Restore]
+  path = /storage/restore
+  available = yes
+  browsable = yes
+  public = yes
+  writable = yes
+  root preexec = mkdir -p /storage/.restore


### PR DESCRIPTION
Add a "Restore" share to make it easier for users to complete a backup > reimage > restore sequence once we grow Generic with multiple nvidia drivers.