### PR TITLE
Allow project specific busybox init script

### DIFF
--- a/packages/sysutils/busybox/package.mk
+++ b/packages/sysutils/busybox/package.mk
@@ -68,6 +68,12 @@ else
   BUSYBOX_CFG_FILE_INIT=$PKG_DIR/config/busybox-init.conf
 fi
 
+if [ -f $PROJECT_DIR/$PROJECT/busybox/init ]; then
+  BUSYBOX_INIT_FILE=$PROJECT_DIR/$PROJECT/busybox/init
+else
+  BUSYBOX_INIT_FILE=$PKG_DIR/scripts/init
+fi
+
 pre_build_target() {
   mkdir -p $PKG_BUILD/.$TARGET_NAME
   cp -RP $PKG_BUILD/* $PKG_BUILD/.$TARGET_NAME
@@ -247,6 +253,6 @@ makeinstall_init() {
     chmod 755 $INSTALL/platform_init
   fi
 
-  cp $PKG_DIR/scripts/init $INSTALL
+  cp $BUSYBOX_INIT_FILE $INSTALL
   chmod 755 $INSTALL/init
 }


### PR DESCRIPTION
busybox package allows configuration on a per project basis by referencing a config file in the project directory. For example, if a developer wanted to add wget to the available init stage commands provided by busybox they could do so in the projects/myproject/busybox/busybox-init.conf file. This feature exist today.

The change here allows the same override mechanics on the script named "init" which likely is the consumer of the new command. For example, by adding wget to the busybox command init configuration the init script can call wget and load a root file system from an http server.

Thank you for considering this change.