### PR TITLE
tbs-linux-drivers: update to tbs-linux-drivers-160126

### DIFF
--- a/packages/linux-drivers/tbs-linux-drivers/package.mk
+++ b/packages/linux-drivers/tbs-linux-drivers/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="tbs-linux-drivers"
-PKG_VERSION="151229"
+PKG_VERSION="160126"
 PKG_REV="1"
 PKG_ARCH="x86_64"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
- fix MMI not stable with CI slots on 6910 
- improve MAC address support for all boards currently in production 
- add support for TBS6290SE 
- improve TBS 6909 driver