### PR TITLE
add generic aarch64 support

### DIFF
--- a/config/arch.aarch64
+++ b/config/arch.aarch64
@@ -1,0 +1,43 @@
+# determines TARGET_CPU, if not forced by user
+  if [ -z "$TARGET_CPU" ]; then
+    TARGET_CPU=cortex-a53
+  fi
+
+# TARGET_CPU:
+# arm2 arm250 arm3 arm6 arm60 arm600 arm610 arm620 arm7 arm7m arm7d
+# arm7dm arm7di arm7dmi arm70 arm700 arm700i arm710 arm710c arm7100
+# arm720 arm7500 arm7500fe arm7tdmi arm7tdmi-s arm710t arm720t
+# arm740t strongarm strongarm110 strongarm1100 strongarm1110 arm8
+# arm810 arm9 arm9e arm920 arm920t arm922t arm946e-s arm966e-s
+# arm968e-s arm926ej-s arm940t arm9tdmi arm10tdmi arm1020t
+# arm1026ej-s arm10e arm1020e arm1022e arm1136j-s arm1136jf-s
+# mpcore mpcorenovfp arm1156t2-s arm1156t2f-s arm1176jz-s
+# arm1176jzf-s generic-armv7-a cortex-a5 cortex-a7 cortex-a8
+# cortex-a9 cortex-a12 cortex-a15 cortex-a17 cortex-a53
+# cortex-a57 cortex-a72 cortex-r4 cortex-r4f cortex-r5 cortex-r7
+# cortex-m7 cortex-m4 cortex-m3 cortex-m1 cortex-m0 cortex-m0plus
+# cortex-m1.small-multiply cortex-m0.small-multiply
+# cortex-m0plus.small-multiply exynos-m1 qdf24xx marvell-pj4
+# xscale iwmmxt iwmmxt2 ep9312 fa526 fa626 fa606te fa626te fmp626
+# fa726te xgene1 cortex-a15.cortex-a7 cortex-a17.cortex-a7
+# cortex-a57.cortex-a53 cortex-a72.cortex-a53
+
+# determine architecture's family
+  case $TARGET_CPU in
+    cortex-a53)
+      TARGET_SUBARCH=aarch64
+      TARGET_VARIANT=armv8-a
+      TARGET_ABI=eabi
+      TARGET_CPU_FLAGS="+crc+crypto"
+      TARGET_EXTRA_FLAGS="-mcpu=${TARGET_CPU}${TARGET_CPU_FLAGS}"
+      SIMD_SUPPORT="yes"
+      ;;
+  esac
+
+  TARGET_GCC_ARCH=$(echo $TARGET_SUBARCH | sed -e "s,-,,")
+  TARGET_KERNEL_ARCH=arm64
+
+# setup ARCH specific *FLAGS
+  TARGET_CFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mabi=lp64 -Wno-psabi $TARGET_EXTRA_FLAGS"
+  TARGET_LDFLAGS="-march=${TARGET_VARIANT}${TARGET_CPU_FLAGS} -mtune=$TARGET_CPU"
+  GCC_OPTS="--with-abi=lp64 --with-arch=$TARGET_VARIANT"

