### PR TITLE
Added support for nspawn containers

### DIFF
--- a/packages/sysutils/systemd/package.mk
+++ b/packages/sysutils/systemd/package.mk
@@ -78,7 +78,7 @@ PKG_CONFIGURE_OPTS_TARGET="ac_cv_func_malloc_0_nonnull=yes \
                            --disable-backlight \
                            --disable-rfkill \
                            --enable-logind \
-                           --disable-machined \
+                           --enable-machined \
                            --disable-importd \
                            --disable-hostnamed \
                            --disable-timedated \
@@ -172,8 +172,8 @@ post_makeinstall_target() {
   rm -rf $INSTALL/usr/lib/systemd/system/*.target.wants/systemd-udev-hwdb-update.service
 
   # remove nspawn
-  rm -rf $INSTALL/usr/bin/systemd-nspawn
-  rm -rf $INSTALL/usr/lib/systemd/system/systemd-nspawn@.service
+#  rm -rf $INSTALL/usr/bin/systemd-nspawn
+#  rm -rf $INSTALL/usr/lib/systemd/system/systemd-nspawn@.service
 
   # remove genetators/catalog
   rm -rf $INSTALL/usr/lib/systemd/system-generators


### PR DESCRIPTION
I saw Sony2's Docker PR adding kernel support for namespaces. systemd has it's own mini container manager that ships with systemd itself utilising kernel namespaces for isolation. I've been using the systemd-nspawn for a little while now to quarantine my own containers preserving the rest of the OpenElec system.

nspawn allows you to run lightweight containers (including Docker containers) and can be enabled in systemd pretty easily...

> systemd-nspawn may be used to run a command or OS in a light-weight namespace container. In many ways it is similar to chroot(1), but more powerful since it fully virtualizes the file system hierarchy, as well as the process tree, the various IPC subsystems and the host and domain name.

Would it be possible to include in the main OpenElec project?
