### PR TITLE
Python: fix cross compile to exclude host directories

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -73,6 +73,11 @@ make_host() {
   make PYTHON_MODULES_INCLUDE="$HOST_INCDIR" \
        PYTHON_MODULES_LIB="$HOST_LIBDIR" \
        PYTHON_DISABLE_MODULES="$PY_DISABLED_MODULES"
+
+  sed -e "s|$ROOT/$TOOLCHAIN/include|$SYSROOT_PREFIX/usr/include|g" \
+      -e "s|$ROOT/$TOOLCHAIN/lib|$SYSROOT_PREFIX/usr/lib|g" \
+      -e "s|$ROOT/$TOOLCHAIN/bin/host-gcc|${TARGET_PREFIX}gcc|g" \
+      -i build/lib.linux-$(uname -m)-2.7/_sysconfigdata.py
 }
 
 makeinstall_host() {


### PR DESCRIPTION
Not the greatest fix but it works. I rebuilt entire OpenELEC to test this changes and it works. Tested with Generic and RPi2.

This fixes #4703 

sample building Pillow
```
building 'PIL._imagingmorph' extension
Building using 4 processes
/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/bin/x86_64-openelec-linux-gnu-gcc -DNDEBUG -O2 -Wall -pipe -I/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/include -Wno-format-security -march=x86-64 -m64 -fomit-frame-pointer -Wall -pipe -Os -fexcess-precision=fast -flto -ffat-lto-objects -mmmx -msse -msse2 -mfpmath=sse -fPIC -I/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/include/freetype2 -I/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/Pillow-3.1.0/libImaging -I/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/include -I/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/include/python2.7 -c _imagingmorph.c -o build/temp.linux-x86_64-2.7/_imagingmorph.o

/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/bin/x86_64-openelec-linux-gnu-gcc -shared -march=x86-64 -m64 -s -Wl,--as-needed -fuse-ld=gold -fuse-linker-plugin -flto -march=x86-64 -m64 -fomit-frame-pointer -Wall -pipe -Os -fexcess-precision=fast -flto -ffat-lto-objects -mmmx -msse -msse2 -mfpmath=sse build/temp.linux-x86_64-2.7/_imagingmorph.o -L/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/lib -L/home/lrusak/official/build.OpenELEC-Generic.x86_64-7.0-devel/toolchain/x86_64-openelec-linux-gnu/sysroot/usr/lib -lpython2.7 -o build/lib.linux-x86_64-2.7/PIL/_imagingmorph.so
```