### PR TITLE
projects/WeTek_Play: Remove RTL drivers

### DIFF
--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -123,7 +123,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU"
+    ADDITIONAL_DRIVERS=""
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -117,7 +117,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU wetekdvb"
+    ADDITIONAL_DRIVERS="wetekdvb"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
WeTeK build fails with them and @stefansaraev confirmed that they are not needed. See https://github.com/OpenELEC/OpenELEC.tv/issues/4674