### PR TITLE
libgpg-error: add mips arch support

### DIFF
--- a/packages/security/libgpg-error/package.mk
+++ b/packages/security/libgpg-error/package.mk
@@ -49,6 +49,10 @@ pre_configure_target() {
       GPGERROR_TUPLE=i486-pc-linux-gnu
       GPGERROR_TARGET=linux-gnu
       ;;
+    mips)
+      GPGERROR_TUPLE=mipsel-unknown-linux-gnu
+      GPGERROR_TARGET=linux-gnu
+      ;;
     x86_64)
       GPGERROR_TUPLE=x86_64-pc-linux-gnu
       GPGERROR_TARGET=linux-gnu


### PR DESCRIPTION
Signed-off-by: Mathieu Malaterre <malat@debian.org>