### PR TITLE
Create linux_010_disable_hid-sony_size_check.patch to resolve issues with new DS4 controllers until kernel 4.5

### DIFF
--- a/packages/linux/patches/linux_010_disable_hid-sony_size_check.patch
+++ b/packages/linux/patches/linux_010_disable_hid-sony_size_check.patch
@@ -1,0 +1,18 @@
+diff --git a/drivers/hid/hid-sony.c b/drivers/hid/hid-sony.c
+index 1041c44..876ea2b 100644
+--- a/drivers/hid/hid-sony.c
++++ b/drivers/hid/hid-sony.c
+@@ -1139,11 +1139,11 @@ static __u8 *sony_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	 * the gyroscope values to corresponding axes so we need a
+ 	 * modified one.
+ 	 */
+-	if ((sc->quirks & DUALSHOCK4_CONTROLLER_USB) && *rsize == 467) {
++	if (sc->quirks & DUALSHOCK4_CONTROLLER_USB) {
+ 		hid_info(hdev, "Using modified Dualshock 4 report descriptor with gyroscope axes\n");
+ 		rdesc = dualshock4_usb_rdesc;
+ 		*rsize = sizeof(dualshock4_usb_rdesc);
+-	} else if ((sc->quirks & DUALSHOCK4_CONTROLLER_BT) && *rsize == 357) {
++	} else if (sc->quirks & DUALSHOCK4_CONTROLLER_BT) {
+ 		hid_info(hdev, "Using modified Dualshock 4 Bluetooth report descriptor\n");
+ 		rdesc = dualshock4_bt_rdesc;
+ 		*rsize = sizeof(dualshock4_bt_rdesc);


### PR DESCRIPTION
Attempting to fix non-funcitoning of new Sony DS4 controllers in the 4.4 kernel by backporting upstream 4.5 mainline patch (https://git.kernel.org/cgit/linux/kernel/git/jikos/hid.git/commit/?h=for-4.5/sony&id=b71b5578a84d297954e4812ba0ca2d466e61cf42)

This enables one of these new-firmware controllers to connect and send input on current trunk builds. Tested with a fresh trunk build on a MinnowBoard MAX. Controller connects and sends input events (though keymap is wonkified).