### PR TITLE
xf86-video-ati: use DRI3

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -67,7 +67,7 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --disable-gles1 \
                            --disable-gles2 \
                            --enable-dri \
-                           --disable-dri3 \
+                           --enable-dri3 \
                            --enable-glx \
                            --disable-osmesa \
                            --disable-gallium-osmesa \
@@ -96,6 +96,10 @@ PKG_CONFIGURE_OPTS_TARGET="CC_FOR_BUILD=$HOST_CC \
                            --with-gallium-drivers=$GALLIUM_DRIVERS \
                            --with-dri-drivers=$DRI_DRIVERS \
                            --with-sysroot=$SYSROOT_PREFIX"
+
+pre_configure_target() {
+  export LIBS="-lxcb-dri3 -lxcb-present -lxcb-sync -lxshmfence"
+}
 
 post_makeinstall_target() {
   # rename and relink for cooperate with nvidia drivers

--- a/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
+++ b/packages/x11/driver/xf86-video-ati/config/xorg-radeon.conf
@@ -1,0 +1,5 @@
+Section "Device"
+   Identifier  "Radeon"
+   Driver      "radeon"
+   Option      "DRI3"   "on"
+EndSection

--- a/packages/x11/driver/xf86-video-ati/package.mk
+++ b/packages/x11/driver/xf86-video-ati/package.mk
@@ -33,3 +33,8 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-glamor --with-xorg-module-dir=$XORG_PATH_MODULES"
+
+post_makeinstall_target() {
+  mkdir -p $INSTALL/etc/X11
+    cp $PKG_DIR/config/*.conf $INSTALL/etc/X11
+}


### PR DESCRIPTION
I'd like to test this out, not sure if there is any negative impact

see, http://www.phoronix.com/scan.php?page=article&item=radeon-dri3-perf&num=1

```
grep -i dri3 /var/log/Xorg.0.log
```
should show something similar to:
>[1550498.698] (**) RADEON(0): Option "DRI3" "on"
>[1550498.864] (**) RADEON(0): DRI3 enabled