### PR TITLE
iptables: Fix build failure due to race

### DIFF
--- a/packages/network/iptables/package.mk
+++ b/packages/network/iptables/package.mk
@@ -33,3 +33,5 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--with-kernel=$(kernel_path)"
+
+MAKEFLAGS="-j1"


### PR DESCRIPTION
A clean build of OpenELEC will sometimes fail as follows:

```
mv -f .deps/xtables_compat_multi-xtables-standalone.Tpo .deps/xtables_compat_multi-xtables-standalone.Po
/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/toolchain/bin/armv7ve-openelec-linux-gnueabi-gcc -DHAVE_CONFIG_H -I. -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/iptables-1.6.0/iptables -I..  -D_LARGEFILE_SOURCE=1 -D_LARGE_FILES -D_FILE_OFFSET_BITS=64 -D_REENTRANT      -DXTABLES_LIBDIR=\"/usr/lib/xtables\" -DXTABLES_INTERNAL -I../include -I.. -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/iptables-1.6.0/include -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/iptables-1.6.0 -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/linux-4.4-rc7/include/uapi -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/linux-4.4-rc7/include -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/linux-4.4-rc7/include/uapi -I/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/linux-4.4-rc7/include     -Wall -Waggregate-return -Wmissing-declarations       -Wmissing-prototypes -Wredundant-decls -Wshadow -Wstrict-prototypes     -Winline -pipe  -DENABLE_NFTABLES -DENABLE_IPV4 -DENABLE_IPV6 -march=armv7ve -mabi=aapcs-linux -Wno-psabi -Wa,-mno-warn-deprecated -mcpu=cortex-a7 -mfloat-abi=hard -mfpu=neon-vfpv4 -fomit-frame-pointer -Wall -pipe -Os -fexcess-precision=fast -flto -ffat-lto-objects  -MT xtables_compat_multi-nft-shared.o -MD -MP -MF .deps/xtables_compat_multi-nft-shared.Tpo -c -o xtables_compat_multi-nft-shared.o `test -f 'nft-shared.c' || echo '/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/iptables-1.6.0/iptables/'`nft-shared.c
/home/neil/projects/OpenELEC.tv/build.OpenELEC-RPi2.arm-7.0-devel/iptables-1.6.0/iptables/nft.c:53:35: fatal error: xtables-config-parser.h: No such file or directory
compilation terminated.
Makefile:794: recipe for target 'xtables_compat_multi-nft.o' failed
make[3]: *** [xtables_compat_multi-nft.o] Error 1
make[3]: *** Waiting for unfinished jobs....
updating xtables-config-parser.h
```

The failure is due to a race condition - other times the build will succeed.

I'd rather not have to submit this PR, but I'm not aware of any better solution.