### PR TITLE
dbus-glib: update dbus-glib version and package link

### DIFF
--- a/packages/devel/dbus-glib/package.mk
+++ b/packages/devel/dbus-glib/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="dbus-glib"
-PKG_VERSION="0.104"
+PKG_VERSION="0.106"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
-PKG_SITE="http://freedesktop.org/wiki/Software/dbus"
-PKG_URL="http://dbus.freedesktop.org/releases/dbus-glib/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_SITE="https://freedesktop.org/wiki/Software/dbus"
+PKG_URL="https://dbus.freedesktop.org/releases/dbus-glib/$PKG_NAME-$PKG_VERSION.tar.gz"
 PKG_DEPENDS_TARGET="toolchain dbus glib expat"
 PKG_PRIORITY="optional"
 PKG_SECTION="devel"


### PR DESCRIPTION
Updated to version 0.106 (CHANGELOG https://cgit.freedesktop.org/dbus/dbus-glib/tree/NEWS?id=dbus-glib-0.106)
Update package link, because http link don't work (linking to https site failed)

similar to #4686