### PR TITLE
fuse : fix unavailable package due to bad url

### DIFF
--- a/packages/sysutils/fuse/package.mk
+++ b/packages/sysutils/fuse/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="fuse"
-PKG_VERSION="2.9.4"
+PKG_VERSION="0285462"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://sourceforge.net/projects/fuse/"
-PKG_URL="$SOURCEFORGE_SRC/fuse/fuse-2.X/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://github.com/libfuse/libfuse.git"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="system"

--- a/tools/mkpkg/mkpkg_fuse
+++ b/tools/mkpkg/mkpkg_fuse
@@ -1,0 +1,43 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+echo "getting sources..."
+  if [ ! -d fuse.git ]; then
+    git clone https://github.com/libfuse/libfuse.git -b fuse_2_9_bugfix fuse.git
+  fi
+
+  cd fuse.git
+    git pull
+    GIT_REV=`git log -n1 --format=%h`
+  cd ..
+
+echo "copying sources..."
+  rm -rf fuse-$GIT_REV
+  cp -R fuse.git fuse-$GIT_REV
+
+echo "cleaning sources..."
+  rm -rf fuse-$GIT_REV/.git
+
+echo "packing sources..."
+  tar cvJf fuse-$GIT_REV.tar.xz fuse-$GIT_REV
+
+echo "remove temporary sourcedir..."
+  rm -rf fuse-$GIT_REV


### PR DESCRIPTION
fuse packages are not available on sourceforge so url:
PKG_URL="$SOURCEFORGE_SRC/fuse/fuse-2.X/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.gz"
is deprecated and building the image with:
 PROJECT=imx6 ARCH=arm make image
fail because archive cannot be found.

Now the repo is available on github:
https://github.com/libfuse/libfuse.git

This patch modify the makefile informations for fuse and add a script to generate the package.

Before merging this patch, the archive genrated with ./tools/mkpkg/mkpkg_fuse must be copied on "$DISTRO_SRC/" mirror.
Be careful that the commit id has not changed since the creation of this patch.