### PR TITLE
[scripts] Add PKG_SOURCE_NAME for non-standard package tarballs

### DIFF
--- a/config/path
+++ b/config/path
@@ -61,6 +61,8 @@ SED="sed -i"
   PKG_LICENSE="unknown"
   PKG_SITE=""
   PKG_URL=""
+  PKG_SOURCE_NAME=""
+  PKG_SOURCE_DIR=""
   PKG_DEPENDS_TARGET=""
   PKG_DEPENDS_HOST=""
   PKG_DEPENDS_INIT=""
@@ -120,6 +122,38 @@ SED="sed -i"
 
   if [ "$PKG_IS_ADDON" = "yes" ] ; then
     [ -z $PKG_SECTION ] && PKG_ADDON_ID="$PKG_NAME" || PKG_ADDON_ID="`echo $PKG_SECTION | sed 's,/,.,g'`.$PKG_NAME"
+  fi
+
+  # Automatically set PKG_SOURCE_NAME unless it is already defined.
+  # PKG_SOURCE_NAME will be automatically set to a name based on
+  # the $PKG_NAME-$PKG_VERSION convention.
+  #
+  # Any $PKG_URL that references more than a single url will abort
+  # the build as these are no longer supported - use mkpkg instead.
+  if [ -n "$PKG_URL" -a -z "$PKG_SOURCE_NAME" ]; then
+    if [[ $PKG_URL =~ .*\ .* ]]; then
+      echo "Error - packages with multiple urls are no longer supported, use mkpkg:"
+      echo "$PKG_URL"
+      exit 1
+    fi
+    PKG_SOURCE_NAME="$(basename "$PKG_URL")"
+    case $PKG_SOURCE_NAME in
+      ${PKG_NAME}-${PKG_VERSION}.*)
+        PKG_SOURCE_NAME=$PKG_SOURCE_NAME
+        ;;
+      *.tar | *.tbz | *.tgz | *.txz | *.7z | *.zip)
+        PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.${PKG_SOURCE_NAME##*\.}
+        ;;
+      *.tar.bz2 | *.tar.gz | *.tar.xz)
+        PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.tar.${PKG_SOURCE_NAME##*\.}
+        ;;
+       *.diff | *.patch | *.diff.bz2 | *.patch.bz2 | patch-*.bz2 | *.diff.gz | *.patch.gz | patch-*.gz)
+        PKG_SOURCE_NAME=$PKG_SOURCE_NAME
+        ;;
+      *)
+        PKG_SOURCE_NAME=${PKG_NAME}-${PKG_VERSION}.${PKG_SOURCE_NAME##*\.}
+        ;;
+    esac
   fi
 
   PKG_BUILD="$BUILD/${PKG_NAME}-${PKG_VERSION}"

--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -109,10 +109,6 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --with-rootprefix=/usr \
                            --with-rootlibdir=/lib"
 
-unpack() {
-  tar xf $ROOT/$SOURCES/systemd/v$PKG_VERSION.tar.gz -C $ROOT/$BUILD
-}
-
 pre_build_target() {
 # broken autoreconf
   ( cd $PKG_BUILD

--- a/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia-legacy/package.mk
@@ -34,10 +34,9 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 unpack() {
-  NV_PKG="`echo $PKG_URL | sed 's%.*/\(.*\)$%\1%'`"
   [ -d $PKG_BUILD ] && rm -rf $PKG_BUILD
 
-  sh $SOURCES/$PKG_NAME/$NV_PKG --extract-only --target $BUILD/$PKG_NAME-$PKG_VERSION
+  sh $SOURCES/$PKG_NAME/$PKG_SOURCE_NAME --extract-only --target $PKG_BUILD
 }
 
 make_target() {

--- a/packages/x11/driver/xf86-video-nvidia/package.mk
+++ b/packages/x11/driver/xf86-video-nvidia/package.mk
@@ -34,10 +34,9 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 unpack() {
-  NV_PKG="`echo $PKG_URL | sed 's%.*/\(.*\)$%\1%'`"
   [ -d $PKG_BUILD ] && rm -rf $PKG_BUILD
 
-  sh $SOURCES/$PKG_NAME/$NV_PKG --extract-only --target $BUILD/$PKG_NAME-$PKG_VERSION
+  sh $SOURCES/$PKG_NAME/$PKG_SOURCE_NAME --extract-only --target $PKG_BUILD
 }
 
 make_target() {

--- a/scripts/extract
+++ b/scripts/extract
@@ -25,21 +25,18 @@ if [ -z "$3" ]; then
   exit 1
 fi
 
-[ -z "$PKG_URL" ] && exit 1
+[ -z "$PKG_URL" -o -z "$PKG_SOURCE_NAME" ] && exit 1
 [ ! -d "$SOURCES/$1" -o ! -d "$3" ] && exit 1
 
-for i in $PKG_URL; do
-  FILE="`basename $i`"
-
-  case $FILE in
+case $PKG_SOURCE_NAME in
   $2)
-    f="$SOURCES/$1/$FILE"
+    f="$SOURCES/$1/$PKG_SOURCE_NAME"
     if [ ! -f $f ]; then
-      echo "error: File $FILE doesn't exists in package $1 sources directory"
+      echo "error: File $PKG_SOURCE_NAME doesn't exists in package $1 sources directory"
       echo "have you called scripts/extract before scripts/get ?"
       exit 1
     fi
-    case $FILE in
+    case $PKG_SOURCE_NAME in
       *.tar)
         tar xf $f -C $3
         ;;
@@ -74,5 +71,4 @@ for i in $PKG_URL; do
         ;;
     esac
     ;;
-  esac
-done
+esac

--- a/scripts/get
+++ b/scripts/get
@@ -27,7 +27,7 @@ if [ -z "$1" ]; then
   done
 fi
 
-if [ -n "$PKG_URL" ]; then
+if [ -n "$PKG_URL" -a -n "$PKG_SOURCE_NAME" ]; then
   mkdir -p $SOURCES/$1
 
   # Avoid concurrent downloads of the same package
@@ -38,40 +38,41 @@ if [ -n "$PKG_URL" ]; then
     sleep 1
   done
 
-  for i in $PKG_URL; do
-    SOURCE_NAME="`basename $i`"
-    PACKAGE="$SOURCES/$1/$SOURCE_NAME"
-    PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
-    [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-    WGET_CMD="wget --timeout=30 --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1"
+  PACKAGE="$SOURCES/$1/$PKG_SOURCE_NAME"
+  PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$PKG_SOURCE_NAME"
+  [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
+  WGET_CMD="wget --timeout=30 --passive-ftp --no-check-certificate -c $WGET_OPT -O $SOURCES/$1/$PKG_SOURCE_NAME"
 
-    NBWGET="1"
+  NBWGET="1"
 
-    STAMP="$PACKAGE.url"
-    MD5SUM="$PACKAGE.md5"
+  STAMP="$PACKAGE.url"
+  MD5SUM="$PACKAGE.md5"
 
-    if [ -f "$STAMP" ]; then
-      [ "`cat $STAMP`" = "$i" ] && continue
-    fi
-    DL="yes"
+  DL="yes"
+  if [ -f "$STAMP" ]; then
+    [ "`cat $STAMP`" == "$PKG_URL" ] && DL="no"
+  fi
 
+  if [ "$DL" == "yes" ]; then
     rm -f $STAMP
 
     printf "%${BUILD_INDENT}c ${boldcyan}GET${endcolor}      $1\n" ' '>&$SILENT_OUT
     export BUILD_INDENT=$((${BUILD_INDENT:-1}+$BUILD_INDENT_SIZE))
 
-    until [ -f "$STAMP" ] || $WGET_CMD $i || $WGET_CMD $PACKAGE_MIRROR; do
+    until [ -f "$STAMP" ] || $WGET_CMD $PKG_URL || $WGET_CMD $PACKAGE_MIRROR; do
       NBWGET=$(($NBWGET+1))
       if [ "$NBWGET" -gt "10" ]; then
-        echo -e "\nCant't get $1 sources : $i\n Try later !!"
+        echo -e "\nCant't get $1 sources : $PKG_URL\n Try later !!"
         exit 1
       fi
     done
 
-    echo $i > $STAMP
+    echo $PKG_URL > $STAMP
     md5sum -t $PACKAGE > $MD5SUM
 
     rm -f $BUILD_BASE*/$STAMPS_NOARCH/$1/unpack
     rm -f $BUILD_BASE*/$STAMPS_NOARCH/$1/build
-  done
+  fi
 fi
+
+exit 0


### PR DESCRIPTION
The vast majority of packages create source tarballs along the lines of `$PKG_NAME-$PKG_VERSION.tar.xz` (or `.gz` etc.).

However some packages do not, eg. https://github.com/OpenELEC/unofficial-addons/pull/96, which creates a package tarball with the file name `v4.0.8.tar.gz`, and requires an `unpack()` function to work around this situation.

With this PR, `PKG_SOURCE_NAME=$PKG_NAME-$PKG_VERSION.tar.xz` (or `.gz` etc.) can be added to `package.mk` to simplify the handling of these non-standard package filenames.

In the case of tvheadend, the entire `unpack()` function can be removed following the addition of `PKG_SOURCE_NAME=$PKG_NAME-$PKG_VERSION.tar.gz`. In addition, the tvheadend source tarball hosted on the OE mirror server can be given the "standard" file name `tvheadend-4.0.8.tar.gz` instead of the ambiguous `v4.0.8.tar.gz` that would otherwise have to be used.

With this change, existing `package.mk` files should work as before, including those with custom `unpack()` functions, or with multiple `PKG_URL`s (ie. [makemkv](https://github.com/OpenELEC/unofficial-addons/blob/master/addons/multimedia/makemkv/package.mk)).

Packages with a single `PKG_URL` could be switched to using `PKG_SOURCE_NAME`, if considered appropriate.

I would suggest switching `tvheadend/pacakge.mk` if this is ever merged.