### PR TITLE
ffmpeg: Stop disabling ARMv5TE and ARMv6T2 - needed by ASM optimisations

### DIFF
--- a/packages/multimedia/ffmpeg/package.mk
+++ b/packages/multimedia/ffmpeg/package.mk
@@ -126,7 +126,6 @@ configure_target() {
               $FFMPEG_PIC \
               --pkg-config="$ROOT/$TOOLCHAIN/bin/pkg-config" \
               --enable-optimizations \
-              --disable-armv5te --disable-armv6t2 \
               --disable-extra-warnings \
               --disable-ffprobe \
               --disable-ffplay \


### PR DESCRIPTION
Disabling ARMv6T is preventing some ARM ASM from being used (ie. cabac optimisations in HEVC code) as `HAVE_ARMV6T2_INLINE` is not enabled, which is hurting performance.

Unless there's a specific reason to disable ARMv5TE then might as well leave it available as well.