### PR TITLE
pulseaudio: fix ltmain to not relink against host libs

### DIFF
--- a/packages/audio/pulseaudio/patches/pulseaudio-0900.03-dont_relink_against_host.patch
+++ b/packages/audio/pulseaudio/patches/pulseaudio-0900.03-dont_relink_against_host.patch
@@ -1,0 +1,13 @@
+diff --git a/build-aux/ltmain.sh b/build-aux/ltmain.sh
+index 63ae69d..cfde522 100644
+--- a/build-aux/ltmain.sh
++++ b/build-aux/ltmain.sh
+@@ -6918,7 +6918,7 @@ func_mode_link ()
+ 	      fi
+ 	    else
+ 	      # We cannot seem to hardcode it, guess we'll fake it.
+-	      add_dir="-L$libdir"
++	      #add_dir="-L$libdir"
+ 	      # Try looking first in the location we're being installed to.
+ 	      if test -n "$inst_prefix_dir"; then
+ 		case $libdir in


### PR DESCRIPTION
Otherwise, libtool will try to link against the system libvorbis (originating from the the libsndfile.la) during installation where libpulse.so gets relinked.
Running `libtoolize` alone to replace the provided `ltmain.sh` by the already patched one from libtool does not work and running a complete `autoreconf`produces a broken `configure`.