### PR TITLE
Various $HOME/.openelec (vendor) fixes

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -55,7 +55,11 @@ setup_toolchain() {
 }
 
 kernel_path() {
-  if [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
+  if [ -e $HOME/.openelec/projects/$PROJECT/packages/linux/package.mk ]; then
+    . $HOME/.openelec/projects/$PROJECT/packages/linux/package.mk
+  elif [ -e $HOME/.openelec/packages/linux/package.mk ]; then
+    . $HOME/.openelec/packages/linux/package.mk
+  elif [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
     . $ROOT/projects/$PROJECT/packages/linux/package.mk
   else
     . $ROOT/packages/linux/package.mk
@@ -65,7 +69,11 @@ kernel_path() {
 }
 
 kernel_version() {
-  if [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
+  if [ -e $HOME/.openelec/projects/$PROJECT/packages/linux/package.mk ]; then
+    . $HOME/.openelec/projects/$PROJECT/packages/linux/package.mk
+  elif [ -e $HOME/.openelec/packages/linux/package.mk ]; then
+    . $HOME/.openelec/packages/linux/package.mk
+  elif [ -e $ROOT/projects/$PROJECT/packages/linux/package.mk ]; then
     . $ROOT/projects/$PROJECT/packages/linux/package.mk
   else
     . $ROOT/packages/linux/package.mk
@@ -82,13 +90,23 @@ get_module_dir() {
 # get package's build dir
 get_build_dir() {
   if [ ! -z $1 ] ; then
-    local _PKG_DIR=$(find $ROOT/projects/$PROJECT/packages -name $1 2>/dev/null)
+    local _PKG_DIR=$(find $HOME/.openelec/projects/$PROJECT/packages -name $1 2>/dev/null)
     if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
       . $_PKG_DIR/package.mk
     else
-      local _PKG_DIR=$(find $ROOT/packages -name $1 2>/dev/null)
+      local _PKG_DIR=$(find $HOME/.openelec/packages -name $1 2>/dev/null)
       if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
         . $_PKG_DIR/package.mk
+      else
+        local _PKG_DIR=$(find $ROOT/projects/$PROJECT/packages -name $1 2>/dev/null)
+        if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
+          . $_PKG_DIR/package.mk
+        else
+          local _PKG_DIR=$(find $ROOT/packages -name $1 2>/dev/null)
+          if [ -d "$_PKG_DIR" -a -f $_PKG_DIR/package.mk ] ; then
+            . $_PKG_DIR/package.mk
+          fi
+        fi
       fi
     fi
 

--- a/packages/tools/u-boot/release
+++ b/packages/tools/u-boot/release
@@ -31,5 +31,7 @@ mkdir -p $RELEASE_DIR/3rdparty/bootloader
   cp -PR $BUILD/u-boot-*/u-boot*.img $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
 
   cp -PR $PROJECT_DIR/$PROJECT/bootloader/uEnv*.txt $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
+  cp -PR $HOME/.openelec/bootloader/* $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
+  cp -PR $HOME/.openelec/projects/$PROJECT/bootloader/* $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
 
-  cp -PR $BUILD/linux-*/arch/arm/boot/dts/*.dtb $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :
+  cp -PR $BUILD/linux-*/arch/$TARGET_KERNEL_ARCH/boot/dts/*.dtb $RELEASE_DIR/3rdparty/bootloader 2>/dev/null || :

--- a/scripts/image
+++ b/scripts/image
@@ -254,10 +254,14 @@ fi
       # remove n previous created release image
         rm -rf $TARGET_IMG/$IMAGE_NAME.img.gz
         if [ -n "$BOOTLOADER" ]; then
-          if [ -d $ROOT/projects/$PROJECT/packages ]; then
-          	BOOTLOADER_DIR=`find $ROOT/projects/$PROJECT/packages -type d -name $BOOTLOADER 2>/dev/null`
+          if [ -n "`find $HOME/.openelec/projects/$PROJECT/packages -type d -name $BOOTLOADER 2>/dev/null`" ]; then
+            BOOTLOADER_DIR=`find $HOME/.openelec/projects/$PROJECT/packages -type d -name $BOOTLOADER 2>/dev/null`
+          elif [ -n "`find $HOME/.openelec/packages -type d -name $BOOTLOADER 2>/dev/null`" ]; then
+            BOOTLOADER_DIR=`find $HOME/.openelec/packages -type d -name $BOOTLOADER 2>/dev/null`
+          elif [ -n "`find $PROJECT_DIR/$PROJECT/packages -type d -name $BOOTLOADER`" ]; then
+            BOOTLOADER_DIR=`find $PROJECT_DIR/$PROJECT/packages -type d -name $BOOTLOADER 2>/dev/null`
           else
-          	BOOTLOADER_DIR=""
+            BOOTLOADER_DIR=""
           fi
 
           if [ -z "$BOOTLOADER_DIR" -o ! -d "$BOOTLOADER_DIR" ]; then
@@ -268,7 +272,11 @@ fi
             cp -R $BOOTLOADER_DIR/files/* $RELEASE_DIR
           fi
 
-          if [ -f $PROJECT_DIR/$PROJECT/bootloader/release ]; then
+          if [ -f $HOME/.openelec/projects/$PROJECT/bootloader/release ]; then
+            . $HOME/.openelec/projects/$PROJECT/bootloader/release
+          elif [ -f $HOME/.openelec/bootloader/release ]; then
+            . $HOME/.openelec/bootloader/release
+          elif [ -f $PROJECT_DIR/$PROJECT/bootloader/release ]; then
             . $PROJECT_DIR/$PROJECT/bootloader/release
           elif [ -f "$BOOTLOADER_DIR"/release ]; then
             . $BOOTLOADER_DIR/release

--- a/scripts/mkimage
+++ b/scripts/mkimage
@@ -186,6 +186,8 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
       mcopy $RELEASE_DIR/3rdparty/bootloader/uEnv.txt ::
     elif [ -f "$RELEASE_DIR/3rdparty/bootloader/boot.scr" ]; then
       mcopy $RELEASE_DIR/3rdparty/bootloader/boot.scr ::
+    elif [ -f "$RELEASE_DIR/3rdparty/bootloader/boot.ini" ]; then
+      mcopy $RELEASE_DIR/3rdparty/bootloader/boot.ini ::
     fi
 
     echo "image: installing u-boot bootloader..."
@@ -197,6 +199,9 @@ elif [ "$BOOTLOADER" = "u-boot" ]; then
       dd if="$RELEASE_DIR/3rdparty/bootloader/u-boot-$UBOOT_SYSTEM.imx" of="$DISK" bs=512 seek=2 conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
     elif [ -f "$RELEASE_DIR/3rdparty/bootloader/u-boot.imx" ]; then
       dd if="$RELEASE_DIR/3rdparty/bootloader/u-boot.imx" of="$DISK" bs=512 seek=2 conv=fsync,notrunc >"$SAVE_ERROR" 2>&1 || show_error
+    elif [ -f "$RELEASE_DIR/3rdparty/bootloader/u-boot-fuse" ]; then
+     # allow custom dd script for vendor specific fusing
+      . $RELEASE_DIR/3rdparty/bootloader/u-boot-fuse
     fi
 
     echo "image: copying files to part1..."

--- a/scripts/unpack
+++ b/scripts/unpack
@@ -116,7 +116,9 @@ for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
          $PKG_DIR/patches/$PATCH_ARCH/$PKG_NAME-*.patch \
          $PKG_DIR/patches/$PKG_VERSION/*.patch \
          $PKG_DIR/patches/$PKG_VERSION/$PATCH_ARCH/*.patch \
-         $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/*.patch; do
+         $PROJECT_DIR/$PROJECT/patches/$PKG_NAME/*.patch \
+         $HOME/.openelec/patches/$PKG_NAME/*.patch \
+         $HOME/.openelec/projects/$PROJECT/patches/$PKG_NAME/*.patch; do
 
   if [ $(dirname $i) = "$PKG_DIR/patches" ]; then
     PATCH_DESC="(common)"
@@ -126,6 +128,10 @@ for i in $PKG_DIR/patches/$PKG_NAME-*.patch \
     PATCH_DESC="($PKG_VERSION - $PATCH_ARCH)"
   elif [ $(dirname $i) = "$PROJECT_DIR/$PROJECT/patches/$PKG_NAME" ]; then
     PATCH_DESC="(project)"
+  elif [ $(dirname $i) = "$HOME/.openelec/patches/$PKG_NAME" ]; then
+    PATCH_DESC="(vendor)"
+  elif [ $(dirname $i) = "$HOME/.openelec/projects/$PROJECT/patches/$PKG_NAME" ]; then
+    PATCH_DESC="(vendor - $PROJECT)"
   fi
 
   if [ -f "$i" ]; then


### PR DESCRIPTION
Allow the use of $HOME/.openelec for all packages, settings, etc.
This fixes issues with the linux package, and allows custom u-boot.