### PR TITLE
Include all default additional drivers into WeTek Play and WeTek Core projects

### DIFF
--- a/projects/WeTek_Core/linux/linux.arm.conf
+++ b/projects/WeTek_Core/linux/linux.arm.conf
@@ -1,6 +1,6 @@
 #
 # Automatically generated file; DO NOT EDIT.
-# Linux/arm 3.10.94 Kernel Configuration
+# Linux/arm 3.10.97 Kernel Configuration
 #
 CONFIG_ARM=y
 CONFIG_SYS_SUPPORTS_APM_EMULATION=y
@@ -3574,8 +3574,7 @@ CONFIG_STACKTRACE=y
 # CONFIG_DEBUG_KOBJECT is not set
 # CONFIG_DEBUG_HIGHMEM is not set
 CONFIG_DEBUG_BUGVERBOSE=y
-CONFIG_DEBUG_INFO=y
-# CONFIG_DEBUG_INFO_REDUCED is not set
+# CONFIG_DEBUG_INFO is not set
 # CONFIG_DEBUG_VM is not set
 # CONFIG_DEBUG_WRITECOUNT is not set
 # CONFIG_DEBUG_MEMORY_INIT is not set

--- a/projects/WeTek_Core/options
+++ b/projects/WeTek_Core/options
@@ -123,7 +123,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,

--- a/projects/WeTek_Play/options
+++ b/projects/WeTek_Play/options
@@ -117,7 +117,7 @@
   # for a list of additinoal drivers see packages/linux-drivers
   # Space separated list is supported,
   # e.g. ADDITIONAL_DRIVERS="DRIVER1 DRIVER2"
-    ADDITIONAL_DRIVERS="RTL8192CU RTL8192DU RTL8188EU wetekdvb"
+    ADDITIONAL_DRIVERS="$ADDITIONAL_DRIVERS wetekdvb"
 
   # additional Firmware to use (dvb-firmware, misc-firmware, wlan-firmware)
   # Space separated list is supported,


### PR DESCRIPTION
Recent change in Amlogic kernel (https://github.com/codesnake/linux/commit/df3f50edddfe8cd512470f98bd35d5a7624e435a) now allows to build all default additional drivers without errors. So include them all into WeTek projects.