### PR TITLE
xorg: enable tcp-transport so '-tcp nolisten' works

### DIFF
--- a/packages/x11/xserver/xorg-server/package.mk
+++ b/packages/x11/xserver/xorg-server/package.mk
@@ -115,7 +115,7 @@ PKG_CONFIGURE_OPTS_TARGET="--disable-debug \
                            --enable-xshmfence \
                            --disable-install-setuid \
                            --enable-unix-transport \
-                           --disable-tcp-transport \
+                           --enable-tcp-transport \
                            --disable-ipv6 \
                            --disable-local-transport \
                            --disable-secure-rpc \


### PR DESCRIPTION
https://github.com/OpenELEC/OpenELEC.tv/commit/567719dea26c12c4b4bafd9a3e5c4c604f9273f5 is incomplete without this additional change. You need to enable tcp transport before -tcp nolisten can silence the error.