### PR TITLE
linux: add support for TechnoTrend CT2-4650 version 2

### DIFF
--- a/packages/linux/patches/4.4/linux-228-support-tt-ct2-4650-v2.patch
+++ b/packages/linux/patches/4.4/linux-228-support-tt-ct2-4650-v2.patch
@@ -1,0 +1,25 @@
+diff -urN a/drivers/media/dvb-core/dvb-usb-ids.h b/drivers/media/dvb-core/dvb-usb-ids.h
+--- a/drivers/media/dvb-core/dvb-usb-ids.h	2016-01-11 01:01:32.000000000 +0200
++++ b/drivers/media/dvb-core/dvb-usb-ids.h	2016-01-13 12:42:17.648388583 +0200
+@@ -247,6 +247,7 @@
+ #define USB_PID_TECHNOTREND_CONNECT_CT3650		0x300d
+ #define USB_PID_TECHNOTREND_CONNECT_S2_4600             0x3011
+ #define USB_PID_TECHNOTREND_CONNECT_CT2_4650_CI		0x3012
++#define USB_PID_TECHNOTREND_CONNECT_CT2_4650_CI_2	0x3015
+ #define USB_PID_TECHNOTREND_TVSTICK_CT2_4400		0x3014
+ #define USB_PID_TERRATEC_CINERGY_DT_XS_DIVERSITY	0x005a
+ #define USB_PID_TERRATEC_CINERGY_DT_XS_DIVERSITY_2	0x0081
+diff -urN a/drivers/media/usb/dvb-usb-v2/dvbsky.c b/drivers/media/usb/dvb-usb-v2/dvbsky.c
+--- a/drivers/media/usb/dvb-usb-v2/dvbsky.c	2016-01-11 01:01:32.000000000 +0200
++++ b/drivers/media/usb/dvb-usb-v2/dvbsky.c	2016-01-13 12:41:17.480386735 +0200
+@@ -847,6 +847,10 @@
+ 		USB_PID_TECHNOTREND_CONNECT_CT2_4650_CI,
+ 		&dvbsky_t680c_props, "TechnoTrend TT-connect CT2-4650 CI",
+ 		RC_MAP_TT_1500) },
++	{ DVB_USB_DEVICE(USB_VID_TECHNOTREND,
++		USB_PID_TECHNOTREND_CONNECT_CT2_4650_CI_2,
++		&dvbsky_t680c_props, "TechnoTrend TT-connect CT2-4650 CI v1.1",
++		RC_MAP_TT_1500) },
+ 	{ DVB_USB_DEVICE(USB_VID_TERRATEC,
+ 		USB_PID_TERRATEC_H7_3,
+ 		&dvbsky_t680c_props, "Terratec H7 Rev.4",


### PR DESCRIPTION
This patch is probably going into kernel 4.6, so this OE patch
is obsolete after that.