### PR TITLE
Remove the `--no-check-certificate` option from the build

### DIFF
--- a/scripts/get
+++ b/scripts/get
@@ -44,7 +44,7 @@ if [ -n "$PKG_URL" -o -n "$PKG_GIT_URL" ]; then
       PACKAGE="$SOURCES/$1/$SOURCE_NAME"
       PACKAGE_MIRROR="$DISTRO_MIRROR/$PKG_NAME/$SOURCE_NAME"
       [ "$VERBOSE" != "yes" ] && WGET_OPT=-q
-      WGET_CMD="wget --timeout=30 --passive-ftp --no-check-certificate -c $WGET_OPT -P $SOURCES/$1"
+      WGET_CMD="wget --timeout=30 --passive-ftp -c $WGET_OPT -P $SOURCES/$1"
 
       NBWGET="1"
 


### PR DESCRIPTION
There is no point in using this option:
- either you want http
- or you want to use https, and you use it corretly