### PR TITLE
update packages

### DIFF
--- a/packages/audio/libopenmpt/package.mk
+++ b/packages/audio/libopenmpt/package.mk
@@ -17,12 +17,13 @@
 ################################################################################
 
 PKG_NAME="libopenmpt"
-PKG_VERSION="0.2.4764"
+PKG_VERSION="0.2.5787-beta16"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
 PKG_SITE="http://lib.openmpt.org/libopenmpt/"
-PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.gz"
+PKG_URL="http://lib.openmpt.org/files/libopenmpt/src/${PKG_NAME}-${PKG_VERSION}-autotools.tar.gz"
+PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION//-beta*/}-autotools"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="audio"
@@ -32,4 +33,7 @@ PKG_LONGDESC="libopenmpt renders mod music files as raw audio data, for playing 
 PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
-PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+PKG_CONFIGURE_OPTS_TARGET="--enable-static \
+			   --disable-shared \
+			   --without-portaudio \
+			   --without-portaudiocpp"

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="rtmpdump"
-PKG_VERSION="a107cef"
+PKG_VERSION="fa8646d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
referring to OpenELEC/OpenELEC.tv/issues/4526
- libopenmpt compiles but portaudio is now enforced (have to disable it through conf) - I have no idea how to check if this works runtime
- rtmpdump compiles (sources are uploaded)