### PR TITLE
Package updates

### DIFF
--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libinput"
-PKG_VERSION="1.1.8"
+PKG_VERSION="1.2.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"
@@ -37,4 +37,5 @@ PKG_CONFIGURE_OPTS_TARGET="--with-sysroot=$SYSROOT_PREFIX \
                            --disable-static \
                            --disable-documentation \
                            --disable-event-gui \
-                           --disable-tests"
+                           --disable-tests \
+                           --disable-libwacom"

--- a/packages/x11/app/xrandr/package.mk
+++ b/packages/x11/app/xrandr/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xrandr"
-PKG_VERSION="1.4.3"
+PKG_VERSION="1.5.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OSS"


### PR DESCRIPTION
[libinput 1.2.0](https://lists.freedesktop.org/archives/wayland-devel/2016-February/027172.html)
[xrandr 1.5.0](https://lists.x.org/archives/xorg-announce/2016-February/002677.html)
- This release adds support for the new monitor objects added in RandR 1.5, and
fixes a few bugs.