### PR TITLE
addons: bump pvr.dvblink pvr.mythtv pvr.nextpvr - add kodi patch

### DIFF
--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="cf756e9"
+PKG_VERSION="b87e8a7"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="8cb158c"
+PKG_VERSION="5450056"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="3a205e4"
+PKG_VERSION="e53841d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-platform/patches/kodi-platform-02_no-multi-lib.patch
+++ b/packages/mediacenter/kodi-platform/patches/kodi-platform-02_no-multi-lib.patch
@@ -1,0 +1,37 @@
+diff -Naur kodi-platform-15edaf7.orig/CMakeLists.txt kodi-platform-15edaf7/CMakeLists.txt
+--- kodi-platform-15edaf7.orig/CMakeLists.txt	2015-10-22 17:44:43.034540766 -0700
++++ kodi-platform-15edaf7/CMakeLists.txt	2015-10-22 17:46:38.851326343 -0700
+@@ -9,7 +9,6 @@
+ find_package(TinyXML REQUIRED)
+ find_package(Threads REQUIRED)
+ find_package(platform REQUIRED)
+-include(UseMultiArch.cmake)
+ include(CheckAtomic.cmake)
+ 
+ set(kodiplatform_NAME kodiplatform)
+@@ -43,7 +42,7 @@
+ set_target_properties(kodiplatform PROPERTIES VERSION ${kodiplatform_VERSION_MAJOR}.${kodiplatform_VERSION_MINOR}.${kodiplatform_VERSION_PATCH}
+                                               SOVERSION ${kodiplatform_VERSION_MAJOR}.0)
+ 
+-install(TARGETS kodiplatform DESTINATION ${CMAKE_INSTALL_LIBDIR})
++install(TARGETS kodiplatform DESTINATION ${CMAKE_INSTALL_PREFIX}/lib)
+ install(FILES src/util/XMLUtils.h
+         DESTINATION include/kodi/util)
+ 
+@@ -57,14 +56,14 @@
+                                  ${CMAKE_INSTALL_PREFIX}/include)
+ 
+   install(FILES ${CMAKE_BINARY_DIR}/kodiplatform.pc
+-          DESTINATION ${CMAKE_INSTALL_LIBDIR_NOARCH}/pkgconfig)
++          DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/pkgconfig)
+ ENDIF(NOT WIN32)
+ 
+ # config mode
+ configure_file (kodiplatform-config.cmake.in
+                 kodiplatform-config.cmake @ONLY)
+ install(FILES ${CMAKE_BINARY_DIR}/kodiplatform-config.cmake
+-        DESTINATION ${CMAKE_INSTALL_LIBDIR_NOARCH}/kodiplatform)
++        DESTINATION ${CMAKE_INSTALL_PREFIX}/lib/kodiplatform)
+ 
+ # Quell warnings with in-tree builds
+ set(KODI_BUILD_DIR ${KODI_BUILD_DIR})

--- a/packages/mediacenter/kodi/patches/kodi-100.14-pvr-githashes-20151226.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.14-pvr-githashes-20151226.patch
@@ -1,0 +1,18 @@
+diff -Naur a/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt b/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt
+--- a/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt	2015-12-26 19:03:33.252651380 +0100
++++ b/project/cmake/addons/addons/pvr.dvblink/pvr.dvblink.txt	2015-12-26 19:23:29.304223912 +0100
+@@ -1 +1 @@
+-pvr.dvblink https://github.com/kodi-pvr/pvr.dvblink cf756e9
++pvr.dvblink https://github.com/kodi-pvr/pvr.dvblink b87e8a7
+diff -Naur a/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt b/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt
+--- a/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt	2015-12-26 19:03:33.252651380 +0100
++++ b/project/cmake/addons/addons/pvr.mythtv/pvr.mythtv.txt	2015-12-26 19:23:47.950262212 +0100
+@@ -1 +1 @@
+-pvr.mythtv https://github.com/kodi-pvr/pvr.mythtv 8cb158c
++pvr.mythtv https://github.com/kodi-pvr/pvr.mythtv 5450056
+diff -Naur a/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt b/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt
+--- a/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt	2015-12-26 19:03:33.252651380 +0100
++++ b/project/cmake/addons/addons/pvr.nextpvr/pvr.nextpvr.txt	2015-12-26 19:24:06.602300524 +0100
+@@ -1 +1 @@
+-pvr.nextpvr https://github.com/kodi-pvr/pvr.nextpvr 3a205e4
++pvr.nextpvr https://github.com/kodi-pvr/pvr.nextpvr e53841d


### PR DESCRIPTION
Kodi sources contain outdated addon hashes (not updated since 15.2 final) so mkpkg scripts used to package kodi-binary-addon sources don't give latest packages. If applied to downloaded Kodi sources this patch updates hashes to current. It's not required to build Kodi - but we have to stash a reminder somewhere.