### PR TITLE
WeTek_Play: fix external audio cards

### DIFF
--- a/projects/WeTek_Play/patches/kodi/1000-dont-force-default-alsa-output.patch
+++ b/projects/WeTek_Play/patches/kodi/1000-dont-force-default-alsa-output.patch
@@ -1,0 +1,12 @@
+diff --git a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+index e22db7a..74da7e8 100644
+--- a/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
++++ b/xbmc/cores/AudioEngine/Sinks/AESinkALSA.cpp
+@@ -527,7 +527,6 @@ bool CAESinkALSA::Initialize(AEAudioFormat &format, std::string &device)
+   if (aml_present())
+   {
+     aml_set_audio_passthrough(m_passthrough);
+-    device = "default";
+   }
+ #endif
+ 


### PR DESCRIPTION
Now that we enumerate SoC output as IEC958, we don't have to force default ALSA output. This allows to use external USB audio cards.