### PR TITLE
Various package updates

### DIFF
--- a/packages/web/curl/package.mk
+++ b/packages/web/curl/package.mk
@@ -25,7 +25,7 @@
 #   there: http://forum.xbmc.org/showthread.php?tid=177557
 
 PKG_NAME="curl"
-PKG_VERSION="7.45.0"
+PKG_VERSION="7.47.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="MIT"

--- a/packages/x11/lib/pixman/package.mk
+++ b/packages/x11/lib/pixman/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pixman"
-PKG_VERSION="0.33.6"
+PKG_VERSION="0.34.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
~~libcec should be safe.~~ nevermind, needs p8-platform

Curl update might need some more testing then what I was able to provide.

pixman should also be safe.

Will look for other updates to include as well.