--- a/packages/mediacenter/kodi/patches/kodi-999.10-aarch64-support.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.10-aarch64-support.patch
@@ -1,0 +1,159 @@
+From ae4e63aa165583ef5eaab4759e7af24eeffbb197 Mon Sep 17 00:00:00 2001
+From: croniccorey <cronmod.dev@gmail.com>
+Date: Sun, 13 Dec 2015 16:37:05 -0500
+Subject: [PATCH] KODI: Add support for aarch64 platform
+
+---
+ addons/library.xbmc.addon/libXBMC_addon.h   |  2 ++
+ configure.ac                                | 12 ++++++++++++
+ m4/xbmc_arch.m4                             |  2 +-
+ xbmc/cores/DllLoader/DllLoader.h            |  2 +-
+ xbmc/cores/DllLoader/ldt_keeper.c           |  2 +-
+ xbmc/cores/VideoRenderers/LinuxRendererGL.h |  2 +-
+ xbmc/linux/PlatformDefs.h                   |  2 +-
+ xbmc/threads/Atomics.cpp                    |  2 +-
+ xbmc/utils/CPUInfo.cpp                      |  2 +-
+ xbmc/utils/MathUtils.h                      |  3 ++-
+ 10 files changed, 23 insertions(+), 8 deletions(-)
+
+diff --git a/addons/library.xbmc.addon/libXBMC_addon.h b/addons/library.xbmc.addon/libXBMC_addon.h
+index c3ed54f..76190b6 100644
+--- a/addons/library.xbmc.addon/libXBMC_addon.h
++++ b/addons/library.xbmc.addon/libXBMC_addon.h
+@@ -55,6 +55,8 @@ typedef intptr_t      ssize_t;
+ #define ADDON_HELPER_ARCH       "powerpc64-linux"
+ #elif defined(__ARMEL__)
+ #define ADDON_HELPER_ARCH       "arm"
++#elif defined(__aarch64__)
++#define ADDON_HELPER_ARCH       "aarch64"
+ #elif defined(__mips__)
+ #define ADDON_HELPER_ARCH       "mips"
+ #else
+diff --git a/configure.ac b/configure.ac
+index c767357..80f3807 100644
+--- a/configure.ac
++++ b/configure.ac
+@@ -691,6 +691,18 @@ case $host in
+      use_wayland=no
+      USE_STATIC_FFMPEG=1
+      ;;
++  aarch64*-*-linux-gnu*)
++     target_platform=target_linux
++     ARCH="aarch64"
++     use_arch="aarch64"
++     use_cpu=cortex-a53
++     use_joystick=no
++     use_neon=yes
++     use_gles=yes
++     use_gl=no
++     use_wayland=no
++     USE_STATIC_FFMPEG=1
++     ;;
+   arm*-*linux-android*)
+      target_platform=target_android
+      use_arch="arm"
+diff --git a/m4/xbmc_arch.m4 b/m4/xbmc_arch.m4
+index 0b66a82..fa08537 100644
+--- a/m4/xbmc_arch.m4
++++ b/m4/xbmc_arch.m4
+@@ -60,7 +60,7 @@ case $host in
+   powerpc64-*-linux-gnu*|powerpc64-*-linux-uclibc*)
+      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX -D_POWERPC64")
+      ;;
+-  arm*-*-linux-gnu*|arm*-*-linux-uclibc*)
++  arm*-*-linux-gnu*|arm*-*-linux-uclibc*|aarch64*-*-linux-gnu*)
+      AC_SUBST(ARCH_DEFINES, "-DTARGET_POSIX -DTARGET_LINUX -D_LINUX")
+      ;;
+   mips*-*-linux-gnu*|mips*-*-linux-uclibc*)
+diff --git a/xbmc/cores/DllLoader/DllLoader.h b/xbmc/cores/DllLoader/DllLoader.h
+index 070aee6..e669203 100644
+--- a/xbmc/cores/DllLoader/DllLoader.h
++++ b/xbmc/cores/DllLoader/DllLoader.h
+@@ -23,7 +23,7 @@
+ #include "coffldr.h"
+ #include "LibraryLoader.h"
+ 
+-#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__)
++#if defined(__linux__) && !defined(__powerpc__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
+ #define USE_LDT_KEEPER
+ #include "ldt_keeper.h"
+ #endif
+diff --git a/xbmc/cores/DllLoader/ldt_keeper.c b/xbmc/cores/DllLoader/ldt_keeper.c
+index 8af9a86..1c0cdb2 100644
+--- a/xbmc/cores/DllLoader/ldt_keeper.c
++++ b/xbmc/cores/DllLoader/ldt_keeper.c
+@@ -19,7 +19,7 @@
+  */
+ 
+ //#ifndef __powerpc__
+-#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__mips__)
++#if !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
+ 
+ #include "ldt_keeper.h"
+ 
+diff --git a/xbmc/cores/VideoRenderers/LinuxRendererGL.h b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+index fcdea8d..5a3e3df 100644
+--- a/xbmc/cores/VideoRenderers/LinuxRendererGL.h
++++ b/xbmc/cores/VideoRenderers/LinuxRendererGL.h
+@@ -323,7 +323,7 @@ class CLinuxRendererGL : public CBaseRenderer
+ 
+ 
+ inline int NP2( unsigned x ) {
+-#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__mips__)
++#if defined(TARGET_POSIX) && !defined(__POWERPC__) && !defined(__PPC__) && !defined(__arm__) && !defined(__mips__) && !defined(__aarch64__)
+   // If there are any issues compiling this, just append a ' && 0'
+   // to the above to make it '#if defined(TARGET_POSIX) && 0'
+ 
+diff --git a/xbmc/linux/PlatformDefs.h b/xbmc/linux/PlatformDefs.h
+index 4350075..2c6fff4 100644
+--- a/xbmc/linux/PlatformDefs.h
++++ b/xbmc/linux/PlatformDefs.h
+@@ -161,7 +161,7 @@
+ #define __int64   long long
+ #define __uint64  unsigned long long
+ 
+-#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined(__mips__) // should this be powerpc64 only?
++#if defined(__x86_64__) || defined(__powerpc__) || defined(__ppc__) || defined (__arm__) || defined(__mips__) || defined(__aarch64__)
+ #define __stdcall
+ #else /* !__x86_64__ */
+ #define __stdcall   __attribute__((__stdcall__))
+diff --git a/xbmc/threads/Atomics.cpp b/xbmc/threads/Atomics.cpp
+index 417b2b6..c172867 100644
+--- a/xbmc/threads/Atomics.cpp
++++ b/xbmc/threads/Atomics.cpp
+@@ -106,7 +106,7 @@ long cas(volatile long *pAddr, long expectedVal, long swapVal)
+ ///////////////////////////////////////////////////////////////////////////
+ long long cas2(volatile long long* pAddr, long long expectedVal, long long swapVal)
+ {
+-#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__)// PowerPC and ARM
++#if defined(__ppc__) || defined(__powerpc__) || defined(__arm__) || defined(__aarch64__) // PowerPC and ARM
+ // Not available/required
+ // Hack to allow compilation
+   throw "cas2 is not implemented";
+diff --git a/xbmc/utils/CPUInfo.cpp b/xbmc/utils/CPUInfo.cpp
+index 9e709e7..d7fef37 100644
+--- a/xbmc/utils/CPUInfo.cpp
++++ b/xbmc/utils/CPUInfo.cpp
+@@ -914,7 +914,7 @@ void CCPUInfo::ReadCPUFeatures()
+   #endif
+ #elif defined(LINUX)
+ // empty on purpose, the implementation is in the constructor
+-#elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__)
++#elif !defined(__powerpc__) && !defined(__ppc__) && !defined(__arm__) && !defined(__aarch64__)
+   m_cpuFeatures |= CPU_FEATURE_MMX;
+ #elif defined(__powerpc__) || defined(__ppc__)
+   m_cpuFeatures |= CPU_FEATURE_ALTIVEC;
+diff --git a/xbmc/utils/MathUtils.h b/xbmc/utils/MathUtils.h
+index 08140b7..249b4dd 100644
+--- a/xbmc/utils/MathUtils.h
++++ b/xbmc/utils/MathUtils.h
+@@ -35,7 +35,8 @@
+ #if defined(__ppc__) || \
+     defined(__powerpc__) || \
+     defined(__mips__) || \
+-    defined(__arm__)
++    defined(__arm__) || \
++    defined(__aarch64__)
+   #define DISABLE_MATHUTILS_ASM_ROUND_INT
+ #endif
+ 

--- a/packages/mediacenter/kodi/patches/kodi-999.11-fix-aarch64-compile.patch
+++ b/packages/mediacenter/kodi/patches/kodi-999.11-fix-aarch64-compile.patch
@@ -1,0 +1,24 @@
+diff -Naur a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp
+--- a/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp	2016-02-02 23:09:39.000000000 +0100
++++ b/xbmc/cores/dvdplayer/DVDCodecs/Video/AMLCodec.cpp	2016-02-10 07:01:28.941399058 +0100
+@@ -1598,7 +1598,7 @@
+         am_private->gcodec.param = (void*)(EXTERNAL_PTS | SYNC_OUTSIDE);
+       break;
+   }
+-  am_private->gcodec.param = (void *)((unsigned int)am_private->gcodec.param | (am_private->video_rotation_degree << 16));
++  am_private->gcodec.param = (void *)((unsigned long)am_private->gcodec.param | (am_private->video_rotation_degree << 16));
+ 
+   // translate from generic to firemware version dependent
+   m_dll->codec_init_para(&am_private->gcodec, &am_private->vcodec);
+diff -Naur a/xbmc/guilib/GUIFontTTFGL.cpp b/xbmc/guilib/GUIFontTTFGL.cpp
+--- a/xbmc/guilib/GUIFontTTFGL.cpp	2016-02-02 23:09:39.000000000 +0100
++++ b/xbmc/guilib/GUIFontTTFGL.cpp	2016-02-10 06:59:49.261293006 +0100
+@@ -232,7 +232,7 @@
+       glUniformMatrix4fv(modelLoc, 1, GL_FALSE, glMatrixModview.Get());
+ 
+       // Bind the buffer to the OpenGL context's GL_ARRAY_BUFFER binding point
+-      glBindBuffer(GL_ARRAY_BUFFER, (GLuint) m_vertexTrans[i].vertexBuffer->bufferHandle);
++      glBindBuffer(GL_ARRAY_BUFFER, (unsigned long) m_vertexTrans[i].vertexBuffer->bufferHandle);
+ 
+       // Do the actual drawing operation, split into groups of characters no
+       // larger than the pre-determined size of the element array

--- a/packages/sysutils/fuse/patches/fuse-0001_aarch64-support.patch
+++ b/packages/sysutils/fuse/patches/fuse-0001_aarch64-support.patch
@@ -1,0 +1,33 @@
+fuse: add aarch64 support
+
+u64/u32 is not defined in sys/types.h, include linux/types.h like
+the kernel version of fuse.h does. Patch sent to upstream mailing list.
+
+Upstream-Status: Submitted
+Signed-off-by: Riku Voipio <riku.voipio@linaro.org>
+Signed-off-by: Hongxu Jia <hongxu.jia@windriver.com>
+---
+ include/fuse_kernel.h | 7 +------
+ 1 file changed, 1 insertion(+), 6 deletions(-)
+
+diff --git a/include/fuse_kernel.h b/include/fuse_kernel.h
+index c632b58..e804278 100644
+--- a/include/fuse_kernel.h
++++ b/include/fuse_kernel.h
+@@ -88,12 +88,7 @@
+ #ifndef _LINUX_FUSE_H
+ #define _LINUX_FUSE_H
+ 
+-#include <sys/types.h>
+-#define __u64 uint64_t
+-#define __s64 int64_t
+-#define __u32 uint32_t
+-#define __s32 int32_t
+-#define __u16 uint16_t
++#include <linux/types.h>
+ 
+ /*
+  * Version negotiation:
+-- 
+1.8.1.2
+


### PR DESCRIPTION
This should get most of the relevant packages to build for aarch64 and will be helpful when to upstream this while I work on the Odroid C2

I have some other amlogic specific aarch64 patches in another branch.

@sraue take a look at the config/arch.arm64 file and see if you are ok with this.

Not sure if the `TARGET_CPU_FLAGS="+crc+crypto"` line is really needed but it did no harm for me while building.
https://gcc.gnu.org/onlinedocs/gcc/AArch64-Options.html

maybe @codesnake can have a look too.