### PR TITLE
mkpkg_binary-addons: don't checkout and create a new branch at the sa…

### DIFF
--- a/tools/mkpkg/mkpkg_binary-addons
+++ b/tools/mkpkg/mkpkg_binary-addons
@@ -41,7 +41,8 @@ git_clone() {
     cd "$3"
     git fetch >/dev/null 2>/dev/null
     git branch -D $4 >/dev/null 2>/dev/null
-    git checkout $4 -b ref-$4 >/dev/null 2>/dev/null
+    git checkout $4 >/dev/null 2>/dev/null
+    git checkout -b ref-$4 >/dev/null 2>/dev/null
     cd ..
   fi
 }


### PR DESCRIPTION
…me time

You can't checkout a branch and create a new branch at the same time. This only worked for git hashes.

So in the past you would be left with `adsp.basic-.tar.xz`

```
$ git checkout v0.2.0 -b ref-v0.2.0
fatal: Cannot update paths and switch to branch 'ref-v0.2.0' at the same time.
Did you intend to checkout 'v0.2.0' which can not be resolved as commit?
```
Separating the checkout into two lines fixes this issue.

Since kodi tells us either a git hash or a branch, this method works fine and is needed for when the branch jarvis addons anyways (which has already happened).