### PR TITLE
gcc: Mark ARMv8 vcvt instructions as unconditional

### DIFF
--- a/packages/lang/gcc/patches/gcc-mark-armv8-vcvt-instructions-as-unconditional-69135.patch
+++ b/packages/lang/gcc/patches/gcc-mark-armv8-vcvt-instructions-as-unconditional-69135.patch
@@ -1,0 +1,81 @@
+commit 885cc3ea9e4ae1f95589a33eb811c4bebb0dc487
+Author: ktkachov <ktkachov@138bc75d-0d04-0410-961f-82ee72b054a4>
+Date:   Tue Jan 19 14:30:23 2016 +0000
+
+    [ARM] PR target/69135: Mark ARMv8 vcvt instructions as unconditional
+    
+    	PR target/69135
+    	* config/arm/vfp.md (l<vrint_pattern><su_optab><mode>si2): Set "conds"
+    	attribute to unconditional.  Remove %? from output template.
+    
+    	* gcc.target/arm/pr69135_1.c: New test.
+    
+    
+    
+    git-svn-id: svn+ssh://gcc.gnu.org/svn/gcc/trunk@232566 138bc75d-0d04-0410-961f-82ee72b054a4
+
+diff --git a/gcc/config/arm/vfp.md b/gcc/config/arm/vfp.md
+index cf3b202..ac5f3b8 100644
+--- a/gcc/config/arm/vfp.md
++++ b/gcc/config/arm/vfp.md
+@@ -1334,8 +1334,9 @@
+                         [(match_operand:SDF 1
+                            "register_operand" "<F_constraint>")] VCVT)))]
+   "TARGET_HARD_FLOAT && TARGET_FPU_ARMV8 <vfp_double_cond>"
+-  "vcvt<vrint_variant>%?.<su>32.<V_if_elem>\\t%0, %<V_reg>1"
++  "vcvt<vrint_variant>.<su>32.<V_if_elem>\\t%0, %<V_reg>1"
+   [(set_attr "predicable" "no")
++   (set_attr "conds" "unconditional")
+    (set_attr "type" "f_cvtf2i")]
+ )
+ 
+diff --git a/gcc/testsuite/gcc.target/arm/pr69135_1.c b/gcc/testsuite/gcc.target/arm/pr69135_1.c
+new file mode 100644
+index 0000000..6fb9e06
+--- /dev/null
++++ b/gcc/testsuite/gcc.target/arm/pr69135_1.c
+@@ -0,0 +1,44 @@
++/* { dg-do assemble } */
++/* { dg-require-effective-target arm_v8_vfp_ok } */
++/* { dg-require-effective-target arm_arch_v8a_ok } */
++/* { dg-options "-O2 -ffast-math" } */
++/* { dg-add-options arm_v8_vfp } */
++/* { dg-add-options arm_arch_v8a } */
++
++int global;
++
++void
++lceil_float (float x, int b)
++{
++  if (b) global = __builtin_lceilf (x);
++}
++
++void
++lceil_double (double x, int b)
++{
++  if (b) global = __builtin_lceil (x);
++}
++
++void
++lfloor_float (float x, int b)
++{
++  if (b) global =  __builtin_lfloorf (x);
++}
++
++void
++lfloor_double (double x, int b)
++{
++  if (b) global = __builtin_lfloor (x);
++}
++
++void
++lround_float (float x, int b)
++{
++  if (b) global = __builtin_lroundf (x);
++}
++
++void
++lround_double (double x, int b)
++{
++  if (b) global = __builtin_lround (x);
++}


### PR DESCRIPTION
When compiling for armv8, eg. `TARGET_SUBARCH=armv8-a+crc`, gcc 5.3.0 will incorrectly generate conditional instructions when compiling `alsa-lib` (specifically, `alisp`) and `libpulsecore`, eg.:

```
{standard input}: Assembler messages:
{standard input}:9597: Error: instruction cannot be conditional -- `vcvtmeq.s32.f64 s15,d16'
Makefile:375: recipe for target 'alisp.lo' failed
```

https://gcc.gnu.org/bugzilla/show_bug.cgi?id=69135
https://gcc.gnu.org/ml/gcc-bugs/2016-01/msg00139.html