### PR TITLE
config/addon/xbmc.python.module.xml: update to use xbmc.python.script

### DIFF
--- a/config/addon/xbmc.python.module.xml
+++ b/config/addon/xbmc.python.module.xml
@@ -8,6 +8,7 @@
     <import addon="xbmc.python" version="2.1.0"/>
 @REQUIRES@
   </requires>
+  <extension point="xbmc.python.script" library="default.py" />
   <extension point="xbmc.python.module" library="lib/">
   </extension>
   <extension point="xbmc.addon.metadata">


### PR DESCRIPTION
needed otherwise add-ons that use xbmc.python.module won't show up in the add-on manager

http://kodi.wiki/view/Addon.xml