### PR TITLE
scripts/unpack: creates empty build-dir for packages without sources …

### DIFF
--- a/scripts/unpack
+++ b/scripts/unpack
@@ -94,6 +94,10 @@ if [ -d "$PKG_DIR/sources" ]; then
   cp -PRf $PKG_DIR/sources/* $BUILD/${PKG_NAME}-${PKG_VERSION}
 fi
 
+if [ -z "$PKG_URL" ]; then
+  mkdir -p "${BUILD}/${PKG_NAME}-${PKG_VERSION}"
+fi
+
 if [ "$(type -t post_unpack)" = "function" ]; then
   post_unpack
 fi


### PR DESCRIPTION
…so deepmd5 works
cherrypicked PR from issue #4749 for master branch