### PR TITLE
cosmetics: rename 'unofficial' to 'community' builds

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -282,7 +282,7 @@ show_config() {
 
   dashes="==========================="
   config_message="$config_message\n $dashes$dashes$dashes"
-  config_message="$config_message\n Configuration for $DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" || echo "unofficial"))"
+  config_message="$config_message\n Configuration for $DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" || echo "community"))"
   config_message="$config_message\n $dashes$dashes$dashes"
 
   # Build options

--- a/scripts/image
+++ b/scripts/image
@@ -95,7 +95,7 @@ fi
   echo -e "VERSION=\"$OPENELEC_VERSION\"" >> $INSTALL/etc/os-release
   echo -e "ID=\"openelec\"" >> $INSTALL/etc/os-release
   echo -e "VERSION_ID=\"$OS_VERSION\"" >> $INSTALL/etc/os-release
-  echo -e "PRETTY_NAME=\"$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "unofficial")) - Version: $OPENELEC_VERSION\"" >> $INSTALL/etc/os-release
+  echo -e "PRETTY_NAME=\"$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "community")) - Version: $OPENELEC_VERSION\"" >> $INSTALL/etc/os-release
   echo -e "HOME_URL=\"http://www.openelec.tv\"" >> $INSTALL/etc/os-release
   echo -e "BUG_REPORT_URL=\"https://github.com/OpenELEC/OpenELEC.tv\"" >> $INSTALL/etc/os-release
   if [ -n "$GIT_HASH" ]; then
@@ -105,7 +105,7 @@ fi
   if [ "$OFFICIAL" = "yes" ]; then
     echo -e "OPENELEC_BUILD=\"official\"" >> $INSTALL/etc/os-release
   else
-    echo -e "OPENELEC_BUILD=\"unofficial\"" >> $INSTALL/etc/os-release
+    echo -e "OPENELEC_BUILD=\"community\"" >> $INSTALL/etc/os-release
   fi
 
 # create /etc/issue
@@ -114,7 +114,7 @@ fi
   echo $GREETING2 >> $INSTALL/etc/issue
   echo $GREETING3 >> $INSTALL/etc/issue
   echo $GREETING4 >> $INSTALL/etc/issue
-  echo "$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "unofficial")) Version: $OPENELEC_VERSION" >> $INSTALL/etc/issue
+  echo "$DISTRONAME ($([ "$OFFICIAL" = "yes" ] && echo "official" ||  echo "community")) Version: $OPENELEC_VERSION" >> $INSTALL/etc/issue
   if [ -n "$GIT_HASH" ]; then
     echo "$DISTRONAME git: $GIT_HASH" >> $INSTALL/etc/issue
   fi


### PR DESCRIPTION
builds created by users in our ecosystem/community should be labelled as such .. it's a friendlier way of saying they are not official builds