### PR TITLE
build: Take a lock on the package download directory

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -32,7 +32,7 @@ if [ -n "$PKG_URL" ]; then
 
   # Avoid concurrent downloads of the same package
   _isblocked=N
-  exec 99>$SOURCES/$1/.lock
+  exec 99<$SOURCES/$1
   while ! flock --nonblock --exclusive 99; do
     [ ${_isblocked} == N ] && { echo "Project ${PROJECT} waiting to avoid concurrent download of ${1}..."; _isblocked=Y; }
     sleep 1


### PR DESCRIPTION
This avoids dropping `.lock` files all over the `sources` directory which is a bit messy - now uses the directory itself as the lock resource (read access).