### PR TITLE
CMake: patch to disable SSLv3 support, was removed in libressl curren…

### DIFF
--- a/packages/devel/cmake/patches/cmake-000-disable-sslv3.patch
+++ b/packages/devel/cmake/patches/cmake-000-disable-sslv3.patch
@@ -1,0 +1,15 @@
+--- a/Utilities/cmcurl/lib/vtls/openssl.c.orig	2016-10-06 15:52:59.115761563 +0200
++++ b/Utilities/cmcurl/lib/vtls/openssl.c	2016-10-06 16:20:36.172690961 +0200
+@@ -108,6 +108,12 @@
+ #define OPENSSL_NO_SSL2
+ #endif
+ 
++#if !defined(HAVE_SSLV3_CLIENT_METHOD) || \
++  OPENSSL_VERSION_NUMBER >= 0x10100000L /* 1.1.0+ has no SSLv3 support */ 
++#undef OPENSSL_NO_SSL3 /* undef first to avoid compiler warnings */
++#define OPENSSL_NO_SSL3
++#endif
++
+ #if (OPENSSL_VERSION_NUMBER >= 0x10100000L) && /* OpenSSL 1.1.0+ */ \
+   !defined(LIBRESSL_VERSION_NUMBER)
+ #define SSLeay_add_ssl_algorithms() SSL_library_init()


### PR DESCRIPTION
was removed in libressl current version. 

Signed-off-by: Jérôme Benoit <jerome.benoit@piment-noir.org>