### PR TITLE
ci20 fpic

### DIFF
--- a/packages/audio/libsndfile/package.mk
+++ b/packages/audio/libsndfile/package.mk
@@ -43,6 +43,10 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --enable-largefile \
                            --with-gnu-ld"
 
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
 }

--- a/packages/audio/sbc/package.mk
+++ b/packages/audio/sbc/package.mk
@@ -34,3 +34,7 @@ PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
          --disable-tools --disable-tester"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/audio/soxr/package.mk
+++ b/packages/audio/soxr/package.mk
@@ -37,3 +37,7 @@ PKG_CMAKE_OPTS_TARGET="-DHAVE_WORDS_BIGENDIAN_EXITCODE=1 \
                        -DBUILD_TESTS=0 \
                        -DBUILD_EXAMPLES=1 \
                        -DBUILD_SHARED_LIBS=OFF"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/audio/speex/package.mk
+++ b/packages/audio/speex/package.mk
@@ -33,3 +33,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--disable-shared --enable-static"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/databases/sqlite/package.mk
+++ b/packages/databases/sqlite/package.mk
@@ -43,6 +43,9 @@ PKG_AUTORECONF="yes"
 # data to help it make better index choices.
   CFLAGS="$CFLAGS -DSQLITE_ENABLE_STAT3"
 
+# relocation R_MIPS_HI16 against `a local symbol' can not be used when making a shared object; recompile with -fPIC
+  CFLAGS="$CFLAGS -fPIC"
+
 # When this C-preprocessor macro is defined, SQLite includes some additional APIs
 # that provide convenient access to meta-data about tables and queries. The APIs that
 # are enabled by this option are:

--- a/packages/devel/lcms2/package.mk
+++ b/packages/devel/lcms2/package.mk
@@ -35,6 +35,10 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared \
                            --with-zlib --with-threads \
                            --without-jpeg --without-tiff"
 
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/bin
 }

--- a/packages/devel/libugpio/package.mk
+++ b/packages/devel/libugpio/package.mk
@@ -32,3 +32,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/devel/netbsd-curses/package.mk
+++ b/packages/devel/netbsd-curses/package.mk
@@ -36,6 +36,10 @@ PKG_AUTORECONF="no"
   export CFLAGS=`echo $CFLAGS | sed -e "s|-D_FORTIFY_SOURCE=.||g"`
   export LDFLAGS=`echo $LDFLAGS | sed -e "s|-D_FORTIFY_SOURCE=.||g"`
 
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}
+
 make_target() {
   make HOSTCC="$HOST_CC" CFLAGS="$CFLAGS -D_GNU_SOURCE" PREFIX=/usr all-static
 }

--- a/packages/devel/popt/package.mk
+++ b/packages/devel/popt/package.mk
@@ -33,3 +33,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/devel/readline/package.mk
+++ b/packages/devel/readline/package.mk
@@ -38,6 +38,10 @@ PKG_CONFIGURE_OPTS_TARGET="bash_cv_wcwidth_broken=no \
                            --with-curses \
                            --without-purify"
 
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}
+
 post_makeinstall_target() {
   rm -rf $INSTALL/usr/share/readline
 }

--- a/packages/multimedia/rtmpdump/package.mk
+++ b/packages/multimedia/rtmpdump/package.mk
@@ -35,6 +35,10 @@ PKG_AUTORECONF="no"
 
 MAKEFLAGS="-j1"
 
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}
+
 make_target() {
   make prefix=/usr \
        incdir=/usr/include/librtmp \

--- a/packages/print/freetype/package.mk
+++ b/packages/print/freetype/package.mk
@@ -42,6 +42,7 @@ PKG_CONFIGURE_OPTS_TARGET="--enable-static \
                            --with-harfbuzz=no"
 
 pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
   # unset LIBTOOL because freetype uses its own
     ( cd ..
       unset LIBTOOL

--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -56,6 +56,7 @@ pre_configure_target() {
   esac
 
   cp $ROOT/$PKG_BUILD/src/syscfg/lock-obj-pub.$GPGERROR_TUPLE.h $ROOT/$PKG_BUILD/src/syscfg/lock-obj-pub.$GPGERROR_TARGET.h
+  CFLAGS="$CFLAGS -fPIC"
 }
 
 post_makeinstall_target() {

--- a/packages/wayland/mtdev/package.mk
+++ b/packages/wayland/mtdev/package.mk
@@ -33,3 +33,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="yes"
 
 PKG_CONFIGURE_OPTS_TARGET="--enable-static --disable-shared"
+
+pre_configure_target() {
+  CFLAGS="$CFLAGS -fPIC"
+}

--- a/packages/x11/other/fontconfig/package.mk
+++ b/packages/x11/other/fontconfig/package.mk
@@ -45,7 +45,9 @@ pre_configure_target() {
   CFLAGS=`echo $CFLAGS | sed -e "s|-O3|-O2|"`
   CXXFLAGS=`echo $CXXFLAGS | sed -e "s|-O3|-O2|"`
   CFLAGS="$CFLAGS -I$ROOT/$PKG_BUILD"
+  CFLAGS="$CFLAGS -fPIC"
   CXXFLAGS="$CXXFLAGS -I$ROOT/$PKG_BUILD"
+  CXXFLAGS="$CXXFLAGS -fPIC"
   LDFLAGS="$LDFLAGS -lz"
 }
 


### PR DESCRIPTION
Like x86_64, mipsel requires compiling shared libraries with -fPIC. Otherwise one would get a compilation error such as:

```
ld: /usr/lib/libsqlite3.a(sqlite3.o): relocation R_MIPS_HI16 against `a local symbol' can not be used when making a shared object; recompile with -fPIC
/usr/lib/libsqlite3.a: could not read symbols: Bad value
collect2: error: ld returned 1 exit status
```