### PR TITLE
Resolve issue with Sony DualShock 4 controllers by backporting linux 4.5 patch

### DIFF
--- a/packages/linux/patches/linux_010_disable_hid-sony_size_check.patch
+++ b/packages/linux/patches/linux_010_disable_hid-sony_size_check.patch
@@ -1,0 +1,18 @@
+diff --git a/drivers/hid/hid-sony.c b/drivers/hid/hid-sony.c
+index 1041c44..876ea2b 100644
+--- a/drivers/hid/hid-sony.c
++++ b/drivers/hid/hid-sony.c
+@@ -1139,11 +1139,11 @@ static __u8 *sony_report_fixup(struct hid_device *hdev, __u8 *rdesc,
+ 	 * the gyroscope values to corresponding axes so we need a
+ 	 * modified one.
+ 	 */
+-	if ((sc->quirks & DUALSHOCK4_CONTROLLER_USB) && *rsize == 467) {
++	if (sc->quirks & DUALSHOCK4_CONTROLLER_USB) {
+ 		hid_info(hdev, "Using modified Dualshock 4 report descriptor with gyroscope axes\n");
+ 		rdesc = dualshock4_usb_rdesc;
+ 		*rsize = sizeof(dualshock4_usb_rdesc);
+-	} else if ((sc->quirks & DUALSHOCK4_CONTROLLER_BT) && *rsize == 357) {
++	} else if (sc->quirks & DUALSHOCK4_CONTROLLER_BT) {
+ 		hid_info(hdev, "Using modified Dualshock 4 Bluetooth report descriptor\n");
+ 		rdesc = dualshock4_bt_rdesc;
+ 		*rsize = sizeof(dualshock4_bt_rdesc);


### PR DESCRIPTION
Attempting to fix non-functioning of new-firmware Sony DualShock 4 controllers by backporting Jiri Kosina's patch to the current build of openelec (patch here https://git.kernel.org/cgit/linux/kernel/git/jikos/hid.git/commit/?h=for-4.5/sony&id=b71b5578a84d297954e4812ba0ca2d466e61cf42)

Frankly the change is so small I can't see it possibly breaking anything. This will be able to be tossed once we move to kernel 4.5 (because it'll be permanently integrated upstream).

This is tested and works on a current trunk build on a Minnowboard Max. It connects and sends input via bluetooth (although the keymap needs some effort, I haven't had time to resolve that issue yet)