### PR TITLE
package updates

### DIFF
--- a/packages/graphics/mesa/package.mk
+++ b/packages/graphics/mesa/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="mesa"
-PKG_VERSION="11.1.2"
+PKG_VERSION="11.2.0-rc1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"
 PKG_SITE="http://www.mesa3d.org/"
-PKG_URL="ftp://freedesktop.org/pub/mesa/$PKG_VERSION/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="ftp://freedesktop.org/pub/mesa/11.2.0/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain Python:host expat glproto dri2proto presentproto libdrm libXext libXdamage libXfixes libXxf86vm libxcb libX11 systemd dri3proto libxshmfence"
 PKG_PRIORITY="optional"
 PKG_SECTION="graphics"

--- a/packages/lang/llvm/package.mk
+++ b/packages/lang/llvm/package.mk
@@ -17,13 +17,13 @@
 ################################################################################
 
 PKG_NAME="llvm"
-PKG_VERSION="3.7.1"
+PKG_VERSION="f65e46b"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
 PKG_SITE="http://llvm.org/"
-PKG_URL="http://llvm.org/releases/$PKG_VERSION/${PKG_NAME}-${PKG_VERSION}.src.tar.xz"
-PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION}.src"
+PKG_URL="$DISTRO_SRC/${PKG_NAME}-${PKG_VERSION}.tar.xz"
+#PKG_SOURCE_DIR="${PKG_NAME}-${PKG_VERSION}.src"
 PKG_DEPENDS_HOST=""
 PKG_DEPENDS_TARGET="toolchain llvm:host"
 PKG_PRIORITY="optional"

--- a/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.argustv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.argustv"
-PKG_VERSION="ff70fe4"
+PKG_VERSION="2aca01c"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.demo/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.demo"
-PKG_VERSION="d23fc13"
+PKG_VERSION="8673b1a"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvblink/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.dvblink"
-PKG_VERSION="dcec4c8"
+PKG_VERSION="9741e69"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.dvbviewer/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.dvbviewer"
-PKG_VERSION="5f32ad5"
+PKG_VERSION="2628660"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.filmon/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.filmon"
-PKG_VERSION="0135100"
+PKG_VERSION="e1e2101"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hdhomerun/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.hdhomerun"
-PKG_VERSION="a1bf18c"
+PKG_VERSION="456913e"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.hts/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.hts"
-PKG_VERSION="3274354"
+PKG_VERSION="3c673b5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.iptvsimple/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.iptvsimple"
-PKG_VERSION="567eeb3"
+PKG_VERSION="ae9bc1d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mediaportal.tvserver/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.mediaportal.tvserver"
-PKG_VERSION="58a3d3d"
+PKG_VERSION="9dd54a6"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.mythtv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.mythtv"
-PKG_VERSION="f278f65"
+PKG_VERSION="2e5a649"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.nextpvr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.nextpvr"
-PKG_VERSION="82462e7"
+PKG_VERSION="d82c0c5"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.njoy/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.njoy"
-PKG_VERSION="7342f9e"
+PKG_VERSION="480c159"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.pctv/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.pctv"
-PKG_VERSION="8ea856c"
+PKG_VERSION="0096770"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.stalker/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.stalker"
-PKG_VERSION="d54e932"
+PKG_VERSION="ffe2b49"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vbox/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vbox"
-PKG_VERSION="e7eaed5"
+PKG_VERSION="15e864d"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vdr.vnsi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vdr.vnsi"
-PKG_VERSION="927c49c"
+PKG_VERSION="7e11b85"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.vuplus/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.vuplus"
-PKG_VERSION="e7bc053"
+PKG_VERSION="815ea2f"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
+++ b/packages/mediacenter/kodi-binary-addons/pvr.wmc/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="pvr.wmc"
-PKG_VERSION="77923a0"
+PKG_VERSION="368de27"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi-theme-Confluence/package.mk
+++ b/packages/mediacenter/kodi-theme-Confluence/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi-theme-Confluence"
-PKG_VERSION="16.0-rc3-34d1e49"
+PKG_VERSION="16.0-a5f3a99"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi/package.mk
+++ b/packages/mediacenter/kodi/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="kodi"
-PKG_VERSION="16.0-rc3-34d1e49"
+PKG_VERSION="16.0-a5f3a99"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/mediacenter/kodi/patches/kodi-100.02-add-openelec.tv-RSS-news.patch
+++ b/packages/mediacenter/kodi/patches/kodi-100.02-add-openelec.tv-RSS-news.patch
@@ -1,14 +1,5 @@
-From a4a1922fee3c51f2005bc6d2738ab1a871319a4f Mon Sep 17 00:00:00 2001
-From: Stefan Saraev <stefan@saraev.ca>
-Date: Sat, 18 Apr 2015 15:23:51 +0300
-Subject: [PATCH 02/13] add openelec.tv RSS news
-
----
- userdata/RssFeeds.xml | 1 +
- 1 file changed, 1 insertion(+)
-
 diff --git a/userdata/RssFeeds.xml b/userdata/RssFeeds.xml
