### PR TITLE
installer: Bump FAT partition size in line with disk image

### DIFF
--- a/packages/tools/installer/config/installer.conf
+++ b/packages/tools/installer/config/installer.conf
@@ -19,8 +19,8 @@
   DISKLABEL_SYSTEM="System"
   DISKLABEL_STORAGE="Storage"
 
-# Defaultsize of system partition (Cylinder: 16=132MB, 31=255MB)
-  PARTSIZE_SYSTEM="31"
+# Defaultsize of system partition (Cylinder: 16=132MB, 31=255MB, 66=517MiB)
+  PARTSIZE_SYSTEM="66"
 
 # additional parameters to extlinux
   EXTLINUX_PARAMETERS=""


### PR DESCRIPTION
Missed this.

http://openelec.tv/forum/120-news-announcements/79858-release-openelec-6-0-1?start=15#156707