### PR TITLE
libass: update to libass-0.13.1

### DIFF
--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -17,11 +17,11 @@
 ################################################################################
 
 PKG_NAME="libass"
-PKG_VERSION="0.13.0"
+PKG_VERSION="0.13.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"
-PKG_SITE="http://code.google.com/p/libass/"
+PKG_SITE="https://github.com/libass/libass"
 PKG_URL="https://github.com/libass/libass/releases/download/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain freetype fontconfig fribidi"
 PKG_PRIORITY="optional"
@@ -42,4 +42,3 @@ if [ $TARGET_ARCH = "x86_64" ]; then
   PKG_DEPENDS_TARGET="$PKG_DEPENDS_TARGET yasm:host"
   PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-asm"
 fi
-


### PR DESCRIPTION
- still leaks memory but at least up to date (OpenELEC/OpenELEC.tv/issues/4591)
- corrected site url