### PR TITLE
banner: fix whitespace padding

### DIFF
--- a/distributions/OpenELEC/options
+++ b/distributions/OpenELEC/options
@@ -6,8 +6,8 @@
 
 # Welcome Message for e.g. SSH Server (up to 5 Lines)
   GREETING0="##############################################"
-  GREETING1="#                  OpenELEC                  #"
-  GREETING2="#             http://openelec.tv             #"
+  GREETING1="# ................ OpenELEC ................ #"
+  GREETING2="# ........... http://openelec.tv ........... #"
   GREETING3="##############################################"
   GREETING4=""
 


### PR DESCRIPTION
I discovered some ssh clients collapse whitespace in the banner so the recent change looks like:

    ##############################################
    # OpenELEC #
    # http://openelec.tv #
    ##############################################```

so this adds whitespace padding to make it look like:

    ##############################################
    # ................ OpenELEC ................ #
    # ........... http://openelec.tv ........... #
    ##############################################```

not _as_ simple, but still cleaner than the original