### PR TITLE
eventlircd: add rule for WeTek_Core power button

### DIFF
--- a/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
+++ b/packages/sysutils/eventlircd/udev.d/98-eventlircd.rules
@@ -64,8 +64,13 @@ SUBSYSTEMS=="acpi", ATTRS{hid}=="LNXPWRBN", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap"
 
-# WeTek Play keyboard (power button)
+# WeTek Play (power button)
 SUBSYSTEMS=="input", ATTRS{name}=="key_input", \
+  ENV{eventlircd_enable}="true", \
+  ENV{eventlircd_evmap}="default.evmap"
+
+# WeTek Core (power button)
+SUBSYSTEMS=="input", ATTRS{name}=="gpio_keypad", \
   ENV{eventlircd_enable}="true", \
   ENV{eventlircd_evmap}="default.evmap"
 


### PR DESCRIPTION
This makes the power button actually power off the device.