### PR TITLE
Update Amlogic kernel to 3.10-ca65e57 (3.10.97)

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20151215"
+PKG_VERSION="20160223"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -31,7 +31,7 @@ PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 case "$LINUX" in
   amlogic)
-    PKG_VERSION="amlogic-3.10-716f179"
+    PKG_VERSION="amlogic-3.10-ca65e57"
     PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
     ;;
   imx6)


### PR DESCRIPTION
* Update Amlogic kernel to 3.10-ca65e57 (3.10.97)
* Update WeTek proprietary DVB binary driver to match the kernel
