### PR TITLE
Add all mtools during host install step.

### DIFF
--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -36,5 +36,5 @@ makeinstall_host() {
   $STRIP mtools
 
   mkdir -p $ROOT/$TOOLCHAIN/sbin
-  cp -P mtools mformat mcopy mmd $ROOT/$TOOLCHAIN/sbin
+  find . -type l -exec cp -P \{\} $ROOT/$TOOLCHAIN/sbin \;
 }

--- a/packages/tools/mtools/package.mk
+++ b/packages/tools/mtools/package.mk
@@ -29,12 +29,4 @@ PKG_SECTION="tools"
 PKG_SHORTDESC="mtools: A collection of utilities to access MS-DOS disks"
 PKG_LONGDESC="mtools: A collection of utilities to access MS-DOS disks"
 PKG_IS_ADDON="no"
-PKG_AUTORECONF="no"
 PKG_AUTORECONF="yes"
-
-makeinstall_host() {
-  $STRIP mtools
-
-  mkdir -p $ROOT/$TOOLCHAIN/sbin
-  find . -type l -exec cp -P \{\} $ROOT/$TOOLCHAIN/sbin \;
-}


### PR DESCRIPTION
Add all mtools during host install step.
Especially mattrib which is used by syslinux.mtools during make image

When absent, this error is observed:
make image

> image: installing extlinux to part1...
> sh: mattrib: command not found
> syslinux.mtools: warning: failed to set system bit on ldlinux.sys
> sh: mattrib: command not found
> syslinux.mtools: warning: failed to set system bit on ldlinux.c32
> image: copying files to part1...