### PR TITLE
Package updates

### DIFF
--- a/packages/debug/gdb/package.mk
+++ b/packages/debug/gdb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="gdb"
-PKG_VERSION="7.10.1"
+PKG_VERSION="7.11"
 PKG_REV="2"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/multimedia/libass/package.mk
+++ b/packages/multimedia/libass/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libass"
-PKG_VERSION="0.13.1"
+PKG_VERSION="0.13.2"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="BSD"

--- a/packages/network/libssh/package.mk
+++ b/packages/network/libssh/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libssh"
-PKG_VERSION="0.7.2"
+PKG_VERSION="0.7.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="OpenSource"
 PKG_SITE="http://www.libssh.org/"
-PKG_URL="https://red.libssh.org/attachments/download/177/$PKG_NAME-$PKG_VERSION.tar.xz"
+PKG_URL="https://red.libssh.org/attachments/download/195/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain zlib libressl"
 PKG_PRIORITY="optional"
 PKG_SECTION="network"

--- a/packages/tools/nano/package.mk
+++ b/packages/tools/nano/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="nano"
-PKG_VERSION="2.5.2"
+PKG_VERSION="2.5.3"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/wayland/libinput/package.mk
+++ b/packages/wayland/libinput/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="libinput"
-PKG_VERSION="1.2.0"
+PKG_VERSION="1.2.1"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"

--- a/packages/x11/driver/xf86-input-libinput/package.mk
+++ b/packages/x11/driver/xf86-input-libinput/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="xf86-input-libinput"
-PKG_VERSION="0.16.0"
+PKG_VERSION="0.17.0"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="GPL"


### PR DESCRIPTION
[libssh 0.7.3](https://www.libssh.org/2016/02/23/libssh-0-7-3-security-and-bugfix-release/)
[gdb 7.11](https://www.gnu.org/software/gdb/download/ANNOUNCEMENT)
[libass 0.13.2](https://github.com/libass/libass/blob/master/Changelog#L1-L8)
[nano 2.5.3](http://svn.savannah.gnu.org/viewvc/trunk/nano/ChangeLog?revision=5680&root=nano&view=markup)
[libinput 1.2.1](https://lists.freedesktop.org/archives/wayland-devel/2016-February/027237.html)
[xf86-input-libinput 0.17.0](https://cgit.freedesktop.org/xorg/driver/xf86-input-libinput/log/)