### PR TITLE
kodi: add patch so pulseaudio is at the end of the list

### DIFF
--- a/packages/mediacenter/kodi/patches/kodi-100.14-move-pulse-device-to-end-of-list.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.14-move-pulse-device-to-end-of-list.patch
@@ -1,0 +1,28 @@
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index fbccce0..597492d 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -1293,6 +1293,22 @@ void CAESinkALSA::EnumerateDevicesEx(AEDeviceInfoList &list, bool force)
+       }
+     }
+   }
++
++  CAEDeviceInfo pulseDevice;
++  bool found = false;
++  for (AEDeviceInfoList::iterator itl = list.begin(); itl != list.end(); ++itl)
++  {
++     if (itl->m_deviceName == "pulse")
++     {
++       pulseDevice = *itl;
++       found = true;
++       list.erase(itl);
++       break;
++     }
++  }
++  // append pulse device at the end
++  if (found)
++    list.push_back(pulseDevice);
+ }
+ 
+ AEDeviceType CAESinkALSA::AEDeviceTypeFromName(const std::string &name)
+


### PR DESCRIPTION
Thanks @fritsch for this.

This makes it so that pulseaudio output isn't selected automatically so we don't have people accidentally using it.

This fixes #4585 

keep open till @fritsch gives the go ahead