### PR TITLE
gcc: fix typo in libatomic handling

### DIFF
--- a/packages/lang/gcc/package.mk
+++ b/packages/lang/gcc/package.mk
@@ -35,7 +35,7 @@ PKG_IS_ADDON="no"
 PKG_AUTORECONF="no"
 
 # Some target need gcc/libatomic:
-if [ "GCC_LIBATOMIC_SUPPORT" = "yes" ]; then
+if [ "$GCC_LIBATOMIC_SUPPORT" = "yes" ]; then
   GCC_LIBATOMIC="--enable-libatomic"
 else
   GCC_LIBATOMIC="--disable-libatomic"


### PR DESCRIPTION
Signed-off-by: Mathieu Malaterre <malat@debian.org>