### PR TITLE
glibc: Fix Generic build issue after #4723

### DIFF
--- a/packages/devel/glibc/package.mk
+++ b/packages/devel/glibc/package.mk
@@ -112,6 +112,7 @@ libc_cv_forced_unwind=yes
 libc_cv_c_cleanup=yes
 libc_cv_gnu89_inline=yes
 libc_cv_ssp=no
+libc_cv_ssp_strong=no
 libc_cv_ctors_header=yes
 libc_cv_slibdir=/lib
 EOF


### PR DESCRIPTION
I'd tested glibc 2.23 with RPi/RPi2 and no issues, but when building Generic it fails as follows:
```
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/bin/x86_64-openelec-linux-gnu-gcc -B/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/ -march=x86-64 -m64   -shared -static-libgcc -Wl,-O1  -Wl,-z,defs -Wl,-dynamic-linker=/lib/ld-linux-x86-64.so.2  -B/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/csu/  -Wl,--version-script=/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/libresolv.map -Wl,-soname=libresolv.so.2 -Wl,-z,combreloc -Wl,-z,relro -Wl,--hash-style=both  -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/math -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/elf -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/dlfcn -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nss -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nis -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/rt -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/crypt -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/mathvec -L/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nptl -Wl,-rpath-link=/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/math:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/elf:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/dlfcn:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nss:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nis:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/rt:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/crypt:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/mathvec:/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/nptl -o /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv.so -T /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/shlib.lds /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/csu/abi-note.o -Wl,--whole-archive /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv_pic.a -Wl,--no-whole-archive  -Wl,--start-group /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/libc.so /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/libc_nonshared.a -Wl,--as-needed /home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/elf/ld.so -Wl,--no-as-needed -Wl,--end-group
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv_pic.a(gethnamaddr.os): In function `addrsort':
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:959: undefined reference to `__stack_chk_guard'
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:996: undefined reference to `__stack_chk_guard'
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv_pic.a(gethnamaddr.os): In function `getanswer':
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:183: undefined reference to `__stack_chk_guard'
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:481: undefined reference to `__stack_chk_guard'
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv_pic.a(gethnamaddr.os): In function `__GI_res_gethostbyname2':
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:505: undefined reference to `__stack_chk_guard'
/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv_pic.a(gethnamaddr.os):/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/resolv/gethnamaddr.c:631: more undefined references to `__stack_chk_guard' follow
collect2: error: ld returned 1 exit status
../Makerules:517: recipe for target '/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv.so' failed
make[3]: *** [/home/neil/projects/OpenELEC.tv/build.OpenELEC-Generic.x86_64-7.0-devel/glibc-2.23/.x86_64-openelec-linux-gnu/resolv/libresolv.so] Error 1
```

This PR fixes the build issue. Does anyone have any concerns about this change before merging?