### PR TITLE
More $HOME/.openelec (Vendor) fixes

### DIFF
--- a/config/functions
+++ b/config/functions
@@ -268,27 +268,27 @@ dashes="==========================="
 
 check_config() {
 dashes="==========================="
-  if [ ! -d $PROJECT_DIR/$PROJECT ]; then
+  if [ ! -d $PROJECT_DIR/$PROJECT -a ! -d $HOME/.openelec/projects/$PROJECT ]; then
     check_project="$check_project\n $dashes$dashes$dashes"
     check_project="$check_project\n ERROR: Project not found, use a valid project or create a new config"
     check_project="$check_project\n $dashes$dashes$dashes"
     check_project="$check_project\n\n Valid projects:"
 
-    for projects in $PROJECT_DIR/*; do
+    for projects in $PROJECT_DIR/* $HOME/.openelec/projects/*; do
       check_project="$check_project\n - $(basename $projects)"
     done
     echo -e $check_project
     exit 1
   fi
 
-  if [ ! -f $PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf ]; then
+  if [ ! -f $PROJECT_DIR/$PROJECT/linux/linux.$TARGET_ARCH.conf -a ! -f $HOME/.openelec/projects/$PROJECT/linux/linux.$TARGET_ARCH.conf ]; then
     check_arch="$check_arch\n $dashes$dashes$dashes"
     check_arch="$check_arch\n ERROR: Architecture not found, use a valid Architecture"
     check_arch="$check_arch\n for your project or create a new config"
     check_arch="$check_arch\n $dashes$dashes$dashes"
     check_arch="$check_arch\n\n Valid Architectures for your project: $PROJECT"
 
-    for arch in $PROJECT_DIR/$PROJECT/linux/*.conf; do
+    for arch in $PROJECT_DIR/$PROJECT/linux/*.conf $HOME/.openelec/projects/$PROJECT/linux/*.conf; do
       check_arch="$check_arch\n - $(basename $arch | cut -f2 -d".")"
     done
     echo -e $check_arch


### PR DESCRIPTION
Only noticed this problem after re-merging upstream into my base and attempting to build.  This should actually allow building said $PROJECT(s) in $HOME/.openelec/projects/$PROJECT as expected.