### PR TITLE
Update Amlogic kernel to 3.10-c8d5b2f (3.10.99)

### DIFF
--- a/packages/linux-drivers/wetekdvb/package.mk
+++ b/packages/linux-drivers/wetekdvb/package.mk
@@ -17,7 +17,7 @@
 ################################################################################
 
 PKG_NAME="wetekdvb"
-PKG_VERSION="20160304"
+PKG_VERSION="20160307"
 PKG_REV="1"
 PKG_ARCH="arm"
 PKG_LICENSE="nonfree"

--- a/packages/linux/package.mk
+++ b/packages/linux/package.mk
@@ -31,7 +31,7 @@ PKG_SHORTDESC="linux26: The Linux kernel 2.6 precompiled kernel binary image and
 PKG_LONGDESC="This package contains a precompiled kernel image and the modules."
 case "$LINUX" in
   amlogic)
-    PKG_VERSION="amlogic-3.10-0f60813"
+    PKG_VERSION="amlogic-3.10-c8d5b2f"
     PKG_URL="$DISTRO_SRC/$PKG_NAME-$PKG_VERSION.tar.xz"
     ;;
   imx6)


### PR DESCRIPTION
* Update Amlogic kernel to 3.10-c8d5b2f (3.10.99). This update includes a fix of for WeTek Core screen capture (amvideocap).
* Update WeTek proprietary DVB module to fit the kernel.

closes #4827
