### PR TITLE
Update Amlogic kernel to 3.10-0f60813 (3.10.98)

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20160223"
+PKG_VERSION="20160304"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -31,7 +31,7 @@ PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 case "$LINUX" in
   amlogic)
-    PKG_VERSION="amlogic-3.10-ca65e57"
+    PKG_VERSION="amlogic-3.10-0f60813"
     PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
     ;;
   imx6)


### PR DESCRIPTION
* Update kernel to 3.10-0f60813 (3.10.98).
The updated kernel has 2 important fixes: https://github.com/codesnake/linux/commit/58ad7d59f5bc4a617e0ef5f001e5d90cccbe5e6e and https://github.com/codesnake/linux/commit/98d35a0d59fcfb4bacccc81dfabc84b78a3e97d4
* Update WeTek proprietary DVB module to 20160304.