### PR TITLE
Package updates

### DIFF
--- a/packages/lang/Python/package.mk
+++ b/packages/lang/Python/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="Python"
-PKG_VERSION="2.7.10"
+PKG_VERSION="2.7.11"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"

--- a/packages/python/system/simplejson/package.mk
+++ b/packages/python/system/simplejson/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="simplejson"
-PKG_VERSION="3.8.1"
+PKG_VERSION="3.8.2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
[Python 2.7.11](https://hg.python.org/cpython/raw-file/53d30ab403f1/Misc/NEWS) works fine with the current patches and the pending fix #4754 

[simplejson 3.8.2](https://github.com/simplejson/simplejson/blob/master/CHANGES.txt#L1-L8) Fix implicit cast compiler warning in _speedups.c