### PR TITLE
projects/imx6/linux: rename Hummingboard on-board analog sgtl5000 audio codec

### DIFF
--- a/projects/imx6/patches/linux/linux-002-rename-sgtl5000-codec.patch
+++ b/projects/imx6/patches/linux/linux-002-rename-sgtl5000-codec.patch
@@ -1,0 +1,25 @@
+From 3499e0d1703d361277e65419178152d792bd55dc Mon Sep 17 00:00:00 2001
+From: Peter Vicman <peter.vicman@gmail.com>
+Date: Mon, 4 Jan 2016 19:55:37 +0100
+Subject: [PATCH] rename sgtl5000 codec
+
+---
+ arch/arm/boot/dts/imx6qdl-hummingboard.dtsi | 2 +-
+ 1 file changed, 1 insertion(+), 1 deletion(-)
+
+diff --git a/arch/arm/boot/dts/imx6qdl-hummingboard.dtsi b/arch/arm/boot/dts/imx6qdl-hummingboard.dtsi
+index 2003262..d2446ef 100644
+--- a/arch/arm/boot/dts/imx6qdl-hummingboard.dtsi
++++ b/arch/arm/boot/dts/imx6qdl-hummingboard.dtsi
+@@ -62,7 +62,7 @@
+ 			"Mic Jack", "Mic Bias",
+ 			"Headphone Jack", "HP_OUT";
+ 		compatible = "fsl,imx-audio-sgtl5000";
+-		model = "On-board Codec";
++		model = "imx-sgtl5000";
+ 		mux-ext-port = <5>;
+ 		mux-int-port = <1>;
+ 		ssi-controller = <&ssi1>;
+-- 
+1.8.1.2
+


### PR DESCRIPTION
In device tree there is
> model = "On-board Codec";

and this doesn't match any alsa config. That's why it is renamed to
> model = "imx-sgtl5000";

for which we already have imx-sgtl5000.conf file.
This enables to use analog sound output on Hummingboard.