### PR TITLE
vdr-addon: fix some vdr plugins

### DIFF
--- a/packages/3rdparty/lib/cxxtools/package.mk
+++ b/packages/3rdparty/lib/cxxtools/package.mk
@@ -44,10 +44,39 @@ pre_configure_target() {
 
 
 post_makeinstall_host() {
-  rm -rf $TOOLCHAIN/bin/cxxtools-config
+  mv $ROOT/$TOOLCHAIN/bin/cxxtools-config $ROOT/$TOOLCHAIN/bin/cxxtools-config.host
+
+  cat >$ROOT/$TOOLCHAIN/bin/cxxtools-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/cxxtools-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/cxxtools-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/cxxtools-config
 }
 
 post_makeinstall_target() {
-  rm -rf $SYSROOT_PREFIX/usr/bin/cxxtools-config
   rm -rf $INSTALL/usr/bin
+
+  mv $SYSROOT_PREFIX/usr/bin/cxxtools-config $ROOT/$TOOLCHAIN/bin/cxxtools-config.target
+
+  cat >$ROOT/$TOOLCHAIN/bin/cxxtools-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/cxxtools-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/cxxtools-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/cxxtools-config
 }

--- a/packages/3rdparty/web/tntnet/package.mk
+++ b/packages/3rdparty/web/tntnet/package.mk
@@ -50,7 +50,41 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-unittest \
                            --with-ssl=no \
                            --with-stressjob=no"
 
+post_makeinstall_host() {
+  mv $ROOT/$TOOLCHAIN/bin/tntnet-config $ROOT/$TOOLCHAIN/bin/tntnet-config.host
+
+  cat >$ROOT/$TOOLCHAIN/bin/tntnet-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/tntnet-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/tntnet-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/tntnet-config
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
   rm -rf $INSTALL/usr/share
+
+  mv $SYSROOT_PREFIX/usr/bin/tntnet-config $ROOT/$TOOLCHAIN/bin/tntnet-config.target
+
+  cat >$ROOT/$TOOLCHAIN/bin/tntnet-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/tntnet-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/tntnet-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/tntnet-config
 }

--- a/packages/devel/pcre/package.mk
+++ b/packages/devel/pcre/package.mk
@@ -44,6 +44,24 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-shared \
              --enable-unicode-properties \
              --with-gnu-ld"
 
+post_makeinstall_host() {
+  mv $ROOT/$TOOLCHAIN/bin/pcre-config $ROOT/$TOOLCHAIN/bin/pcre-config.host
+
+  cat >$ROOT/$TOOLCHAIN/bin/pcre-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/pcre-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/pcre-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/pcre-config
+}
+
 pre_configure_target() {
   CFLAGS="$CFLAGS -fPIC"
   CXXFLAGS="$CXXFLAGS -fPIC"
@@ -52,4 +70,20 @@ pre_configure_target() {
 
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
+
+  mv $SYSROOT_PREFIX/usr/bin/pcre-config $ROOT/$TOOLCHAIN/bin/pcre-config.target
+
+  cat >$ROOT/$TOOLCHAIN/bin/pcre-config <<EOT
+#!/bin/sh
+case "\$1" in
+--c*flags*|--libs*)
+$ROOT/$TOOLCHAIN/bin/pcre-config.\$DESTIMAGE "\$@" | xargs -n1 | grep -v -e^-I/usr/include\\$ -e^-L/usr/lib\\$ | xargs
+;;
+*)
+$ROOT/$TOOLCHAIN/bin/pcre-config.\$DESTIMAGE "\$@"
+;;
+esac
+EOT
+
+  chmod 0755 $ROOT/$TOOLCHAIN/bin/pcre-config
 }


### PR DESCRIPTION
After [PR#4441](https://github.com/OpenELEC/OpenELEC.tv/pull/4441) vdr-epgsearh, vdr-plugin-epgfixer and vdr-live are broken. They are built without errors but fail to load on target. Their makefiles use XXXX-config (e.g. pcre-config) scripts instead of pkg-config and if a XXXX:host package is built XXXX-config outputs paths for the host libraries. As the result the plugins above are linked (dynamically) against the host libraries (can be checked with ldd) and failed to load. 
The proposed solution allows to run the host XXXX-config when building for a host and the target one when building for a target (with /usr/include and /usr/lib stripped).
