### PR TITLE
scripts/mkimage: sync disk few more times

### DIFF
--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -99,6 +99,7 @@ fi
 
 # create filesystem on part1
   losetup -d "$LOOP"
+  sync
   echo "image: creating filesystem on part1..."
   OFFSET=$(( 2048 * 512 ))
   SIZELIMIT=$(( $SYSTEM_SIZE * 1024 * 1024 ))
@@ -216,6 +217,7 @@ fi # bootloader
 
 # create filesystem on part2
   losetup -d "$LOOP"
+  sync
   echo "image: creating filesystem on part2..."
   OFFSET=$(( $STORAGE_PART_START * 512 ))
   SIZELIMIT=$(( $STORAGE_SIZE * 1024 * 1024 ))


### PR DESCRIPTION
fix issue like this
```
image: creating filesystem on part1...
losetup: /dev/loop0: device is busy
```