### PR TITLE
bcm_sta: add patches for bugs and 4.3+ kernels

### DIFF
--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0002-user_ioctl.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0002-user_ioctl.patch
@@ -1,0 +1,15 @@
+--- a/x86-64/src/wl/sys/wl_linux.c
++++ b/x86-64/src/wl/sys/wl_linux.c
+@@ -1659,11 +1659,7 @@
+ 	}
+ 
+ 	WL_LOCK(wl);
+-	if (!capable(CAP_NET_ADMIN)) {
+-		bcmerror = BCME_EPERM;
+-	} else {
+-		bcmerror = wlc_ioctl(wl->wlc, ioc.cmd, buf, ioc.len, wlif->wlcif);
+-	}
++	bcmerror = wlc_ioctl(wl->wlc, ioc.cmd, buf, ioc.len, wlif->wlcif);
+ 	WL_UNLOCK(wl);
+ 
+ done1:

--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0003-remove-date-time-macros.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0003-remove-date-time-macros.patch
@@ -1,0 +1,22 @@
+--- a/x86-64/src/wl/sys/wl_linux.c
++++ b/x86-64/src/wl/sys/wl_linux.c
+@@ -724,7 +724,7 @@ wl_attach(uint16 vendor, uint16 device,
+ 		WL_ALL_PASSIVE_ENAB(wl) ?  ", Passive Mode" : "", EPI_VERSION_STR);
+ 
+ #ifdef BCMDBG
+-	printf(" (Compiled in " SRCBASE " at " __TIME__ " on " __DATE__ ")");
++	printf(" (Compiled in " SRCBASE ")");
+ #endif 
+ 	printf("\n");
+ 
+@@ -2049,8 +2049,7 @@ wl_osl_pcie_rc(struct wl_info *wl, uint
+ void
+ wl_dump_ver(wl_info_t *wl, struct bcmstrbuf *b)
+ {
+-	bcm_bprintf(b, "wl%d: %s %s version %s\n", wl->pub->unit,
+-		__DATE__, __TIME__, EPI_VERSION_STR);
++	bcm_bprintf(b, "wl%d: version %s\n", wl->pub->unit, EPI_VERSION_STR);
+ }
+ 
+ #if defined(BCMDBG)
+

--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0004-null-pointer-crash.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0004-null-pointer-crash.patch
@@ -1,0 +1,11 @@
+--- a/x86-64/src/wl/sys/wl_linux.c
++++ b/x86-64/src/wl/sys/wl_linux.c
+@@ -2160,8 +2160,8 @@ wl_start(struct sk_buff *skb, struct net
+ 	wlif = WL_DEV_IF(dev);
+ 	wl = WL_INFO(dev);
+ 
++	skb->prev = NULL;
+ 	if (WL_ALL_PASSIVE_ENAB(wl) || (WL_RTR() && WL_CONFIG_SMP())) {
+-		skb->prev = NULL;
+ 
+ 		TXQ_LOCK(wl);

--- a/packages/linux-drivers/bcm_sta/patches/bcm_sta-0005-rdtscl.patch
+++ b/packages/linux-drivers/bcm_sta/patches/bcm_sta-0005-rdtscl.patch
@@ -1,0 +1,15 @@
+--- a/x86-64/src/shared/linux_osl.c	2015-09-19 01:47:15.000000000 +0300
++++ b/x86-64/src/shared/linux_osl.c	2015-11-21 15:20:30.585902518 +0200
+@@ -932,7 +932,11 @@
+ 	uint cycles;
+ 
+ #if defined(__i386__)
++#if LINUX_VERSION_CODE >= KERNEL_VERSION(4, 3, 0)
++	cycles = (u32)rdtsc();
++#else
+ 	rdtscl(cycles);
++#endif
+ #else
+ 	cycles = 0;
+ #endif
+


### PR DESCRIPTION
These are required for some driver bugs and changes in 4.3+ kernels. I've been using them with 32-bit builds for a while but have not build-tested them with a 64-bit build yet so please hold on merging until I confirm. Thanks.