### PR TITLE
libdvbcsa: improved version

### DIFF
--- a/packages/multimedia/libdvbcsa/package.mk
+++ b/packages/multimedia/libdvbcsa/package.mk
@@ -17,12 +17,12 @@
 ################################################################################
 
 PKG_NAME="libdvbcsa"
-PKG_VERSION="1.1.0"
+PKG_VERSION="f988715"
 PKG_REV="1"
 PKG_ARCH="any"
 PKG_LICENSE="LGPL"
-PKG_SITE="http://www.videolan.org/developers/libdvbcsa.html"
-PKG_URL="http://download.videolan.org/pub/videolan/libdvbcsa/${PKG_VERSION}/libdvbcsa-${PKG_VERSION}.tar.gz"
+PKG_SITE="https://github.com/glenvt18/libdvbcsa"
+PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
 PKG_DEPENDS_TARGET="toolchain"
 PKG_PRIORITY="optional"
 PKG_SECTION="lib"
@@ -33,3 +33,16 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static --with-sysroot=$SYSROOT_PREFIX"
+
+if echo "$TARGET_FPU" | grep -q '^neon'; then
+  PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-neon"
+elif [ "$TARGET_ARCH" = x86_64  ]; then
+  if echo "$PROJECT_CFLAGS" | grep -q '\-mssse3'; then
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-ssse3"
+  elif echo "$PROJECT_CFLAGS" | grep -q '\-msse2'; then
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-sse2"
+  else
+    PKG_CONFIGURE_OPTS_TARGET="$PKG_CONFIGURE_OPTS_TARGET --enable-uint64"
+  fi
+fi
+

--- a/tools/mkpkg/mkpkg_libdvbcsa
+++ b/tools/mkpkg/mkpkg_libdvbcsa
@@ -1,0 +1,46 @@
+#!/bin/sh
+################################################################################
+#      This file is part of OpenELEC - http://www.openelec.tv
+#      Copyright (C) 2009-2012 Stephan Raue (stephan@openelec.tv)
+#
+#  This Program is free software; you can redistribute it and/or modify
+#  it under the terms of the GNU General Public License as published by
+#  the Free Software Foundation; either version 2, or (at your option)
+#  any later version.
+#
+#  This Program is distributed in the hope that it will be useful,
+#  but WITHOUT ANY WARRANTY; without even the implied warranty of
+#  MERCHANTABILITY or FITNESS FOR A PARTICULAR PURPOSE. See the
+#  GNU General Public License for more details.
+#
+#  You should have received a copy of the GNU General Public License
+#  along with OpenELEC.tv; see the file COPYING.  If not, write to
+#  the Free Software Foundation, 51 Franklin Street, Suite 500, Boston, MA 02110, USA.
+#  http://www.gnu.org/copyleft/gpl.html
+################################################################################
+
+PKG_NAME="libdvbcsa"
+PKG_REPO="git://github.com/glenvt18/libdvbcsa.git"
+
+echo "getting sources..."
+  if [ ! -d $PKG_NAME.git ]; then
+    git clone $PKG_REPO $PKG_NAME.git
+  fi
+
+  cd $PKG_NAME.git
+    git pull
+    GIT_REV=`git log -n1 --format=%h`
+  cd ..
+
+echo "copying sources..."
+  rm -rf $PKG_NAME-$GIT_REV
+  cp -R $PKG_NAME.git $PKG_NAME-$GIT_REV
+
+echo "cleaning sources..."
+  rm -rf $PKG_NAME-$GIT_REV/.git
+
+echo "packing sources..."
+  tar cvJf $PKG_NAME-$GIT_REV.tar.xz $PKG_NAME-$GIT_REV
+
+echo "remove temporary sourcedir..."
+  rm -rf $PKG_NAME-$GIT_REV


### PR DESCRIPTION
Hi folks.
I've made a [version](https://github.com/glenvt18/libdvbcsa) of [libdvbcsa](http://www.videolan.org/developers/libdvbcsa.html) which is 2-3x faster than the original from videolan on both ARM and x86_64 platforms. Unfortunately, I couldn't get it merged upstream. But this version is well tested and maintained. If this is OK with you, you can merge this PR. I think this is better than keeping a batch of patches to the original. It would allow to process high bit rate TS streams on RPi2 and Atoms. There is also a AArch64/NEON dev [branch](https://github.com/glenvt18/libdvbcsa/commits/arm64) looking for testers.