-index 6169113..631aafb 100644
+index 48b99e8..856bf1e 100644
 --- a/userdata/RssFeeds.xml
 +++ b/userdata/RssFeeds.xml
 @@ -3,6 +3,7 @@
@@ -16,9 +7,6 @@ index 6169113..631aafb 100644
    <!-- To use different sets in your skin, each must be called from skin with a unique id.             	!-->
    <set id="1">
 +    <feed updateinterval="30">http://feeds.openelec.tv/news</feed>
-     <feed updateinterval="30">http://feeds.xbmc.org/xbmc</feed>
-     <feed updateinterval="30">http://feeds.xbmc.org/latest_xbmc_addons</feed>
-     <feed updateinterval="30">http://feeds.xbmc.org/updated_xbmc_addons</feed>
--- 
-2.5.0
-
+     <feed updateinterval="30">http://feeds.kodi.tv/xbmc</feed>
+     <feed updateinterval="30">http://feeds.kodi.tv/latest_xbmc_addons</feed>
+     <feed updateinterval="30">http://feeds.kodi.tv/updated_xbmc_addons</feed>

--- a/packages/mediacenter/kodi/patches/kodi-999.01-fix-segfault.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.01-fix-segfault.patch
@@ -1,0 +1,69 @@
+From 7216c71bfd250f8c3f9fa82685ec635cf7be4b60 Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Sun, 21 Feb 2016 17:54:20 +0100
+Subject: [PATCH] vaapi: fix segfault
+
+---
+ xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp | 10 ++++++----
+ 1 file changed, 6 insertions(+), 4 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+index 19f05ca..540f914 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/VAAPI.cpp
+@@ -738,12 +738,14 @@ int CDecoder::FFGetBuffer(AVCodecContext *avctx, AVFrame *pic, int flags)
+ 
+ void CDecoder::FFReleaseBuffer(uint8_t *data)
+ {
+-  VASurfaceID surf;
++  {
++    VASurfaceID surf;
+ 
+-  CSingleLock lock(m_DecoderSection);
++    CSingleLock lock(m_DecoderSection);
+ 
+-  surf = (VASurfaceID)(uintptr_t)data;
+-  m_videoSurfaces.ClearReference(surf);
++    surf = (VASurfaceID)(uintptr_t)data;
++    m_videoSurfaces.ClearReference(surf);
++  }
+ 
+   IHardwareDecoder::Release();
+ }
+
+From eb7ccc54a4db746368191927c5b2fe77b4f678fe Mon Sep 17 00:00:00 2001
+From: Rainer Hochecker <fernetmenta@online.de>
+Date: Sun, 21 Feb 2016 18:00:24 +0100
+Subject: [PATCH] dxva2: fix segfault
+
+---
+ xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp | 14 ++++++++------
+ 1 file changed, 8 insertions(+), 6 deletions(-)
+
+diff --git a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+index 1fc5061..a340183 100644
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/DXVA.cpp
+@@ -1144,14 +1144,16 @@ bool CDecoder::Supports(enum PixelFormat fmt)
+ 
+ void CDecoder::RelBuffer(uint8_t *data)
+ {
+-  CSingleLock lock(m_section);
+-  ID3D11VideoDecoderOutputView* view = (ID3D11VideoDecoderOutputView*)(uintptr_t)data;
+-
+-  if (!m_surface_context->IsValid(view))
+   {
+-    CLog::Log(LOGWARNING, "%s - return of invalid surface", __FUNCTION__);
++    CSingleLock lock(m_section);
++    ID3D11VideoDecoderOutputView* view = (ID3D11VideoDecoderOutputView*)(uintptr_t)data;
++
++    if (!m_surface_context->IsValid(view))
++    {
++      CLog::Log(LOGWARNING, "%s - return of invalid surface", __FUNCTION__);
++    }
++    m_surface_context->ClearReference(view);
+   }
+-  m_surface_context->ClearReference(view);
+ 
+   IHardwareDecoder::Release();
+ }


### PR DESCRIPTION
llvm 3.8 hasn't been released yet, so I am temporarily updating to a git version, hopefully it is released any day now.

This updates kodi to latest Jarvis git. seems there is a segfault issue in 16.0 so 16.1rc1 has already been tagged.